### PR TITLE
Add citizenlab namespace alias to stix files

### DIFF
--- a/201510_NGO_Burma/stix.xml
+++ b/201510_NGO_Burma/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,20 +59,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-a3126f94-8e7e-48d3-ad30-dcc198ba7c78" version="1.1.1" timestamp="2016-11-10T21:28:56.977467+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-a3126f94-8e7e-48d3-ad30-dcc198ba7c78" version="1.1.1" timestamp="2016-11-10T21:28:56.977467+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-581bac8e-b478-474a-a013-49798e96ca05" version="1.1.1" timestamp="2016-11-10T16:26:09+00:00">
+            <stix:Package id="citizenlab:STIXPackage-581bac8e-b478-474a-a013-49798e96ca05" version="1.1.1" timestamp="2016-11-10T16:26:09+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Targeted Malware Attacks against NGO Linked to Attacks on Burmese Government Websites (MISP Event #4)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:TTPs>
-                    <stix:TTP id=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: 9002 (MISP Attribute #87)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -82,7 +82,7 @@
                             </ttp:Malware>
                         </ttp:Behavior>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: 3102 (MISP Attribute #88)</ttp:Title>
                         <ttp:Description>The variant is labeled 3102, because it always uses the string “3102” in its first communications with a C2 server</ttp:Description>
                         <ttp:Behavior>
@@ -95,7 +95,7 @@
                     </stix:TTP>
                 </stix:TTPs>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-581bac8e-b478-474a-a013-49798e96ca05" timestamp="2016-11-10T16:26:30+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-581bac8e-b478-474a-a013-49798e96ca05" timestamp="2016-11-10T16:26:30+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Targeted Malware Attacks against NGO Linked to Attacks on Burmese Government Websites</incident:Title>
                         <incident:External_ID source="MISP Event">4</incident:External_ID>
                         <incident:Time>
@@ -106,14 +106,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad50-2488-429a-b001-497a8e96ca05" timestamp="2016-11-10T16:22:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad50-2488-429a-b001-497a8e96ca05" timestamp="2016-11-10T16:22:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: c4c147bdfddffec2eea6bf99661e69ee (MISP Attribute #93)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: c4c147bdfddffec2eea6bf99661e69ee (MISP Attribute #93)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad50-2488-429a-b001-497a8e96ca05">
-                                        <cybox:Object id=":File-581bad50-2488-429a-b001-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad50-2488-429a-b001-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-581bad50-2488-429a-b001-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -125,10 +125,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:22:16+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -138,14 +138,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad50-aea8-4d5f-8e0c-497a8e96ca05" timestamp="2016-11-10T16:22:25+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad50-aea8-4d5f-8e0c-497a8e96ca05" timestamp="2016-11-10T16:22:25+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 884d46c01c762ad6ddd2759fd921bf71 (MISP Attribute #94)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 884d46c01c762ad6ddd2759fd921bf71 (MISP Attribute #94)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad50-aea8-4d5f-8e0c-497a8e96ca05">
-                                        <cybox:Object id=":File-581bad50-aea8-4d5f-8e0c-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad50-aea8-4d5f-8e0c-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-581bad50-aea8-4d5f-8e0c-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -157,10 +157,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:22:25+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -170,14 +170,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad50-a014-4095-a054-497a8e96ca05" timestamp="2016-11-10T16:22:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad50-a014-4095-a054-497a8e96ca05" timestamp="2016-11-10T16:22:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 56f0e67d981024ddcc215543698f44fb (MISP Attribute #95)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 56f0e67d981024ddcc215543698f44fb (MISP Attribute #95)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad50-a014-4095-a054-497a8e96ca05">
-                                        <cybox:Object id=":File-581bad50-a014-4095-a054-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad50-a014-4095-a054-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-581bad50-a014-4095-a054-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -189,10 +189,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:22:33+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -202,14 +202,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad50-d494-4e55-aa91-497a8e96ca05" timestamp="2016-11-10T16:22:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad50-d494-4e55-aa91-497a8e96ca05" timestamp="2016-11-10T16:22:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 7e0081fba718fcd71753d3199a290f03 (MISP Attribute #96)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 7e0081fba718fcd71753d3199a290f03 (MISP Attribute #96)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad50-d494-4e55-aa91-497a8e96ca05">
-                                        <cybox:Object id=":File-581bad50-d494-4e55-aa91-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad50-d494-4e55-aa91-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-581bad50-d494-4e55-aa91-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -221,10 +221,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:22:44+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -234,14 +234,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad50-8998-4012-926d-497a8e96ca05" timestamp="2016-11-10T16:23:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad50-8998-4012-926d-497a8e96ca05" timestamp="2016-11-10T16:23:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 5710d567d98a8f4a6682859ce3a35336 (MISP Attribute #97)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 5710d567d98a8f4a6682859ce3a35336 (MISP Attribute #97)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad50-8998-4012-926d-497a8e96ca05">
-                                        <cybox:Object id=":File-581bad50-8998-4012-926d-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad50-8998-4012-926d-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-581bad50-8998-4012-926d-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -253,10 +253,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:23:13+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -266,14 +266,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad50-7890-4dcf-8436-497a8e96ca05" timestamp="2016-11-10T16:23:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad50-7890-4dcf-8436-497a8e96ca05" timestamp="2016-11-10T16:23:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: cec071424d417a095221bf8992819388 (MISP Attribute #98)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: cec071424d417a095221bf8992819388 (MISP Attribute #98)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad50-7890-4dcf-8436-497a8e96ca05">
-                                        <cybox:Object id=":File-581bad50-7890-4dcf-8436-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad50-7890-4dcf-8436-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-581bad50-7890-4dcf-8436-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -285,10 +285,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:23:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -298,14 +298,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad60-2a18-44cc-ac40-49798e96ca05" timestamp="2016-11-10T16:23:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad60-2a18-44cc-ac40-49798e96ca05" timestamp="2016-11-10T16:23:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 49ceba3347d39870f15f2ab0391af234 (MISP Attribute #99)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 49ceba3347d39870f15f2ab0391af234 (MISP Attribute #99)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad60-2a18-44cc-ac40-49798e96ca05">
-                                        <cybox:Object id=":File-581bad60-2a18-44cc-ac40-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad60-2a18-44cc-ac40-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581bad60-2a18-44cc-ac40-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -317,10 +317,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:23:34+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -330,16 +330,16 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5824e57b-8458-4669-b6a0-497a8e96ca05" timestamp="2016-11-10T16:24:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5824e57b-8458-4669-b6a0-497a8e96ca05" timestamp="2016-11-10T16:24:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: wojiaojilao2@sohu.com (MISP Attribute #1876)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: wojiaojilao2@sohu.com (MISP Attribute #1876)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:24:11+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -349,24 +349,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bacca-eb70-4443-a7d1-49798e96ca05" timestamp="2016-11-03T17:31:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bacca-eb70-4443-a7d1-49798e96ca05" timestamp="2016-11-03T17:31:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: usafbi.websecexp.com (MISP Attribute #83)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: usafbi.websecexp.com (MISP Attribute #83)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bacca-eb70-4443-a7d1-49798e96ca05">
-                                        <cybox:Object id=":DomainName-581bacca-eb70-4443-a7d1-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bacca-eb70-4443-a7d1-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581bacca-eb70-4443-a7d1-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">usafbi.websecexp.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:31:54+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -376,24 +376,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bacca-464c-4997-8812-49798e96ca05" timestamp="2016-11-03T17:31:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bacca-464c-4997-8812-49798e96ca05" timestamp="2016-11-03T17:31:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: usacia.websecexp.com (MISP Attribute #84)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: usacia.websecexp.com (MISP Attribute #84)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bacca-464c-4997-8812-49798e96ca05">
-                                        <cybox:Object id=":DomainName-581bacca-464c-4997-8812-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bacca-464c-4997-8812-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581bacca-464c-4997-8812-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">usacia.websecexp.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:31:54+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -403,24 +403,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bacca-5998-41ad-afb4-49798e96ca05" timestamp="2016-11-03T17:31:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bacca-5998-41ad-afb4-49798e96ca05" timestamp="2016-11-03T17:31:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webhttps.websecexp.com (MISP Attribute #85)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webhttps.websecexp.com (MISP Attribute #85)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bacca-5998-41ad-afb4-49798e96ca05">
-                                        <cybox:Object id=":DomainName-581bacca-5998-41ad-afb4-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bacca-5998-41ad-afb4-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581bacca-5998-41ad-afb4-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webhttps.websecexp.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:31:54+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -430,24 +430,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5824e58f-be40-407d-b91b-497a8e96ca05" timestamp="2016-11-10T16:24:31+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5824e58f-be40-407d-b91b-497a8e96ca05" timestamp="2016-11-10T16:24:31+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: iyouthen.com (MISP Attribute #1877)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: iyouthen.com (MISP Attribute #1877)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5824e58f-be40-407d-b91b-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-5824e58f-be40-407d-b91b-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5824e58f-be40-407d-b91b-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5824e58f-be40-407d-b91b-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">iyouthen.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:24:31+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -457,24 +457,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bacca-ad18-4ff6-b8b5-49798e96ca05" timestamp="2016-11-03T17:31:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bacca-ad18-4ff6-b8b5-49798e96ca05" timestamp="2016-11-03T17:31:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: appeur.gnway.cc (MISP Attribute #86)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: appeur.gnway.cc (MISP Attribute #86)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bacca-ad18-4ff6-b8b5-49798e96ca05">
-                                        <cybox:Object id=":DomainName-581bacca-ad18-4ff6-b8b5-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bacca-ad18-4ff6-b8b5-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581bacca-ad18-4ff6-b8b5-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">appeur.gnway.cc</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:31:54+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -484,24 +484,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad77-2c58-479e-833e-497a8e96ca05" timestamp="2016-11-03T17:34:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad77-2c58-479e-833e-497a8e96ca05" timestamp="2016-11-03T17:34:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: t1.mailsecurityservice.com (MISP Attribute #100)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: t1.mailsecurityservice.com (MISP Attribute #100)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad77-2c58-479e-833e-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-581bad77-2c58-479e-833e-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad77-2c58-479e-833e-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581bad77-2c58-479e-833e-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">t1.mailsecurityservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:34:47+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -511,24 +511,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad77-cde8-4c65-9449-497a8e96ca05" timestamp="2016-11-03T17:34:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad77-cde8-4c65-9449-497a8e96ca05" timestamp="2016-11-03T17:34:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: t2.mailsecurityservice.com (MISP Attribute #101)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: t2.mailsecurityservice.com (MISP Attribute #101)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad77-cde8-4c65-9449-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-581bad77-cde8-4c65-9449-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad77-cde8-4c65-9449-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581bad77-cde8-4c65-9449-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">t2.mailsecurityservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:34:47+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -538,24 +538,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad0a-7524-46f8-9d57-497a8e96ca05" timestamp="2016-11-03T17:32:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad0a-7524-46f8-9d57-497a8e96ca05" timestamp="2016-11-03T17:32:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 198.44.190.85 (MISP Attribute #89)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 198.44.190.85 (MISP Attribute #89)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad0a-7524-46f8-9d57-497a8e96ca05">
-                                        <cybox:Object id=":Address-581bad0a-7524-46f8-9d57-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad0a-7524-46f8-9d57-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-581bad0a-7524-46f8-9d57-497a8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">198.44.190.85</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:32:58+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -565,14 +565,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad2c-3a60-4be9-8d21-49798e96ca05" timestamp="2016-11-03T17:33:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad2c-3a60-4be9-8d21-49798e96ca05" timestamp="2016-11-03T17:33:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 53f81415ccedf453d6e3ebcdc142b966 (MISP Attribute #90)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 53f81415ccedf453d6e3ebcdc142b966 (MISP Attribute #90)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad2c-3a60-4be9-8d21-49798e96ca05">
-                                        <cybox:Object id=":File-581bad2c-3a60-4be9-8d21-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad2c-3a60-4be9-8d21-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581bad2c-3a60-4be9-8d21-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -584,10 +584,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:33:32+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -597,14 +597,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad2c-e744-4a48-ae12-49798e96ca05" timestamp="2016-11-03T17:33:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad2c-e744-4a48-ae12-49798e96ca05" timestamp="2016-11-03T17:33:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 6701662097e274f3cd089ceec35471d2 (MISP Attribute #91)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 6701662097e274f3cd089ceec35471d2 (MISP Attribute #91)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad2c-e744-4a48-ae12-49798e96ca05">
-                                        <cybox:Object id=":File-581bad2c-e744-4a48-ae12-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad2c-e744-4a48-ae12-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581bad2c-e744-4a48-ae12-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -616,10 +616,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:33:32+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -629,14 +629,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581bad2c-d2d4-46f4-b0cb-49798e96ca05" timestamp="2016-11-03T17:33:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581bad2c-d2d4-46f4-b0cb-49798e96ca05" timestamp="2016-11-03T17:33:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 699b3d90b050cae37f65c855ec7f616a (MISP Attribute #92)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 699b3d90b050cae37f65c855ec7f616a (MISP Attribute #92)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581bad2c-d2d4-46f4-b0cb-49798e96ca05">
-                                        <cybox:Object id=":File-581bad2c-d2d4-46f4-b0cb-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581bad2c-d2d4-46f4-b0cb-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581bad2c-d2d4-46f4-b0cb-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -648,10 +648,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:33:32+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -661,24 +661,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5824e5f1-d174-487e-9156-497a8e96ca05" timestamp="2016-11-10T16:26:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5824e5f1-d174-487e-9156-497a8e96ca05" timestamp="2016-11-10T16:26:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://www.hjclub.info/bbs/uploadfiles/45/ca-bundle.exe (MISP Attribute #1878)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://www.hjclub.info/bbs/uploadfiles/45/ca-bundle.exe (MISP Attribute #1878)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5824e5f1-d174-487e-9156-497a8e96ca05">
-                                        <cybox:Object id=":URI-5824e5f1-d174-487e-9156-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5824e5f1-d174-487e-9156-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:URI-5824e5f1-d174-487e-9156-497a8e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.hjclub.info/bbs/uploadfiles/45/ca-bundle.exe</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:26:09+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -690,11 +690,11 @@
                         <incident:Leveraged_TTPs>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-581bace8-59d0-4c6e-859a-497a8e96ca05" timestamp="2016-11-03T17:32:24+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-581bacf2-d924-45bd-a930-49798e96ca05" timestamp="2016-11-03T17:32:34+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                         </incident:Leveraged_TTPs>
                         <incident:History>

--- a/201512_PackRAT/stix.xml
+++ b/201512_PackRAT/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,20 +59,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-2de45e5f-6ccd-445d-affb-16a2a2f22214" version="1.1.1" timestamp="2016-11-08T21:38:30.512967+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-2de45e5f-6ccd-445d-affb-16a2a2f22214" version="1.1.1" timestamp="2016-11-08T21:38:30.512967+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-581c11ef-a8c4-4c26-a4ea-49798e96ca05" version="1.1.1" timestamp="2016-11-08T16:36:35+00:00">
+            <stix:Package id="citizenlab:STIXPackage-581c11ef-a8c4-4c26-a4ea-49798e96ca05" version="1.1.1" timestamp="2016-11-08T16:36:35+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Packrat: Seven Years of a South American Threat Actor (MISP Event #12)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:TTPs>
-                    <stix:TTP id=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: CyberGate (MISP Attribute #1350)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -82,7 +82,7 @@
                             </ttp:Malware>
                         </ttp:Behavior>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: Xtreme RAT (MISP Attribute #1351)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -92,7 +92,7 @@
                             </ttp:Malware>
                         </ttp:Behavior>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: AlienSpy (MISP Attribute #1352)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -102,7 +102,7 @@
                             </ttp:Malware>
                         </ttp:Behavior>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: Adzok (MISP Attribute #1353)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -114,7 +114,7 @@
                     </stix:TTP>
                 </stix:TTPs>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-581c11ef-a8c4-4c26-a4ea-49798e96ca05" timestamp="2016-11-08T16:38:11+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-581c11ef-a8c4-4c26-a4ea-49798e96ca05" timestamp="2016-11-08T16:38:11+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Packrat: Seven Years of a South American Threat Actor</incident:Title>
                         <incident:External_ID source="MISP Event">12</incident:External_ID>
                         <incident:Time>
@@ -125,14 +125,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-b0bd3917-ba04-4d95-a5d3-928993f331a9" timestamp="2016-11-08T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-b0bd3917-ba04-4d95-a5d3-928993f331a9" timestamp="2016-11-08T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: a988235ad7d47acbeca5ccb4ea5a1ed5 (MISP Attribute #539)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: a988235ad7d47acbeca5ccb4ea5a1ed5 (MISP Attribute #539)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-b0bd3917-ba04-4d95-a5d3-928993f331a9">
-                                        <cybox:Object id=":File-b0bd3917-ba04-4d95-a5d3-928993f331a9">
+                                    <indicator:Observable id="citizenlab:observable-b0bd3917-ba04-4d95-a5d3-928993f331a9">
+                                        <cybox:Object id="citizenlab:File-b0bd3917-ba04-4d95-a5d3-928993f331a9">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -144,16 +144,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:34:12+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -163,14 +163,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-2034aaac-cd1a-4f24-9c9e-a622763cc35a" timestamp="2016-11-08T16:34:21+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-2034aaac-cd1a-4f24-9c9e-a622763cc35a" timestamp="2016-11-08T16:34:21+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 15ebe16cd9500de534d5bfd5eeceaf73 (MISP Attribute #540)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 15ebe16cd9500de534d5bfd5eeceaf73 (MISP Attribute #540)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-2034aaac-cd1a-4f24-9c9e-a622763cc35a">
-                                        <cybox:Object id=":File-2034aaac-cd1a-4f24-9c9e-a622763cc35a">
+                                    <indicator:Observable id="citizenlab:observable-2034aaac-cd1a-4f24-9c9e-a622763cc35a">
+                                        <cybox:Object id="citizenlab:File-2034aaac-cd1a-4f24-9c9e-a622763cc35a">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -182,16 +182,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:34:21+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -201,14 +201,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-2cd0f135-c88d-4a89-8cd4-bbc6cd3efa0f" timestamp="2016-11-08T16:34:30+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-2cd0f135-c88d-4a89-8cd4-bbc6cd3efa0f" timestamp="2016-11-08T16:34:30+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 01dec1b1d0760d5a1a562edcfeb478d1 (MISP Attribute #541)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 01dec1b1d0760d5a1a562edcfeb478d1 (MISP Attribute #541)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-2cd0f135-c88d-4a89-8cd4-bbc6cd3efa0f">
-                                        <cybox:Object id=":File-2cd0f135-c88d-4a89-8cd4-bbc6cd3efa0f">
+                                    <indicator:Observable id="citizenlab:observable-2cd0f135-c88d-4a89-8cd4-bbc6cd3efa0f">
+                                        <cybox:Object id="citizenlab:File-2cd0f135-c88d-4a89-8cd4-bbc6cd3efa0f">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -220,16 +220,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:34:30+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -239,14 +239,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-378b1659-18cc-484d-aa90-df1a36849693" timestamp="2016-11-08T16:34:41+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-378b1659-18cc-484d-aa90-df1a36849693" timestamp="2016-11-08T16:34:41+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 1e6d0b59d4fb7650453c207688385f3a (MISP Attribute #542)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 1e6d0b59d4fb7650453c207688385f3a (MISP Attribute #542)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-378b1659-18cc-484d-aa90-df1a36849693">
-                                        <cybox:Object id=":File-378b1659-18cc-484d-aa90-df1a36849693">
+                                    <indicator:Observable id="citizenlab:observable-378b1659-18cc-484d-aa90-df1a36849693">
+                                        <cybox:Object id="citizenlab:File-378b1659-18cc-484d-aa90-df1a36849693">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -258,16 +258,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:34:41+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -277,14 +277,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-440b7b2b-7d18-4a95-a95c-f4d80412535c" timestamp="2016-11-08T16:34:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-440b7b2b-7d18-4a95-a95c-f4d80412535c" timestamp="2016-11-08T16:34:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: e03be1849ad7cecba1e20923074cd22f (MISP Attribute #543)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: e03be1849ad7cecba1e20923074cd22f (MISP Attribute #543)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-440b7b2b-7d18-4a95-a95c-f4d80412535c">
-                                        <cybox:Object id=":File-440b7b2b-7d18-4a95-a95c-f4d80412535c">
+                                    <indicator:Observable id="citizenlab:observable-440b7b2b-7d18-4a95-a95c-f4d80412535c">
+                                        <cybox:Object id="citizenlab:File-440b7b2b-7d18-4a95-a95c-f4d80412535c">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -296,16 +296,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:34:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -315,14 +315,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-8d8d0ac6-1cbe-4d9c-9b3c-8b7dbd1a1ce4" timestamp="2016-11-08T16:35:02+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-8d8d0ac6-1cbe-4d9c-9b3c-8b7dbd1a1ce4" timestamp="2016-11-08T16:35:02+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 779a79c11f581b84e7c81f321fd8d743 (MISP Attribute #544)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 779a79c11f581b84e7c81f321fd8d743 (MISP Attribute #544)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-8d8d0ac6-1cbe-4d9c-9b3c-8b7dbd1a1ce4">
-                                        <cybox:Object id=":File-8d8d0ac6-1cbe-4d9c-9b3c-8b7dbd1a1ce4">
+                                    <indicator:Observable id="citizenlab:observable-8d8d0ac6-1cbe-4d9c-9b3c-8b7dbd1a1ce4">
+                                        <cybox:Object id="citizenlab:File-8d8d0ac6-1cbe-4d9c-9b3c-8b7dbd1a1ce4">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -334,16 +334,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:35:02+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -353,14 +353,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-9fbc655c-1010-4057-8af4-d29425574e3e" timestamp="2016-11-08T16:35:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-9fbc655c-1010-4057-8af4-d29425574e3e" timestamp="2016-11-08T16:35:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 13d939b2412c6adbab3cc1b539166671 (MISP Attribute #545)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 13d939b2412c6adbab3cc1b539166671 (MISP Attribute #545)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-9fbc655c-1010-4057-8af4-d29425574e3e">
-                                        <cybox:Object id=":File-9fbc655c-1010-4057-8af4-d29425574e3e">
+                                    <indicator:Observable id="citizenlab:observable-9fbc655c-1010-4057-8af4-d29425574e3e">
+                                        <cybox:Object id="citizenlab:File-9fbc655c-1010-4057-8af4-d29425574e3e">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -372,16 +372,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:35:13+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -391,14 +391,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-3cd6d0dd-13e7-40b1-adaf-957bedfc212b" timestamp="2016-11-08T16:35:28+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-3cd6d0dd-13e7-40b1-adaf-957bedfc212b" timestamp="2016-11-08T16:35:28+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 7b2cb5249d704cb1df8d4210e7c3d553 (MISP Attribute #546)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 7b2cb5249d704cb1df8d4210e7c3d553 (MISP Attribute #546)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-3cd6d0dd-13e7-40b1-adaf-957bedfc212b">
-                                        <cybox:Object id=":File-3cd6d0dd-13e7-40b1-adaf-957bedfc212b">
+                                    <indicator:Observable id="citizenlab:observable-3cd6d0dd-13e7-40b1-adaf-957bedfc212b">
+                                        <cybox:Object id="citizenlab:File-3cd6d0dd-13e7-40b1-adaf-957bedfc212b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -410,16 +410,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:35:28+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -429,14 +429,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-665a391e-0346-477b-8062-0e093fba3333" timestamp="2016-11-08T16:35:38+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-665a391e-0346-477b-8062-0e093fba3333" timestamp="2016-11-08T16:35:38+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: a09f100ddc7cf29f8a93a3d7a79c58b9 (MISP Attribute #547)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: a09f100ddc7cf29f8a93a3d7a79c58b9 (MISP Attribute #547)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-665a391e-0346-477b-8062-0e093fba3333">
-                                        <cybox:Object id=":File-665a391e-0346-477b-8062-0e093fba3333">
+                                    <indicator:Observable id="citizenlab:observable-665a391e-0346-477b-8062-0e093fba3333">
+                                        <cybox:Object id="citizenlab:File-665a391e-0346-477b-8062-0e093fba3333">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -448,16 +448,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:35:38+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -467,14 +467,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-11c2de46-6ded-4948-914e-a8acff9ff027" timestamp="2016-11-08T16:36:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-11c2de46-6ded-4948-914e-a8acff9ff027" timestamp="2016-11-08T16:36:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: ce6065346a918a813eeb58bbb0814a23 (MISP Attribute #548)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: ce6065346a918a813eeb58bbb0814a23 (MISP Attribute #548)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-11c2de46-6ded-4948-914e-a8acff9ff027">
-                                        <cybox:Object id=":File-11c2de46-6ded-4948-914e-a8acff9ff027">
+                                    <indicator:Observable id="citizenlab:observable-11c2de46-6ded-4948-914e-a8acff9ff027">
+                                        <cybox:Object id="citizenlab:File-11c2de46-6ded-4948-914e-a8acff9ff027">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -486,16 +486,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:36:04+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -505,14 +505,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-ac5dde92-e97e-4b57-9305-5e439f9bbb40" timestamp="2016-11-08T16:36:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-ac5dde92-e97e-4b57-9305-5e439f9bbb40" timestamp="2016-11-08T16:36:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: ea50bf8abcf9c0c40c4490dc15fb0a2a (MISP Attribute #549)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: ea50bf8abcf9c0c40c4490dc15fb0a2a (MISP Attribute #549)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-ac5dde92-e97e-4b57-9305-5e439f9bbb40">
-                                        <cybox:Object id=":File-ac5dde92-e97e-4b57-9305-5e439f9bbb40">
+                                    <indicator:Observable id="citizenlab:observable-ac5dde92-e97e-4b57-9305-5e439f9bbb40">
+                                        <cybox:Object id="citizenlab:File-ac5dde92-e97e-4b57-9305-5e439f9bbb40">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -524,16 +524,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:36:13+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -543,14 +543,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-85d91d34-8222-4b2e-b154-0b394ec75fe3" timestamp="2016-11-08T16:36:25+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-85d91d34-8222-4b2e-b154-0b394ec75fe3" timestamp="2016-11-08T16:36:25+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 3a61d64986ee6529cee271ab6754faa5 (MISP Attribute #550)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 3a61d64986ee6529cee271ab6754faa5 (MISP Attribute #550)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-85d91d34-8222-4b2e-b154-0b394ec75fe3">
-                                        <cybox:Object id=":File-85d91d34-8222-4b2e-b154-0b394ec75fe3">
+                                    <indicator:Observable id="citizenlab:observable-85d91d34-8222-4b2e-b154-0b394ec75fe3">
+                                        <cybox:Object id="citizenlab:File-85d91d34-8222-4b2e-b154-0b394ec75fe3">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -562,16 +562,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:36:25+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -581,14 +581,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-04da6270-0f60-44e0-a68c-bb6d0eb89d84" timestamp="2016-11-08T16:36:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-04da6270-0f60-44e0-a68c-bb6d0eb89d84" timestamp="2016-11-08T16:36:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 695db7dd3b1daf89f2c56d59faecc088 (MISP Attribute #551)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 695db7dd3b1daf89f2c56d59faecc088 (MISP Attribute #551)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-04da6270-0f60-44e0-a68c-bb6d0eb89d84">
-                                        <cybox:Object id=":File-04da6270-0f60-44e0-a68c-bb6d0eb89d84">
+                                    <indicator:Observable id="citizenlab:observable-04da6270-0f60-44e0-a68c-bb6d0eb89d84">
+                                        <cybox:Object id="citizenlab:File-04da6270-0f60-44e0-a68c-bb6d0eb89d84">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -600,16 +600,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:36:35+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -619,14 +619,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-da13fa70-4007-4c44-b611-a890dd8b1f31" timestamp="2016-11-08T16:31:42+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-da13fa70-4007-4c44-b611-a890dd8b1f31" timestamp="2016-11-08T16:31:42+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: ea7bcf58a4ccdecb0c64e56b9998a4ac (MISP Attribute #552)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: ea7bcf58a4ccdecb0c64e56b9998a4ac (MISP Attribute #552)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-da13fa70-4007-4c44-b611-a890dd8b1f31">
-                                        <cybox:Object id=":File-da13fa70-4007-4c44-b611-a890dd8b1f31">
+                                    <indicator:Observable id="citizenlab:observable-da13fa70-4007-4c44-b611-a890dd8b1f31">
+                                        <cybox:Object id="citizenlab:File-da13fa70-4007-4c44-b611-a890dd8b1f31">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -638,16 +638,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:31:42+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -657,14 +657,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-1242c1d0-3d53-48f2-a30f-f6566a46b262" timestamp="2016-11-08T16:31:08+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-1242c1d0-3d53-48f2-a30f-f6566a46b262" timestamp="2016-11-08T16:31:08+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: efc0009d76a2057f86c5f00030378c72 (MISP Attribute #553)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: efc0009d76a2057f86c5f00030378c72 (MISP Attribute #553)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-1242c1d0-3d53-48f2-a30f-f6566a46b262">
-                                        <cybox:Object id=":File-1242c1d0-3d53-48f2-a30f-f6566a46b262">
+                                    <indicator:Observable id="citizenlab:observable-1242c1d0-3d53-48f2-a30f-f6566a46b262">
+                                        <cybox:Object id="citizenlab:File-1242c1d0-3d53-48f2-a30f-f6566a46b262">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -676,16 +676,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:31:08+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -695,14 +695,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-a179e1f8-66e4-4055-a762-ed5d9166afa2" timestamp="2016-11-08T16:31:22+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-a179e1f8-66e4-4055-a762-ed5d9166afa2" timestamp="2016-11-08T16:31:22+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 74613eae84347183b4ca61b912a4573f (MISP Attribute #554)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 74613eae84347183b4ca61b912a4573f (MISP Attribute #554)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-a179e1f8-66e4-4055-a762-ed5d9166afa2">
-                                        <cybox:Object id=":File-a179e1f8-66e4-4055-a762-ed5d9166afa2">
+                                    <indicator:Observable id="citizenlab:observable-a179e1f8-66e4-4055-a762-ed5d9166afa2">
+                                        <cybox:Object id="citizenlab:File-a179e1f8-66e4-4055-a762-ed5d9166afa2">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -714,16 +714,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:31:22+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -733,14 +733,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-dad67427-90fd-429f-94cc-15aab9efefc7" timestamp="2016-11-08T16:30:31+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-dad67427-90fd-429f-94cc-15aab9efefc7" timestamp="2016-11-08T16:30:31+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: bc97437fec7e7e8634c2eabae3cc4832 (MISP Attribute #555)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: bc97437fec7e7e8634c2eabae3cc4832 (MISP Attribute #555)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-dad67427-90fd-429f-94cc-15aab9efefc7">
-                                        <cybox:Object id=":File-dad67427-90fd-429f-94cc-15aab9efefc7">
+                                    <indicator:Observable id="citizenlab:observable-dad67427-90fd-429f-94cc-15aab9efefc7">
+                                        <cybox:Object id="citizenlab:File-dad67427-90fd-429f-94cc-15aab9efefc7">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -752,16 +752,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:30:31+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -771,14 +771,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-a8d6eb71-318f-4516-b319-5e50d6996770" timestamp="2016-11-08T16:27:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-a8d6eb71-318f-4516-b319-5e50d6996770" timestamp="2016-11-08T16:27:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: dd1101adc86fd282f5f183942cc2f3b7 (MISP Attribute #556)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: dd1101adc86fd282f5f183942cc2f3b7 (MISP Attribute #556)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-a8d6eb71-318f-4516-b319-5e50d6996770">
-                                        <cybox:Object id=":File-a8d6eb71-318f-4516-b319-5e50d6996770">
+                                    <indicator:Observable id="citizenlab:observable-a8d6eb71-318f-4516-b319-5e50d6996770">
+                                        <cybox:Object id="citizenlab:File-a8d6eb71-318f-4516-b319-5e50d6996770">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -790,16 +790,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:27:54+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -809,14 +809,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-694b6503-2ef8-4da9-8adf-1eaf5b0393c8" timestamp="2016-11-08T16:28:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-694b6503-2ef8-4da9-8adf-1eaf5b0393c8" timestamp="2016-11-08T16:28:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 2d722592a4e3c8030410dccccb221ce4 (MISP Attribute #557)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 2d722592a4e3c8030410dccccb221ce4 (MISP Attribute #557)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-694b6503-2ef8-4da9-8adf-1eaf5b0393c8">
-                                        <cybox:Object id=":File-694b6503-2ef8-4da9-8adf-1eaf5b0393c8">
+                                    <indicator:Observable id="citizenlab:observable-694b6503-2ef8-4da9-8adf-1eaf5b0393c8">
+                                        <cybox:Object id="citizenlab:File-694b6503-2ef8-4da9-8adf-1eaf5b0393c8">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -828,16 +828,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:28:09+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -847,14 +847,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-475c2ee5-d819-4a55-bb4d-1d909905c039" timestamp="2016-11-08T16:28:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-475c2ee5-d819-4a55-bb4d-1d909905c039" timestamp="2016-11-08T16:28:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: d2adecc6287dd4d559fe6ce2ce7a7e31 (MISP Attribute #558)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: d2adecc6287dd4d559fe6ce2ce7a7e31 (MISP Attribute #558)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-475c2ee5-d819-4a55-bb4d-1d909905c039">
-                                        <cybox:Object id=":File-475c2ee5-d819-4a55-bb4d-1d909905c039">
+                                    <indicator:Observable id="citizenlab:observable-475c2ee5-d819-4a55-bb4d-1d909905c039">
+                                        <cybox:Object id="citizenlab:File-475c2ee5-d819-4a55-bb4d-1d909905c039">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -866,16 +866,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:28:44+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -885,14 +885,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-075b1d0f-b7b2-4571-bd0c-9a2ad1c98663" timestamp="2016-11-08T16:28:56+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-075b1d0f-b7b2-4571-bd0c-9a2ad1c98663" timestamp="2016-11-08T16:28:56+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 93b630891db21a4a2350280a360c713d (MISP Attribute #559)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 93b630891db21a4a2350280a360c713d (MISP Attribute #559)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-075b1d0f-b7b2-4571-bd0c-9a2ad1c98663">
-                                        <cybox:Object id=":File-075b1d0f-b7b2-4571-bd0c-9a2ad1c98663">
+                                    <indicator:Observable id="citizenlab:observable-075b1d0f-b7b2-4571-bd0c-9a2ad1c98663">
+                                        <cybox:Object id="citizenlab:File-075b1d0f-b7b2-4571-bd0c-9a2ad1c98663">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -904,16 +904,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:28:56+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -923,14 +923,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-17548c65-6dd6-473f-b79c-9ad3095fb9b2" timestamp="2016-11-08T16:29:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-17548c65-6dd6-473f-b79c-9ad3095fb9b2" timestamp="2016-11-08T16:29:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: a73351623577f44a2b578fed1e78e37e (MISP Attribute #560)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: a73351623577f44a2b578fed1e78e37e (MISP Attribute #560)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-17548c65-6dd6-473f-b79c-9ad3095fb9b2">
-                                        <cybox:Object id=":File-17548c65-6dd6-473f-b79c-9ad3095fb9b2">
+                                    <indicator:Observable id="citizenlab:observable-17548c65-6dd6-473f-b79c-9ad3095fb9b2">
+                                        <cybox:Object id="citizenlab:File-17548c65-6dd6-473f-b79c-9ad3095fb9b2">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -942,16 +942,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:29:09+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -961,14 +961,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-09e60b2e-a849-4dc3-9910-59cd78bc3f82" timestamp="2016-11-08T16:29:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-09e60b2e-a849-4dc3-9910-59cd78bc3f82" timestamp="2016-11-08T16:29:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 5a8975873f52436377d8fb0b5ab0d87a (MISP Attribute #561)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 5a8975873f52436377d8fb0b5ab0d87a (MISP Attribute #561)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-09e60b2e-a849-4dc3-9910-59cd78bc3f82">
-                                        <cybox:Object id=":File-09e60b2e-a849-4dc3-9910-59cd78bc3f82">
+                                    <indicator:Observable id="citizenlab:observable-09e60b2e-a849-4dc3-9910-59cd78bc3f82">
+                                        <cybox:Object id="citizenlab:File-09e60b2e-a849-4dc3-9910-59cd78bc3f82">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -980,16 +980,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:29:46+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -999,14 +999,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-d036cf1a-59fb-4c11-9da9-cbf99f5733a7" timestamp="2016-11-08T16:29:55+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-d036cf1a-59fb-4c11-9da9-cbf99f5733a7" timestamp="2016-11-08T16:29:55+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: ed8d7ed45b64890b8901b735018318f3 (MISP Attribute #562)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: ed8d7ed45b64890b8901b735018318f3 (MISP Attribute #562)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-d036cf1a-59fb-4c11-9da9-cbf99f5733a7">
-                                        <cybox:Object id=":File-d036cf1a-59fb-4c11-9da9-cbf99f5733a7">
+                                    <indicator:Observable id="citizenlab:observable-d036cf1a-59fb-4c11-9da9-cbf99f5733a7">
+                                        <cybox:Object id="citizenlab:File-d036cf1a-59fb-4c11-9da9-cbf99f5733a7">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1018,16 +1018,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:29:55+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1037,14 +1037,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-3a638a7b-6cc4-4cfe-940c-921fb417e79c" timestamp="2016-11-08T16:30:08+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-3a638a7b-6cc4-4cfe-940c-921fb417e79c" timestamp="2016-11-08T16:30:08+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: c2237e9d415f542ce6e73adb260af123 (MISP Attribute #563)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: c2237e9d415f542ce6e73adb260af123 (MISP Attribute #563)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-3a638a7b-6cc4-4cfe-940c-921fb417e79c">
-                                        <cybox:Object id=":File-3a638a7b-6cc4-4cfe-940c-921fb417e79c">
+                                    <indicator:Observable id="citizenlab:observable-3a638a7b-6cc4-4cfe-940c-921fb417e79c">
+                                        <cybox:Object id="citizenlab:File-3a638a7b-6cc4-4cfe-940c-921fb417e79c">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1056,16 +1056,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:30:08+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1075,14 +1075,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-69d8d573-3f23-493b-97f4-8fa6b4cf9f1b" timestamp="2016-11-08T16:30:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-69d8d573-3f23-493b-97f4-8fa6b4cf9f1b" timestamp="2016-11-08T16:30:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 2827450763b55c5e71fda3caaf8e75f9 (MISP Attribute #564)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 2827450763b55c5e71fda3caaf8e75f9 (MISP Attribute #564)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-69d8d573-3f23-493b-97f4-8fa6b4cf9f1b">
-                                        <cybox:Object id=":File-69d8d573-3f23-493b-97f4-8fa6b4cf9f1b">
+                                    <indicator:Observable id="citizenlab:observable-69d8d573-3f23-493b-97f4-8fa6b4cf9f1b">
+                                        <cybox:Object id="citizenlab:File-69d8d573-3f23-493b-97f4-8fa6b4cf9f1b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1094,16 +1094,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:30:20+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1113,14 +1113,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-8ae2e6c9-806a-4a57-aa17-aed767339990" timestamp="2016-11-08T16:30:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-8ae2e6c9-806a-4a57-aa17-aed767339990" timestamp="2016-11-08T16:30:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: d7f34168b1a7dd7cbd8e62a5ab1ebc0e (MISP Attribute #565)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: d7f34168b1a7dd7cbd8e62a5ab1ebc0e (MISP Attribute #565)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-8ae2e6c9-806a-4a57-aa17-aed767339990">
-                                        <cybox:Object id=":File-8ae2e6c9-806a-4a57-aa17-aed767339990">
+                                    <indicator:Observable id="citizenlab:observable-8ae2e6c9-806a-4a57-aa17-aed767339990">
+                                        <cybox:Object id="citizenlab:File-8ae2e6c9-806a-4a57-aa17-aed767339990">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1132,16 +1132,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:30:43+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1151,14 +1151,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-f7dbcb2a-96c1-48d9-8bda-785348f8d91b" timestamp="2016-11-08T16:30:53+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-f7dbcb2a-96c1-48d9-8bda-785348f8d91b" timestamp="2016-11-08T16:30:53+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 6c34d4296126679d9c6a0bc2660dc453 (MISP Attribute #566)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 6c34d4296126679d9c6a0bc2660dc453 (MISP Attribute #566)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-f7dbcb2a-96c1-48d9-8bda-785348f8d91b">
-                                        <cybox:Object id=":File-f7dbcb2a-96c1-48d9-8bda-785348f8d91b">
+                                    <indicator:Observable id="citizenlab:observable-f7dbcb2a-96c1-48d9-8bda-785348f8d91b">
+                                        <cybox:Object id="citizenlab:File-f7dbcb2a-96c1-48d9-8bda-785348f8d91b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1170,16 +1170,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:30:53+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1189,14 +1189,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-8f38d4c7-dff5-484f-be90-3aaa3fba6753" timestamp="2016-11-08T16:31:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-8f38d4c7-dff5-484f-be90-3aaa3fba6753" timestamp="2016-11-08T16:31:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: d2f151312f7dee2483ddcab9766b56db (MISP Attribute #567)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: d2f151312f7dee2483ddcab9766b56db (MISP Attribute #567)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-8f38d4c7-dff5-484f-be90-3aaa3fba6753">
-                                        <cybox:Object id=":File-8f38d4c7-dff5-484f-be90-3aaa3fba6753">
+                                    <indicator:Observable id="citizenlab:observable-8f38d4c7-dff5-484f-be90-3aaa3fba6753">
+                                        <cybox:Object id="citizenlab:File-8f38d4c7-dff5-484f-be90-3aaa3fba6753">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1208,16 +1208,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:31:33+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1227,14 +1227,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-55ab0c50-6ba9-44f0-bbf5-e30f13396fba" timestamp="2016-11-08T16:31:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-55ab0c50-6ba9-44f0-bbf5-e30f13396fba" timestamp="2016-11-08T16:31:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 1e4265a0c37773c2372b97bb6630ae57 (MISP Attribute #568)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 1e4265a0c37773c2372b97bb6630ae57 (MISP Attribute #568)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-55ab0c50-6ba9-44f0-bbf5-e30f13396fba">
-                                        <cybox:Object id=":File-55ab0c50-6ba9-44f0-bbf5-e30f13396fba">
+                                    <indicator:Observable id="citizenlab:observable-55ab0c50-6ba9-44f0-bbf5-e30f13396fba">
+                                        <cybox:Object id="citizenlab:File-55ab0c50-6ba9-44f0-bbf5-e30f13396fba">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1246,16 +1246,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:31:54+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1265,14 +1265,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-c103e0dc-7fb4-4e6d-a3d1-d6dfadc90045" timestamp="2016-11-08T16:32:53+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-c103e0dc-7fb4-4e6d-a3d1-d6dfadc90045" timestamp="2016-11-08T16:32:53+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 08a3bb5b220eb1e0dc2ecccbbc6859f5 (MISP Attribute #569)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 08a3bb5b220eb1e0dc2ecccbbc6859f5 (MISP Attribute #569)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-c103e0dc-7fb4-4e6d-a3d1-d6dfadc90045">
-                                        <cybox:Object id=":File-c103e0dc-7fb4-4e6d-a3d1-d6dfadc90045">
+                                    <indicator:Observable id="citizenlab:observable-c103e0dc-7fb4-4e6d-a3d1-d6dfadc90045">
+                                        <cybox:Object id="citizenlab:File-c103e0dc-7fb4-4e6d-a3d1-d6dfadc90045">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1284,16 +1284,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:32:53+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1303,14 +1303,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-53d09cce-3d68-4a76-bddb-118176b5eda6" timestamp="2016-11-08T16:33:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-53d09cce-3d68-4a76-bddb-118176b5eda6" timestamp="2016-11-08T16:33:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 2de51e74fd571319bbf763ec62781096 (MISP Attribute #570)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 2de51e74fd571319bbf763ec62781096 (MISP Attribute #570)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-53d09cce-3d68-4a76-bddb-118176b5eda6">
-                                        <cybox:Object id=":File-53d09cce-3d68-4a76-bddb-118176b5eda6">
+                                    <indicator:Observable id="citizenlab:observable-53d09cce-3d68-4a76-bddb-118176b5eda6">
+                                        <cybox:Object id="citizenlab:File-53d09cce-3d68-4a76-bddb-118176b5eda6">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1322,16 +1322,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:33:11+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1341,14 +1341,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-6cb4f4a0-1cf6-4cf4-98c2-5b9b93ff9867" timestamp="2016-11-08T16:33:21+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-6cb4f4a0-1cf6-4cf4-98c2-5b9b93ff9867" timestamp="2016-11-08T16:33:21+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 8fb96dfab7e4c0acb1eb9f4e950ba4b9 (MISP Attribute #571)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 8fb96dfab7e4c0acb1eb9f4e950ba4b9 (MISP Attribute #571)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-6cb4f4a0-1cf6-4cf4-98c2-5b9b93ff9867">
-                                        <cybox:Object id=":File-6cb4f4a0-1cf6-4cf4-98c2-5b9b93ff9867">
+                                    <indicator:Observable id="citizenlab:observable-6cb4f4a0-1cf6-4cf4-98c2-5b9b93ff9867">
+                                        <cybox:Object id="citizenlab:File-6cb4f4a0-1cf6-4cf4-98c2-5b9b93ff9867">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1360,16 +1360,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:33:21+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1379,14 +1379,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-078ea337-c004-430a-87d7-982e517f81c4" timestamp="2016-11-08T16:33:31+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-078ea337-c004-430a-87d7-982e517f81c4" timestamp="2016-11-08T16:33:31+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 4a23a1d6779d199aaa582cf0a5868ad1 (MISP Attribute #572)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 4a23a1d6779d199aaa582cf0a5868ad1 (MISP Attribute #572)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-078ea337-c004-430a-87d7-982e517f81c4">
-                                        <cybox:Object id=":File-078ea337-c004-430a-87d7-982e517f81c4">
+                                    <indicator:Observable id="citizenlab:observable-078ea337-c004-430a-87d7-982e517f81c4">
+                                        <cybox:Object id="citizenlab:File-078ea337-c004-430a-87d7-982e517f81c4">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1398,16 +1398,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:33:31+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1417,14 +1417,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-bd9e3887-abea-465a-9f42-4ca38ea31d17" timestamp="2016-11-08T16:33:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-bd9e3887-abea-465a-9f42-4ca38ea31d17" timestamp="2016-11-08T16:33:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 0ae0038ffe8cf5c3170734a71ff2213d (MISP Attribute #573)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 0ae0038ffe8cf5c3170734a71ff2213d (MISP Attribute #573)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-bd9e3887-abea-465a-9f42-4ca38ea31d17">
-                                        <cybox:Object id=":File-bd9e3887-abea-465a-9f42-4ca38ea31d17">
+                                    <indicator:Observable id="citizenlab:observable-bd9e3887-abea-465a-9f42-4ca38ea31d17">
+                                        <cybox:Object id="citizenlab:File-bd9e3887-abea-465a-9f42-4ca38ea31d17">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1436,16 +1436,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:33:40+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1455,14 +1455,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-9096fec9-6b26-4c94-a9a1-8bfe16caf1b5" timestamp="2016-11-08T16:33:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-9096fec9-6b26-4c94-a9a1-8bfe16caf1b5" timestamp="2016-11-08T16:33:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 8e0f021dcbbfa586a1c6780e77ac0fb6 (MISP Attribute #574)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 8e0f021dcbbfa586a1c6780e77ac0fb6 (MISP Attribute #574)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-9096fec9-6b26-4c94-a9a1-8bfe16caf1b5">
-                                        <cybox:Object id=":File-9096fec9-6b26-4c94-a9a1-8bfe16caf1b5">
+                                    <indicator:Observable id="citizenlab:observable-9096fec9-6b26-4c94-a9a1-8bfe16caf1b5">
+                                        <cybox:Object id="citizenlab:File-9096fec9-6b26-4c94-a9a1-8bfe16caf1b5">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1474,16 +1474,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:33:49+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1493,14 +1493,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-341b2a91-d835-4766-8a27-d0a04cf9af90" timestamp="2016-11-08T16:34:00+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-341b2a91-d835-4766-8a27-d0a04cf9af90" timestamp="2016-11-08T16:34:00+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: a74ef893b1bf21c9df6d8e31285db981 (MISP Attribute #575)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: a74ef893b1bf21c9df6d8e31285db981 (MISP Attribute #575)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-341b2a91-d835-4766-8a27-d0a04cf9af90">
-                                        <cybox:Object id=":File-341b2a91-d835-4766-8a27-d0a04cf9af90">
+                                    <indicator:Observable id="citizenlab:observable-341b2a91-d835-4766-8a27-d0a04cf9af90">
+                                        <cybox:Object id="citizenlab:File-341b2a91-d835-4766-8a27-d0a04cf9af90">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1512,16 +1512,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:34:00+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1531,14 +1531,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-c7d3ba98-9951-45a1-864f-ad1c6c000aad" timestamp="2016-11-04T00:43:53+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-c7d3ba98-9951-45a1-864f-ad1c6c000aad" timestamp="2016-11-04T00:43:53+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: HKLM\SOFTWARE\Microsoft\Active (MISP Attribute #576)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Host Characteristics</indicator:Type>
                                     <indicator:Description>Artifacts dropped: HKLM\SOFTWARE\Microsoft\Active (MISP Attribute #576)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-c7d3ba98-9951-45a1-864f-ad1c6c000aad">
-                                        <cybox:Object id=":WinRegistryKey-c7d3ba98-9951-45a1-864f-ad1c6c000aad">
+                                    <indicator:Observable id="citizenlab:observable-c7d3ba98-9951-45a1-864f-ad1c6c000aad">
+                                        <cybox:Object id="citizenlab:WinRegistryKey-c7d3ba98-9951-45a1-864f-ad1c6c000aad">
                                             <cybox:Properties xsi:type="WinRegistryKeyObj:WindowsRegistryKeyObjectType">
                                                 <WinRegistryKeyObj:Key condition="Equals">SOFTWARE\Microsoft\Active</WinRegistryKeyObj:Key>
                                                 <WinRegistryKeyObj:Hive condition="Equals">HKEY_LOCAL_MACHINE</WinRegistryKeyObj:Hive>
@@ -1546,16 +1546,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1571,14 +1571,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-a723650f-2306-48f3-a588-e57822f92448" timestamp="2016-11-04T00:43:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-a723650f-2306-48f3-a588-e57822f92448" timestamp="2016-11-04T00:43:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\policies\Explorer\Run\Policies (MISP Attribute #577)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Host Characteristics</indicator:Type>
                                     <indicator:Description>Artifacts dropped: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\policies\Explorer\Run\Policies (MISP Attribute #577)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-a723650f-2306-48f3-a588-e57822f92448">
-                                        <cybox:Object id=":WinRegistryKey-a723650f-2306-48f3-a588-e57822f92448">
+                                    <indicator:Observable id="citizenlab:observable-a723650f-2306-48f3-a588-e57822f92448">
+                                        <cybox:Object id="citizenlab:WinRegistryKey-a723650f-2306-48f3-a588-e57822f92448">
                                             <cybox:Properties xsi:type="WinRegistryKeyObj:WindowsRegistryKeyObjectType">
                                                 <WinRegistryKeyObj:Key condition="Equals">SOFTWARE\Microsoft\Windows\CurrentVersion\policies\Explorer\Run\Policies</WinRegistryKeyObj:Key>
                                                 <WinRegistryKeyObj:Hive condition="Equals">HKEY_LOCAL_MACHINE</WinRegistryKeyObj:Hive>
@@ -1586,16 +1586,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1611,14 +1611,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-2738530c-979b-43ef-a7a3-6e509d38d073" timestamp="2016-11-04T00:43:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-2738530c-979b-43ef-a7a3-6e509d38d073" timestamp="2016-11-04T00:43:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\msconfig (MISP Attribute #578)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Host Characteristics</indicator:Type>
                                     <indicator:Description>Artifacts dropped: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\msconfig (MISP Attribute #578)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-2738530c-979b-43ef-a7a3-6e509d38d073">
-                                        <cybox:Object id=":WinRegistryKey-2738530c-979b-43ef-a7a3-6e509d38d073">
+                                    <indicator:Observable id="citizenlab:observable-2738530c-979b-43ef-a7a3-6e509d38d073">
+                                        <cybox:Object id="citizenlab:WinRegistryKey-2738530c-979b-43ef-a7a3-6e509d38d073">
                                             <cybox:Properties xsi:type="WinRegistryKeyObj:WindowsRegistryKeyObjectType">
                                                 <WinRegistryKeyObj:Key condition="Equals">SOFTWARE\Microsoft\Windows\CurrentVersion\Run\msconfig</WinRegistryKeyObj:Key>
                                                 <WinRegistryKeyObj:Hive condition="Equals">HKEY_LOCAL_MACHINE</WinRegistryKeyObj:Hive>
@@ -1626,16 +1626,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1651,30 +1651,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-64c9eefd-aabd-47be-8a66-56a3f777fca0" timestamp="2016-11-04T00:43:55+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-64c9eefd-aabd-47be-8a66-56a3f777fca0" timestamp="2016-11-04T00:43:55+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: taskmgr.redirectme.net (MISP Attribute #580)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: taskmgr.redirectme.net (MISP Attribute #580)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-64c9eefd-aabd-47be-8a66-56a3f777fca0">
-                                        <cybox:Object id=":DomainName-64c9eefd-aabd-47be-8a66-56a3f777fca0">
+                                    <indicator:Observable id="citizenlab:observable-64c9eefd-aabd-47be-8a66-56a3f777fca0">
+                                        <cybox:Object id="citizenlab:DomainName-64c9eefd-aabd-47be-8a66-56a3f777fca0">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">taskmgr.redirectme.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1690,30 +1690,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-83aa404a-cb12-407c-993c-1ff9b7fa1947" timestamp="2016-11-04T00:43:55+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-83aa404a-cb12-407c-993c-1ff9b7fa1947" timestamp="2016-11-04T00:43:55+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ftp.server.com (MISP Attribute #581)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ftp.server.com (MISP Attribute #581)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-83aa404a-cb12-407c-993c-1ff9b7fa1947">
-                                        <cybox:Object id=":DomainName-83aa404a-cb12-407c-993c-1ff9b7fa1947">
+                                    <indicator:Observable id="citizenlab:observable-83aa404a-cb12-407c-993c-1ff9b7fa1947">
+                                        <cybox:Object id="citizenlab:DomainName-83aa404a-cb12-407c-993c-1ff9b7fa1947">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ftp.server.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1729,30 +1729,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-19da57bf-1c40-4472-a9e1-696a56ff0d12" timestamp="2016-11-04T00:43:55+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-19da57bf-1c40-4472-a9e1-696a56ff0d12" timestamp="2016-11-04T00:43:55+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: update-outlook.info (MISP Attribute #582)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: update-outlook.info (MISP Attribute #582)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-19da57bf-1c40-4472-a9e1-696a56ff0d12">
-                                        <cybox:Object id=":DomainName-19da57bf-1c40-4472-a9e1-696a56ff0d12">
+                                    <indicator:Observable id="citizenlab:observable-19da57bf-1c40-4472-a9e1-696a56ff0d12">
+                                        <cybox:Object id="citizenlab:DomainName-19da57bf-1c40-4472-a9e1-696a56ff0d12">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">update-outlook.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1768,30 +1768,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7b018a95-eb5d-4226-a5ca-9e32f4b288e4" timestamp="2016-11-04T00:43:56+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7b018a95-eb5d-4226-a5ca-9e32f4b288e4" timestamp="2016-11-04T00:43:56+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: deyrep.com (MISP Attribute #583)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: deyrep.com (MISP Attribute #583)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7b018a95-eb5d-4226-a5ca-9e32f4b288e4">
-                                        <cybox:Object id=":DomainName-7b018a95-eb5d-4226-a5ca-9e32f4b288e4">
+                                    <indicator:Observable id="citizenlab:observable-7b018a95-eb5d-4226-a5ca-9e32f4b288e4">
+                                        <cybox:Object id="citizenlab:DomainName-7b018a95-eb5d-4226-a5ca-9e32f4b288e4">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">deyrep.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1807,30 +1807,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-cfd9e067-855e-4c38-af7b-b1ec7b9c5e0f" timestamp="2016-11-04T00:43:56+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-cfd9e067-855e-4c38-af7b-b1ec7b9c5e0f" timestamp="2016-11-04T00:43:56+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: support-whatsapp.com (MISP Attribute #584)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: support-whatsapp.com (MISP Attribute #584)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-cfd9e067-855e-4c38-af7b-b1ec7b9c5e0f">
-                                        <cybox:Object id=":DomainName-cfd9e067-855e-4c38-af7b-b1ec7b9c5e0f">
+                                    <indicator:Observable id="citizenlab:observable-cfd9e067-855e-4c38-af7b-b1ec7b9c5e0f">
+                                        <cybox:Object id="citizenlab:DomainName-cfd9e067-855e-4c38-af7b-b1ec7b9c5e0f">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">support-whatsapp.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1846,30 +1846,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-668f1383-b9db-44fb-ab01-49537c77ad1e" timestamp="2016-11-04T00:43:56+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-668f1383-b9db-44fb-ab01-49537c77ad1e" timestamp="2016-11-04T00:43:56+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: blackboxmusic.co (MISP Attribute #585)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: blackboxmusic.co (MISP Attribute #585)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-668f1383-b9db-44fb-ab01-49537c77ad1e">
-                                        <cybox:Object id=":DomainName-668f1383-b9db-44fb-ab01-49537c77ad1e">
+                                    <indicator:Observable id="citizenlab:observable-668f1383-b9db-44fb-ab01-49537c77ad1e">
+                                        <cybox:Object id="citizenlab:DomainName-668f1383-b9db-44fb-ab01-49537c77ad1e">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">blackboxmusic.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1885,30 +1885,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-035cef0c-ab5b-4870-8a2d-3fffb2002a86" timestamp="2016-11-04T00:43:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-035cef0c-ab5b-4870-8a2d-3fffb2002a86" timestamp="2016-11-04T00:43:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.blackboxmusic.co (MISP Attribute #586)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.blackboxmusic.co (MISP Attribute #586)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-035cef0c-ab5b-4870-8a2d-3fffb2002a86">
-                                        <cybox:Object id=":DomainName-035cef0c-ab5b-4870-8a2d-3fffb2002a86">
+                                    <indicator:Observable id="citizenlab:observable-035cef0c-ab5b-4870-8a2d-3fffb2002a86">
+                                        <cybox:Object id="citizenlab:DomainName-035cef0c-ab5b-4870-8a2d-3fffb2002a86">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.blackboxmusic.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1924,30 +1924,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-102812f0-1515-475b-85c9-fe3b9f298322" timestamp="2016-11-04T00:43:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-102812f0-1515-475b-85c9-fe3b9f298322" timestamp="2016-11-04T00:43:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-account-update.com (MISP Attribute #587)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-account-update.com (MISP Attribute #587)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-102812f0-1515-475b-85c9-fe3b9f298322">
-                                        <cybox:Object id=":DomainName-102812f0-1515-475b-85c9-fe3b9f298322">
+                                    <indicator:Observable id="citizenlab:observable-102812f0-1515-475b-85c9-fe3b9f298322">
+                                        <cybox:Object id="citizenlab:DomainName-102812f0-1515-475b-85c9-fe3b9f298322">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-account-update.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -1963,30 +1963,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-abb6b95e-2364-4aad-b826-7c925b587d0a" timestamp="2016-11-04T00:43:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-abb6b95e-2364-4aad-b826-7c925b587d0a" timestamp="2016-11-04T00:43:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: lavozmericana.info (MISP Attribute #588)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: lavozmericana.info (MISP Attribute #588)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-abb6b95e-2364-4aad-b826-7c925b587d0a">
-                                        <cybox:Object id=":DomainName-abb6b95e-2364-4aad-b826-7c925b587d0a">
+                                    <indicator:Observable id="citizenlab:observable-abb6b95e-2364-4aad-b826-7c925b587d0a">
+                                        <cybox:Object id="citizenlab:DomainName-abb6b95e-2364-4aad-b826-7c925b587d0a">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">lavozmericana.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2002,30 +2002,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-1d17b791-20fd-4a0b-b074-36282e6fe9b9" timestamp="2016-11-04T00:43:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-1d17b791-20fd-4a0b-b074-36282e6fe9b9" timestamp="2016-11-04T00:43:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: support-java.com (MISP Attribute #589)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: support-java.com (MISP Attribute #589)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-1d17b791-20fd-4a0b-b074-36282e6fe9b9">
-                                        <cybox:Object id=":DomainName-1d17b791-20fd-4a0b-b074-36282e6fe9b9">
+                                    <indicator:Observable id="citizenlab:observable-1d17b791-20fd-4a0b-b074-36282e6fe9b9">
+                                        <cybox:Object id="citizenlab:DomainName-1d17b791-20fd-4a0b-b074-36282e6fe9b9">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">support-java.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2041,30 +2041,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-ab318121-5622-4ea7-aca3-59e972601644" timestamp="2016-11-04T00:43:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-ab318121-5622-4ea7-aca3-59e972601644" timestamp="2016-11-04T00:43:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: n3.pancaliente.info (MISP Attribute #590)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: n3.pancaliente.info (MISP Attribute #590)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-ab318121-5622-4ea7-aca3-59e972601644">
-                                        <cybox:Object id=":DomainName-ab318121-5622-4ea7-aca3-59e972601644">
+                                    <indicator:Observable id="citizenlab:observable-ab318121-5622-4ea7-aca3-59e972601644">
+                                        <cybox:Object id="citizenlab:DomainName-ab318121-5622-4ea7-aca3-59e972601644">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">n3.pancaliente.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2080,30 +2080,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-613fc81a-9472-402a-864f-ba796bd820f9" timestamp="2016-11-04T00:43:59+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-613fc81a-9472-402a-864f-ba796bd820f9" timestamp="2016-11-04T00:43:59+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: n4.pancaliente.info (MISP Attribute #591)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: n4.pancaliente.info (MISP Attribute #591)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-613fc81a-9472-402a-864f-ba796bd820f9">
-                                        <cybox:Object id=":DomainName-613fc81a-9472-402a-864f-ba796bd820f9">
+                                    <indicator:Observable id="citizenlab:observable-613fc81a-9472-402a-864f-ba796bd820f9">
+                                        <cybox:Object id="citizenlab:DomainName-613fc81a-9472-402a-864f-ba796bd820f9">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">n4.pancaliente.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2119,30 +2119,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-576bf524-78bd-47b8-9ae0-54ecea1bb4af" timestamp="2016-11-04T00:43:59+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-576bf524-78bd-47b8-9ae0-54ecea1bb4af" timestamp="2016-11-04T00:43:59+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ns1.deyrep.com (MISP Attribute #592)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ns1.deyrep.com (MISP Attribute #592)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-576bf524-78bd-47b8-9ae0-54ecea1bb4af">
-                                        <cybox:Object id=":DomainName-576bf524-78bd-47b8-9ae0-54ecea1bb4af">
+                                    <indicator:Observable id="citizenlab:observable-576bf524-78bd-47b8-9ae0-54ecea1bb4af">
+                                        <cybox:Object id="citizenlab:DomainName-576bf524-78bd-47b8-9ae0-54ecea1bb4af">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ns1.deyrep.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2158,30 +2158,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7ca51a3d-b093-497f-accf-00bca0964287" timestamp="2016-11-04T00:44:00+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7ca51a3d-b093-497f-accf-00bca0964287" timestamp="2016-11-04T00:44:00+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ns2.deyrep.com (MISP Attribute #593)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ns2.deyrep.com (MISP Attribute #593)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7ca51a3d-b093-497f-accf-00bca0964287">
-                                        <cybox:Object id=":DomainName-7ca51a3d-b093-497f-accf-00bca0964287">
+                                    <indicator:Observable id="citizenlab:observable-7ca51a3d-b093-497f-accf-00bca0964287">
+                                        <cybox:Object id="citizenlab:DomainName-7ca51a3d-b093-497f-accf-00bca0964287">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ns2.deyrep.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2197,30 +2197,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-32c1f9d8-b15a-4f28-a91d-1d781b28aaa0" timestamp="2016-11-04T00:44:00+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-32c1f9d8-b15a-4f28-a91d-1d781b28aaa0" timestamp="2016-11-04T00:44:00+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: n1.login-office365.com (MISP Attribute #594)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: n1.login-office365.com (MISP Attribute #594)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-32c1f9d8-b15a-4f28-a91d-1d781b28aaa0">
-                                        <cybox:Object id=":DomainName-32c1f9d8-b15a-4f28-a91d-1d781b28aaa0">
+                                    <indicator:Observable id="citizenlab:observable-32c1f9d8-b15a-4f28-a91d-1d781b28aaa0">
+                                        <cybox:Object id="citizenlab:DomainName-32c1f9d8-b15a-4f28-a91d-1d781b28aaa0">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">n1.login-office365.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2236,30 +2236,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7908fe7c-4346-4810-9f79-3ad2a8b93fd6" timestamp="2016-11-04T00:44:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7908fe7c-4346-4810-9f79-3ad2a8b93fd6" timestamp="2016-11-04T00:44:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: n2.login-office365.com (MISP Attribute #595)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: n2.login-office365.com (MISP Attribute #595)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7908fe7c-4346-4810-9f79-3ad2a8b93fd6">
-                                        <cybox:Object id=":DomainName-7908fe7c-4346-4810-9f79-3ad2a8b93fd6">
+                                    <indicator:Observable id="citizenlab:observable-7908fe7c-4346-4810-9f79-3ad2a8b93fd6">
+                                        <cybox:Object id="citizenlab:DomainName-7908fe7c-4346-4810-9f79-3ad2a8b93fd6">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">n2.login-office365.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2275,30 +2275,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-b0df1407-9653-4f07-8f2e-5cd7f1c1a212" timestamp="2016-11-04T00:44:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-b0df1407-9653-4f07-8f2e-5cd7f1c1a212" timestamp="2016-11-04T00:44:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: n1.update-outlook.info (MISP Attribute #596)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: n1.update-outlook.info (MISP Attribute #596)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-b0df1407-9653-4f07-8f2e-5cd7f1c1a212">
-                                        <cybox:Object id=":DomainName-b0df1407-9653-4f07-8f2e-5cd7f1c1a212">
+                                    <indicator:Observable id="citizenlab:observable-b0df1407-9653-4f07-8f2e-5cd7f1c1a212">
+                                        <cybox:Object id="citizenlab:DomainName-b0df1407-9653-4f07-8f2e-5cd7f1c1a212">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">n1.update-outlook.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2314,30 +2314,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-fd6b3ff2-e441-4bc1-ba2d-d3d9dd50ab24" timestamp="2016-11-04T00:44:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-fd6b3ff2-e441-4bc1-ba2d-d3d9dd50ab24" timestamp="2016-11-04T00:44:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ns.update-outlook.info (MISP Attribute #597)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ns.update-outlook.info (MISP Attribute #597)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-fd6b3ff2-e441-4bc1-ba2d-d3d9dd50ab24">
-                                        <cybox:Object id=":DomainName-fd6b3ff2-e441-4bc1-ba2d-d3d9dd50ab24">
+                                    <indicator:Observable id="citizenlab:observable-fd6b3ff2-e441-4bc1-ba2d-d3d9dd50ab24">
+                                        <cybox:Object id="citizenlab:DomainName-fd6b3ff2-e441-4bc1-ba2d-d3d9dd50ab24">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ns.update-outlook.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2353,30 +2353,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-65be605b-ce44-483a-9398-c9b6c1d2584f" timestamp="2016-11-04T00:44:02+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-65be605b-ce44-483a-9398-c9b6c1d2584f" timestamp="2016-11-04T00:44:02+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: s1.mgoogle.us (MISP Attribute #598)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: s1.mgoogle.us (MISP Attribute #598)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-65be605b-ce44-483a-9398-c9b6c1d2584f">
-                                        <cybox:Object id=":DomainName-65be605b-ce44-483a-9398-c9b6c1d2584f">
+                                    <indicator:Observable id="citizenlab:observable-65be605b-ce44-483a-9398-c9b6c1d2584f">
+                                        <cybox:Object id="citizenlab:DomainName-65be605b-ce44-483a-9398-c9b6c1d2584f">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">s1.mgoogle.us</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2392,30 +2392,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-bc40a9ee-df43-4ba3-ad9d-529dc845d04b" timestamp="2016-11-04T00:44:02+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-bc40a9ee-df43-4ba3-ad9d-529dc845d04b" timestamp="2016-11-04T00:44:02+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: s2.mgoogle.us (MISP Attribute #599)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: s2.mgoogle.us (MISP Attribute #599)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-bc40a9ee-df43-4ba3-ad9d-529dc845d04b">
-                                        <cybox:Object id=":DomainName-bc40a9ee-df43-4ba3-ad9d-529dc845d04b">
+                                    <indicator:Observable id="citizenlab:observable-bc40a9ee-df43-4ba3-ad9d-529dc845d04b">
+                                        <cybox:Object id="citizenlab:DomainName-bc40a9ee-df43-4ba3-ad9d-529dc845d04b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">s2.mgoogle.us</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2431,30 +2431,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-f7508074-3443-4ceb-a1b6-08e87bc65b44" timestamp="2016-11-04T00:44:03+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-f7508074-3443-4ceb-a1b6-08e87bc65b44" timestamp="2016-11-04T00:44:03+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: support-login-validate-outlook.tk (MISP Attribute #600)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: support-login-validate-outlook.tk (MISP Attribute #600)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-f7508074-3443-4ceb-a1b6-08e87bc65b44">
-                                        <cybox:Object id=":DomainName-f7508074-3443-4ceb-a1b6-08e87bc65b44">
+                                    <indicator:Observable id="citizenlab:observable-f7508074-3443-4ceb-a1b6-08e87bc65b44">
+                                        <cybox:Object id="citizenlab:DomainName-f7508074-3443-4ceb-a1b6-08e87bc65b44">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">support-login-validate-outlook.tk</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2470,30 +2470,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-1b9f7074-c66c-472d-8917-0592bd07202e" timestamp="2016-11-04T00:44:03+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-1b9f7074-c66c-472d-8917-0592bd07202e" timestamp="2016-11-04T00:44:03+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: verify-gmail-support-secure.tk (MISP Attribute #601)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: verify-gmail-support-secure.tk (MISP Attribute #601)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-1b9f7074-c66c-472d-8917-0592bd07202e">
-                                        <cybox:Object id=":DomainName-1b9f7074-c66c-472d-8917-0592bd07202e">
+                                    <indicator:Observable id="citizenlab:observable-1b9f7074-c66c-472d-8917-0592bd07202e">
+                                        <cybox:Object id="citizenlab:DomainName-1b9f7074-c66c-472d-8917-0592bd07202e">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">verify-gmail-support-secure.tk</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2509,30 +2509,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-b373771f-54f4-4559-8297-52779ee94c28" timestamp="2016-11-04T00:44:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-b373771f-54f4-4559-8297-52779ee94c28" timestamp="2016-11-04T00:44:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: soporte-login-account-gmail.tk (MISP Attribute #602)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: soporte-login-account-gmail.tk (MISP Attribute #602)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-b373771f-54f4-4559-8297-52779ee94c28">
-                                        <cybox:Object id=":DomainName-b373771f-54f4-4559-8297-52779ee94c28">
+                                    <indicator:Observable id="citizenlab:observable-b373771f-54f4-4559-8297-52779ee94c28">
+                                        <cybox:Object id="citizenlab:DomainName-b373771f-54f4-4559-8297-52779ee94c28">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">soporte-login-account-gmail.tk</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2548,30 +2548,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5f6ed532-7034-4529-8f1f-eca4f3ead06a" timestamp="2016-11-04T00:44:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5f6ed532-7034-4529-8f1f-eca4f3ead06a" timestamp="2016-11-04T00:44:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: soporte-login-account-yahoo.tk (MISP Attribute #603)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: soporte-login-account-yahoo.tk (MISP Attribute #603)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5f6ed532-7034-4529-8f1f-eca4f3ead06a">
-                                        <cybox:Object id=":DomainName-5f6ed532-7034-4529-8f1f-eca4f3ead06a">
+                                    <indicator:Observable id="citizenlab:observable-5f6ed532-7034-4529-8f1f-eca4f3ead06a">
+                                        <cybox:Object id="citizenlab:DomainName-5f6ed532-7034-4529-8f1f-eca4f3ead06a">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">soporte-login-account-yahoo.tk</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2587,30 +2587,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-887aba05-4662-4967-8d93-09cb8b3d7685" timestamp="2016-11-04T00:44:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-887aba05-4662-4967-8d93-09cb8b3d7685" timestamp="2016-11-04T00:44:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: n1.support-java.com (MISP Attribute #604)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: n1.support-java.com (MISP Attribute #604)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-887aba05-4662-4967-8d93-09cb8b3d7685">
-                                        <cybox:Object id=":DomainName-887aba05-4662-4967-8d93-09cb8b3d7685">
+                                    <indicator:Observable id="citizenlab:observable-887aba05-4662-4967-8d93-09cb8b3d7685">
+                                        <cybox:Object id="citizenlab:DomainName-887aba05-4662-4967-8d93-09cb8b3d7685">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">n1.support-java.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2626,30 +2626,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-aea5a3f5-d174-47c1-81a0-c97a5a478e00" timestamp="2016-11-04T00:44:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-aea5a3f5-d174-47c1-81a0-c97a5a478e00" timestamp="2016-11-04T00:44:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: n1.lavozamericana.info (MISP Attribute #605)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: n1.lavozamericana.info (MISP Attribute #605)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-aea5a3f5-d174-47c1-81a0-c97a5a478e00">
-                                        <cybox:Object id=":DomainName-aea5a3f5-d174-47c1-81a0-c97a5a478e00">
+                                    <indicator:Observable id="citizenlab:observable-aea5a3f5-d174-47c1-81a0-c97a5a478e00">
+                                        <cybox:Object id="citizenlab:DomainName-aea5a3f5-d174-47c1-81a0-c97a5a478e00">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">n1.lavozamericana.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2665,30 +2665,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-d605e928-93ec-4aec-897e-0de476fe3f0e" timestamp="2016-11-04T00:44:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-d605e928-93ec-4aec-897e-0de476fe3f0e" timestamp="2016-11-04T00:44:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: s1.support (MISP Attribute #606)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: s1.support (MISP Attribute #606)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-d605e928-93ec-4aec-897e-0de476fe3f0e">
-                                        <cybox:Object id=":DomainName-d605e928-93ec-4aec-897e-0de476fe3f0e">
+                                    <indicator:Observable id="citizenlab:observable-d605e928-93ec-4aec-897e-0de476fe3f0e">
+                                        <cybox:Object id="citizenlab:DomainName-d605e928-93ec-4aec-897e-0de476fe3f0e">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">s1.support</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2704,30 +2704,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-2bcfdd38-8a5d-4512-b575-9b06096bed81" timestamp="2016-11-04T00:44:06+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-2bcfdd38-8a5d-4512-b575-9b06096bed81" timestamp="2016-11-04T00:44:06+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ns1.ukraine.com.ua (MISP Attribute #607)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ns1.ukraine.com.ua (MISP Attribute #607)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-2bcfdd38-8a5d-4512-b575-9b06096bed81">
-                                        <cybox:Object id=":DomainName-2bcfdd38-8a5d-4512-b575-9b06096bed81">
+                                    <indicator:Observable id="citizenlab:observable-2bcfdd38-8a5d-4512-b575-9b06096bed81">
+                                        <cybox:Object id="citizenlab:DomainName-2bcfdd38-8a5d-4512-b575-9b06096bed81">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ns1.ukraine.com.ua</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2743,30 +2743,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-a0787877-1f51-45a2-a268-99585abd3753" timestamp="2016-11-04T00:44:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-a0787877-1f51-45a2-a268-99585abd3753" timestamp="2016-11-04T00:44:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: android-flash.com (MISP Attribute #608)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: android-flash.com (MISP Attribute #608)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-a0787877-1f51-45a2-a268-99585abd3753">
-                                        <cybox:Object id=":DomainName-a0787877-1f51-45a2-a268-99585abd3753">
+                                    <indicator:Observable id="citizenlab:observable-a0787877-1f51-45a2-a268-99585abd3753">
+                                        <cybox:Object id="citizenlab:DomainName-a0787877-1f51-45a2-a268-99585abd3753">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">android-flash.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2782,30 +2782,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-2b8e7578-2b1b-4ee4-b690-812825551490" timestamp="2016-11-08T16:24:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-2b8e7578-2b1b-4ee4-b690-812825551490" timestamp="2016-11-08T16:24:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: deyrep24.ddns.net (MISP Attribute #609)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: deyrep24.ddns.net (MISP Attribute #609)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-2b8e7578-2b1b-4ee4-b690-812825551490">
-                                        <cybox:Object id=":DomainName-2b8e7578-2b1b-4ee4-b690-812825551490">
+                                    <indicator:Observable id="citizenlab:observable-2b8e7578-2b1b-4ee4-b690-812825551490">
+                                        <cybox:Object id="citizenlab:DomainName-2b8e7578-2b1b-4ee4-b690-812825551490">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">deyrep24.ddns.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:24:48+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2815,30 +2815,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-c6f40987-2e22-495f-9fcf-ce681c67e901" timestamp="2016-11-08T16:26:30+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-c6f40987-2e22-495f-9fcf-ce681c67e901" timestamp="2016-11-08T16:26:30+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: daynews.sytes.net (MISP Attribute #610)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: daynews.sytes.net (MISP Attribute #610)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-c6f40987-2e22-495f-9fcf-ce681c67e901">
-                                        <cybox:Object id=":DomainName-c6f40987-2e22-495f-9fcf-ce681c67e901">
+                                    <indicator:Observable id="citizenlab:observable-c6f40987-2e22-495f-9fcf-ce681c67e901">
+                                        <cybox:Object id="citizenlab:DomainName-c6f40987-2e22-495f-9fcf-ce681c67e901">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">daynews.sytes.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:26:30+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2848,30 +2848,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-1f129d35-b9b2-42b4-81f6-8903c25c7080" timestamp="2016-11-08T16:26:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-1f129d35-b9b2-42b4-81f6-8903c25c7080" timestamp="2016-11-08T16:26:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: taskmgr.serveftp.com (MISP Attribute #611)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: taskmgr.serveftp.com (MISP Attribute #611)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-1f129d35-b9b2-42b4-81f6-8903c25c7080">
-                                        <cybox:Object id=":DomainName-1f129d35-b9b2-42b4-81f6-8903c25c7080">
+                                    <indicator:Observable id="citizenlab:observable-1f129d35-b9b2-42b4-81f6-8903c25c7080">
+                                        <cybox:Object id="citizenlab:DomainName-1f129d35-b9b2-42b4-81f6-8903c25c7080">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">taskmgr.serveftp.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:26:48+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2881,30 +2881,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-d79f9f17-548f-4712-afdf-a8dc5dc43be1" timestamp="2016-11-04T00:44:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-d79f9f17-548f-4712-afdf-a8dc5dc43be1" timestamp="2016-11-04T00:44:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: taskmgr.servehttp.com (MISP Attribute #612)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: taskmgr.servehttp.com (MISP Attribute #612)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-d79f9f17-548f-4712-afdf-a8dc5dc43be1">
-                                        <cybox:Object id=":DomainName-d79f9f17-548f-4712-afdf-a8dc5dc43be1">
+                                    <indicator:Observable id="citizenlab:observable-d79f9f17-548f-4712-afdf-a8dc5dc43be1">
+                                        <cybox:Object id="citizenlab:DomainName-d79f9f17-548f-4712-afdf-a8dc5dc43be1">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">taskmgr.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2920,30 +2920,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-4e37e013-f1ce-4df9-ae83-f04eb6b18ba9" timestamp="2016-11-04T00:44:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-4e37e013-f1ce-4df9-ae83-f04eb6b18ba9" timestamp="2016-11-04T00:44:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: taskmgr.redirectme.com (MISP Attribute #613)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: taskmgr.redirectme.com (MISP Attribute #613)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-4e37e013-f1ce-4df9-ae83-f04eb6b18ba9">
-                                        <cybox:Object id=":DomainName-4e37e013-f1ce-4df9-ae83-f04eb6b18ba9">
+                                    <indicator:Observable id="citizenlab:observable-4e37e013-f1ce-4df9-ae83-f04eb6b18ba9">
+                                        <cybox:Object id="citizenlab:DomainName-4e37e013-f1ce-4df9-ae83-f04eb6b18ba9">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">taskmgr.redirectme.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2959,30 +2959,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-b812855c-8fdc-41f2-8857-8966aa84ea89" timestamp="2016-11-04T00:44:10+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-b812855c-8fdc-41f2-8857-8966aa84ea89" timestamp="2016-11-04T00:44:10+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ruley.no-ip.org (MISP Attribute #614)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ruley.no-ip.org (MISP Attribute #614)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-b812855c-8fdc-41f2-8857-8966aa84ea89">
-                                        <cybox:Object id=":DomainName-b812855c-8fdc-41f2-8857-8966aa84ea89">
+                                    <indicator:Observable id="citizenlab:observable-b812855c-8fdc-41f2-8857-8966aa84ea89">
+                                        <cybox:Object id="citizenlab:DomainName-b812855c-8fdc-41f2-8857-8966aa84ea89">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ruley.no-ip.org</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -2998,30 +2998,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-83bc4a8a-fe39-48d7-b26c-f4e4bfe08cde" timestamp="2016-11-04T00:44:10+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-83bc4a8a-fe39-48d7-b26c-f4e4bfe08cde" timestamp="2016-11-04T00:44:10+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: lolinha.no-ip.org (MISP Attribute #615)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: lolinha.no-ip.org (MISP Attribute #615)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-83bc4a8a-fe39-48d7-b26c-f4e4bfe08cde">
-                                        <cybox:Object id=":DomainName-83bc4a8a-fe39-48d7-b26c-f4e4bfe08cde">
+                                    <indicator:Observable id="citizenlab:observable-83bc4a8a-fe39-48d7-b26c-f4e4bfe08cde">
+                                        <cybox:Object id="citizenlab:DomainName-83bc4a8a-fe39-48d7-b26c-f4e4bfe08cde">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">lolinha.no-ip.org</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3037,30 +3037,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-cbdf99c3-ac02-49e1-bd44-aa95c5e2acac" timestamp="2016-11-04T00:44:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-cbdf99c3-ac02-49e1-bd44-aa95c5e2acac" timestamp="2016-11-04T00:44:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: wjwj.no-ip.org (MISP Attribute #616)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: wjwj.no-ip.org (MISP Attribute #616)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-cbdf99c3-ac02-49e1-bd44-aa95c5e2acac">
-                                        <cybox:Object id=":DomainName-cbdf99c3-ac02-49e1-bd44-aa95c5e2acac">
+                                    <indicator:Observable id="citizenlab:observable-cbdf99c3-ac02-49e1-bd44-aa95c5e2acac">
+                                        <cybox:Object id="citizenlab:DomainName-cbdf99c3-ac02-49e1-bd44-aa95c5e2acac">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">wjwj.no-ip.org</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3076,30 +3076,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-1013af0f-98ea-44cf-8c57-d5dfcc2a9398" timestamp="2016-11-04T00:44:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-1013af0f-98ea-44cf-8c57-d5dfcc2a9398" timestamp="2016-11-04T00:44:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: conhost.servehttp.com (MISP Attribute #617)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: conhost.servehttp.com (MISP Attribute #617)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-1013af0f-98ea-44cf-8c57-d5dfcc2a9398">
-                                        <cybox:Object id=":DomainName-1013af0f-98ea-44cf-8c57-d5dfcc2a9398">
+                                    <indicator:Observable id="citizenlab:observable-1013af0f-98ea-44cf-8c57-d5dfcc2a9398">
+                                        <cybox:Object id="citizenlab:DomainName-1013af0f-98ea-44cf-8c57-d5dfcc2a9398">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">conhost.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3115,30 +3115,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-29d3b93f-a8c7-46f0-8aaa-d5b1d3a7efa6" timestamp="2016-11-04T00:44:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-29d3b93f-a8c7-46f0-8aaa-d5b1d3a7efa6" timestamp="2016-11-04T00:44:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dllhost.servehttp.com (MISP Attribute #618)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dllhost.servehttp.com (MISP Attribute #618)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-29d3b93f-a8c7-46f0-8aaa-d5b1d3a7efa6">
-                                        <cybox:Object id=":DomainName-29d3b93f-a8c7-46f0-8aaa-d5b1d3a7efa6">
+                                    <indicator:Observable id="citizenlab:observable-29d3b93f-a8c7-46f0-8aaa-d5b1d3a7efa6">
+                                        <cybox:Object id="citizenlab:DomainName-29d3b93f-a8c7-46f0-8aaa-d5b1d3a7efa6">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dllhost.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3154,30 +3154,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-c67572b2-b7f4-4f32-9e4d-a8892079fec4" timestamp="2016-11-04T00:44:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-c67572b2-b7f4-4f32-9e4d-a8892079fec4" timestamp="2016-11-04T00:44:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: wjwjwj.no-ip.org (MISP Attribute #619)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: wjwjwj.no-ip.org (MISP Attribute #619)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-c67572b2-b7f4-4f32-9e4d-a8892079fec4">
-                                        <cybox:Object id=":DomainName-c67572b2-b7f4-4f32-9e4d-a8892079fec4">
+                                    <indicator:Observable id="citizenlab:observable-c67572b2-b7f4-4f32-9e4d-a8892079fec4">
+                                        <cybox:Object id="citizenlab:DomainName-c67572b2-b7f4-4f32-9e4d-a8892079fec4">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">wjwjwj.no-ip.org</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3193,30 +3193,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-a38d5330-38f4-4016-a6a5-82fefed9aacd" timestamp="2016-11-04T00:44:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-a38d5330-38f4-4016-a6a5-82fefed9aacd" timestamp="2016-11-04T00:44:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: wjwjwjwj.no-ip.org (MISP Attribute #620)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: wjwjwjwj.no-ip.org (MISP Attribute #620)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-a38d5330-38f4-4016-a6a5-82fefed9aacd">
-                                        <cybox:Object id=":DomainName-a38d5330-38f4-4016-a6a5-82fefed9aacd">
+                                    <indicator:Observable id="citizenlab:observable-a38d5330-38f4-4016-a6a5-82fefed9aacd">
+                                        <cybox:Object id="citizenlab:DomainName-a38d5330-38f4-4016-a6a5-82fefed9aacd">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">wjwjwjwj.no-ip.org</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3232,30 +3232,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-b66ec73a-4faf-4873-bdd8-8fdde6207ca4" timestamp="2016-11-04T00:44:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-b66ec73a-4faf-4873-bdd8-8fdde6207ca4" timestamp="2016-11-04T00:44:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ecuadorenvivo.co (MISP Attribute #621)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ecuadorenvivo.co (MISP Attribute #621)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-b66ec73a-4faf-4873-bdd8-8fdde6207ca4">
-                                        <cybox:Object id=":DomainName-b66ec73a-4faf-4873-bdd8-8fdde6207ca4">
+                                    <indicator:Observable id="citizenlab:observable-b66ec73a-4faf-4873-bdd8-8fdde6207ca4">
+                                        <cybox:Object id="citizenlab:DomainName-b66ec73a-4faf-4873-bdd8-8fdde6207ca4">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ecuadorenvivo.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3271,30 +3271,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-568339a3-cddf-4539-8e40-f2d726a5341b" timestamp="2016-11-04T00:44:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-568339a3-cddf-4539-8e40-f2d726a5341b" timestamp="2016-11-04T00:44:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ecuadorenvivo.com (MISP Attribute #622)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ecuadorenvivo.com (MISP Attribute #622)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-568339a3-cddf-4539-8e40-f2d726a5341b">
-                                        <cybox:Object id=":DomainName-568339a3-cddf-4539-8e40-f2d726a5341b">
+                                    <indicator:Observable id="citizenlab:observable-568339a3-cddf-4539-8e40-f2d726a5341b">
+                                        <cybox:Object id="citizenlab:DomainName-568339a3-cddf-4539-8e40-f2d726a5341b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ecuadorenvivo.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3310,30 +3310,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-93541388-7cc4-436a-bf73-1e1584776a59" timestamp="2016-11-04T00:44:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-93541388-7cc4-436a-bf73-1e1584776a59" timestamp="2016-11-04T00:44:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.movimientoanticorreista.com (MISP Attribute #623)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.movimientoanticorreista.com (MISP Attribute #623)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-93541388-7cc4-436a-bf73-1e1584776a59">
-                                        <cybox:Object id=":DomainName-93541388-7cc4-436a-bf73-1e1584776a59">
+                                    <indicator:Observable id="citizenlab:observable-93541388-7cc4-436a-bf73-1e1584776a59">
+                                        <cybox:Object id="citizenlab:DomainName-93541388-7cc4-436a-bf73-1e1584776a59">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.movimientoanticorreista.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3349,30 +3349,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-33a05e11-fe8c-47e0-b8a2-55b568df6adf" timestamp="2016-11-04T00:44:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-33a05e11-fe8c-47e0-b8a2-55b568df6adf" timestamp="2016-11-04T00:44:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: focusecuador.tk (MISP Attribute #624)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: focusecuador.tk (MISP Attribute #624)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-33a05e11-fe8c-47e0-b8a2-55b568df6adf">
-                                        <cybox:Object id=":DomainName-33a05e11-fe8c-47e0-b8a2-55b568df6adf">
+                                    <indicator:Observable id="citizenlab:observable-33a05e11-fe8c-47e0-b8a2-55b568df6adf">
+                                        <cybox:Object id="citizenlab:DomainName-33a05e11-fe8c-47e0-b8a2-55b568df6adf">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">focusecuador.tk</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3388,30 +3388,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-22c32e7b-f0a5-4e57-8821-a080cb880cdb" timestamp="2016-11-04T00:44:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-22c32e7b-f0a5-4e57-8821-a080cb880cdb" timestamp="2016-11-04T00:44:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mesvr.com (MISP Attribute #625)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mesvr.com (MISP Attribute #625)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-22c32e7b-f0a5-4e57-8821-a080cb880cdb">
-                                        <cybox:Object id=":DomainName-22c32e7b-f0a5-4e57-8821-a080cb880cdb">
+                                    <indicator:Observable id="citizenlab:observable-22c32e7b-f0a5-4e57-8821-a080cb880cdb">
+                                        <cybox:Object id="citizenlab:DomainName-22c32e7b-f0a5-4e57-8821-a080cb880cdb">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mesvr.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3427,30 +3427,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-a391d94a-2311-4420-a315-067f450915c2" timestamp="2016-11-04T00:44:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-a391d94a-2311-4420-a315-067f450915c2" timestamp="2016-11-04T00:44:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ftp.ftpserver.com (MISP Attribute #626)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ftp.ftpserver.com (MISP Attribute #626)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-a391d94a-2311-4420-a315-067f450915c2">
-                                        <cybox:Object id=":DomainName-a391d94a-2311-4420-a315-067f450915c2">
+                                    <indicator:Observable id="citizenlab:observable-a391d94a-2311-4420-a315-067f450915c2">
+                                        <cybox:Object id="citizenlab:DomainName-a391d94a-2311-4420-a315-067f450915c2">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ftp.ftpserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3466,30 +3466,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-f5818138-37c1-412a-8cf7-2d7bcb538367" timestamp="2016-11-04T00:44:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-f5818138-37c1-412a-8cf7-2d7bcb538367" timestamp="2016-11-04T00:44:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: lavozamericana.info (MISP Attribute #627)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: lavozamericana.info (MISP Attribute #627)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-f5818138-37c1-412a-8cf7-2d7bcb538367">
-                                        <cybox:Object id=":DomainName-f5818138-37c1-412a-8cf7-2d7bcb538367">
+                                    <indicator:Observable id="citizenlab:observable-f5818138-37c1-412a-8cf7-2d7bcb538367">
+                                        <cybox:Object id="citizenlab:DomainName-f5818138-37c1-412a-8cf7-2d7bcb538367">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">lavozamericana.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3505,30 +3505,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-8eecda70-e625-413f-b7fc-8451d76f4765" timestamp="2016-11-04T00:44:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-8eecda70-e625-413f-b7fc-8451d76f4765" timestamp="2016-11-04T00:44:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ec.cu9.co (MISP Attribute #628)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ec.cu9.co (MISP Attribute #628)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-8eecda70-e625-413f-b7fc-8451d76f4765">
-                                        <cybox:Object id=":DomainName-8eecda70-e625-413f-b7fc-8451d76f4765">
+                                    <indicator:Observable id="citizenlab:observable-8eecda70-e625-413f-b7fc-8451d76f4765">
+                                        <cybox:Object id="citizenlab:DomainName-8eecda70-e625-413f-b7fc-8451d76f4765">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ec.cu9.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3544,30 +3544,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-395f1ba8-c107-4622-a845-f2a2e2660b64" timestamp="2016-11-04T00:44:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-395f1ba8-c107-4622-a845-f2a2e2660b64" timestamp="2016-11-04T00:44:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: movimientoanticorreista.com (MISP Attribute #629)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: movimientoanticorreista.com (MISP Attribute #629)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-395f1ba8-c107-4622-a845-f2a2e2660b64">
-                                        <cybox:Object id=":DomainName-395f1ba8-c107-4622-a845-f2a2e2660b64">
+                                    <indicator:Observable id="citizenlab:observable-395f1ba8-c107-4622-a845-f2a2e2660b64">
+                                        <cybox:Object id="citizenlab:DomainName-395f1ba8-c107-4622-a845-f2a2e2660b64">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">movimientoanticorreista.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3583,30 +3583,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-74bc6c34-77bb-4328-9edc-75059585e539" timestamp="2016-11-04T00:44:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-74bc6c34-77bb-4328-9edc-75059585e539" timestamp="2016-11-04T00:44:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mgoogle.us (MISP Attribute #630)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mgoogle.us (MISP Attribute #630)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-74bc6c34-77bb-4328-9edc-75059585e539">
-                                        <cybox:Object id=":DomainName-74bc6c34-77bb-4328-9edc-75059585e539">
+                                    <indicator:Observable id="citizenlab:observable-74bc6c34-77bb-4328-9edc-75059585e539">
+                                        <cybox:Object id="citizenlab:DomainName-74bc6c34-77bb-4328-9edc-75059585e539">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mgoogle.us</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3622,30 +3622,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-b5b19817-6112-4eeb-b3d1-666f92b33ee7" timestamp="2016-11-04T00:44:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-b5b19817-6112-4eeb-b3d1-666f92b33ee7" timestamp="2016-11-04T00:44:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: no.response.delivery.es (MISP Attribute #631)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: no.response.delivery.es (MISP Attribute #631)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-b5b19817-6112-4eeb-b3d1-666f92b33ee7">
-                                        <cybox:Object id=":DomainName-b5b19817-6112-4eeb-b3d1-666f92b33ee7">
+                                    <indicator:Observable id="citizenlab:observable-b5b19817-6112-4eeb-b3d1-666f92b33ee7">
+                                        <cybox:Object id="citizenlab:DomainName-b5b19817-6112-4eeb-b3d1-666f92b33ee7">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">no.response.delivery.es</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3661,30 +3661,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-50dd1978-ed90-48a0-8fae-f841d7d26c0e" timestamp="2016-11-04T00:44:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-50dd1978-ed90-48a0-8fae-f841d7d26c0e" timestamp="2016-11-04T00:44:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: cu9.co (MISP Attribute #632)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: cu9.co (MISP Attribute #632)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-50dd1978-ed90-48a0-8fae-f841d7d26c0e">
-                                        <cybox:Object id=":DomainName-50dd1978-ed90-48a0-8fae-f841d7d26c0e">
+                                    <indicator:Observable id="citizenlab:observable-50dd1978-ed90-48a0-8fae-f841d7d26c0e">
+                                        <cybox:Object id="citizenlab:DomainName-50dd1978-ed90-48a0-8fae-f841d7d26c0e">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">cu9.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3700,30 +3700,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-491292ff-d9e0-481e-aed8-575ac817cff9" timestamp="2016-11-04T00:44:21+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-491292ff-d9e0-481e-aed8-575ac817cff9" timestamp="2016-11-04T00:44:21+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: asambleanacional-gob-ec.cu9.co (MISP Attribute #634)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: asambleanacional-gob-ec.cu9.co (MISP Attribute #634)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-491292ff-d9e0-481e-aed8-575ac817cff9">
-                                        <cybox:Object id=":DomainName-491292ff-d9e0-481e-aed8-575ac817cff9">
+                                    <indicator:Observable id="citizenlab:observable-491292ff-d9e0-481e-aed8-575ac817cff9">
+                                        <cybox:Object id="citizenlab:DomainName-491292ff-d9e0-481e-aed8-575ac817cff9">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">asambleanacional-gob-ec.cu9.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3739,30 +3739,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-cf896608-add9-45a1-8a66-8a04096b70f1" timestamp="2016-11-04T00:44:22+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-cf896608-add9-45a1-8a66-8a04096b70f1" timestamp="2016-11-04T00:44:22+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail.asambleanacional.gob.ec (MISP Attribute #635)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail.asambleanacional.gob.ec (MISP Attribute #635)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-cf896608-add9-45a1-8a66-8a04096b70f1">
-                                        <cybox:Object id=":DomainName-cf896608-add9-45a1-8a66-8a04096b70f1">
+                                    <indicator:Observable id="citizenlab:observable-cf896608-add9-45a1-8a66-8a04096b70f1">
+                                        <cybox:Object id="citizenlab:DomainName-cf896608-add9-45a1-8a66-8a04096b70f1">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail.asambleanacional.gob.ec</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3778,30 +3778,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-53063744-8009-4309-823f-44ac089a9f4d" timestamp="2016-11-04T00:44:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-53063744-8009-4309-823f-44ac089a9f4d" timestamp="2016-11-04T00:44:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: formmail.com (MISP Attribute #636)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: formmail.com (MISP Attribute #636)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-53063744-8009-4309-823f-44ac089a9f4d">
-                                        <cybox:Object id=":DomainName-53063744-8009-4309-823f-44ac089a9f4d">
+                                    <indicator:Observable id="citizenlab:observable-53063744-8009-4309-823f-44ac089a9f4d">
+                                        <cybox:Object id="citizenlab:DomainName-53063744-8009-4309-823f-44ac089a9f4d">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">formmail.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3817,30 +3817,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-c00a3cd4-3530-4a3d-a0b2-4231aad495ad" timestamp="2016-11-04T00:44:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-c00a3cd4-3530-4a3d-a0b2-4231aad495ad" timestamp="2016-11-04T00:44:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: login-office365.com (MISP Attribute #637)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: login-office365.com (MISP Attribute #637)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-c00a3cd4-3530-4a3d-a0b2-4231aad495ad">
-                                        <cybox:Object id=":DomainName-c00a3cd4-3530-4a3d-a0b2-4231aad495ad">
+                                    <indicator:Observable id="citizenlab:observable-c00a3cd4-3530-4a3d-a0b2-4231aad495ad">
+                                        <cybox:Object id="citizenlab:DomainName-c00a3cd4-3530-4a3d-a0b2-4231aad495ad">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">login-office365.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3856,30 +3856,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-abc292cf-5485-4189-8c0a-b18d830cc7f2" timestamp="2016-11-04T00:44:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-abc292cf-5485-4189-8c0a-b18d830cc7f2" timestamp="2016-11-04T00:44:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: pancaliente.info (MISP Attribute #638)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: pancaliente.info (MISP Attribute #638)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-abc292cf-5485-4189-8c0a-b18d830cc7f2">
-                                        <cybox:Object id=":DomainName-abc292cf-5485-4189-8c0a-b18d830cc7f2">
+                                    <indicator:Observable id="citizenlab:observable-abc292cf-5485-4189-8c0a-b18d830cc7f2">
+                                        <cybox:Object id="citizenlab:DomainName-abc292cf-5485-4189-8c0a-b18d830cc7f2">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">pancaliente.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3895,30 +3895,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-77cc5d54-a422-4f1b-ab2f-167cdfde8bef" timestamp="2016-11-04T00:44:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-77cc5d54-a422-4f1b-ab2f-167cdfde8bef" timestamp="2016-11-04T00:44:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: focusecuador.net (MISP Attribute #639)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: focusecuador.net (MISP Attribute #639)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-77cc5d54-a422-4f1b-ab2f-167cdfde8bef">
-                                        <cybox:Object id=":DomainName-77cc5d54-a422-4f1b-ab2f-167cdfde8bef">
+                                    <indicator:Observable id="citizenlab:observable-77cc5d54-a422-4f1b-ab2f-167cdfde8bef">
+                                        <cybox:Object id="citizenlab:DomainName-77cc5d54-a422-4f1b-ab2f-167cdfde8bef">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">focusecuador.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3934,30 +3934,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-ec9d62d6-4906-45a7-a781-a4b3939e77bc" timestamp="2016-11-04T00:44:26+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-ec9d62d6-4906-45a7-a781-a4b3939e77bc" timestamp="2016-11-04T00:44:26+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: gmail.com.msg07.xyz (MISP Attribute #641)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: gmail.com.msg07.xyz (MISP Attribute #641)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-ec9d62d6-4906-45a7-a781-a4b3939e77bc">
-                                        <cybox:Object id=":DomainName-ec9d62d6-4906-45a7-a781-a4b3939e77bc">
+                                    <indicator:Observable id="citizenlab:observable-ec9d62d6-4906-45a7-a781-a4b3939e77bc">
+                                        <cybox:Object id="citizenlab:DomainName-ec9d62d6-4906-45a7-a781-a4b3939e77bc">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">gmail.com.msg07.xyz</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -3973,30 +3973,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-0fabddd8-3837-4d33-bb62-efc4edfe67a5" timestamp="2016-11-04T00:44:26+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-0fabddd8-3837-4d33-bb62-efc4edfe67a5" timestamp="2016-11-04T00:44:26+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: supportgmai1.com (MISP Attribute #642)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: supportgmai1.com (MISP Attribute #642)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-0fabddd8-3837-4d33-bb62-efc4edfe67a5">
-                                        <cybox:Object id=":DomainName-0fabddd8-3837-4d33-bb62-efc4edfe67a5">
+                                    <indicator:Observable id="citizenlab:observable-0fabddd8-3837-4d33-bb62-efc4edfe67a5">
+                                        <cybox:Object id="citizenlab:DomainName-0fabddd8-3837-4d33-bb62-efc4edfe67a5">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">supportgmai1.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4012,30 +4012,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-1fcd075d-0b8f-42d9-852d-31813ae49879" timestamp="2016-11-04T00:44:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-1fcd075d-0b8f-42d9-852d-31813ae49879" timestamp="2016-11-04T00:44:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: chavistas24.com (MISP Attribute #643)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: chavistas24.com (MISP Attribute #643)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-1fcd075d-0b8f-42d9-852d-31813ae49879">
-                                        <cybox:Object id=":DomainName-1fcd075d-0b8f-42d9-852d-31813ae49879">
+                                    <indicator:Observable id="citizenlab:observable-1fcd075d-0b8f-42d9-852d-31813ae49879">
+                                        <cybox:Object id="citizenlab:DomainName-1fcd075d-0b8f-42d9-852d-31813ae49879">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">chavistas24.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4051,30 +4051,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7a7a2e9e-8e1e-45c7-ba5d-c6d6ce59465a" timestamp="2016-11-04T00:44:28+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7a7a2e9e-8e1e-45c7-ba5d-c6d6ce59465a" timestamp="2016-11-04T00:44:28+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ns1.hostinger.ru (MISP Attribute #644)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ns1.hostinger.ru (MISP Attribute #644)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7a7a2e9e-8e1e-45c7-ba5d-c6d6ce59465a">
-                                        <cybox:Object id=":DomainName-7a7a2e9e-8e1e-45c7-ba5d-c6d6ce59465a">
+                                    <indicator:Observable id="citizenlab:observable-7a7a2e9e-8e1e-45c7-ba5d-c6d6ce59465a">
+                                        <cybox:Object id="citizenlab:DomainName-7a7a2e9e-8e1e-45c7-ba5d-c6d6ce59465a">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ns1.hostinger.ru</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4090,30 +4090,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-0c0abe15-22aa-433f-9a15-0b8196c3a99a" timestamp="2016-11-04T00:44:28+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-0c0abe15-22aa-433f-9a15-0b8196c3a99a" timestamp="2016-11-04T00:44:28+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: venezuela365.com (MISP Attribute #645)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: venezuela365.com (MISP Attribute #645)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-0c0abe15-22aa-433f-9a15-0b8196c3a99a">
-                                        <cybox:Object id=":DomainName-0c0abe15-22aa-433f-9a15-0b8196c3a99a">
+                                    <indicator:Observable id="citizenlab:observable-0c0abe15-22aa-433f-9a15-0b8196c3a99a">
+                                        <cybox:Object id="citizenlab:DomainName-0c0abe15-22aa-433f-9a15-0b8196c3a99a">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">venezuela365.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4129,30 +4129,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-4e2e0b4c-8e54-40bc-9432-152d34b9980b" timestamp="2016-11-04T00:44:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-4e2e0b4c-8e54-40bc-9432-152d34b9980b" timestamp="2016-11-04T00:44:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 24.com (MISP Attribute #646)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 24.com (MISP Attribute #646)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-4e2e0b4c-8e54-40bc-9432-152d34b9980b">
-                                        <cybox:Object id=":DomainName-4e2e0b4c-8e54-40bc-9432-152d34b9980b">
+                                    <indicator:Observable id="citizenlab:observable-4e2e0b4c-8e54-40bc-9432-152d34b9980b">
+                                        <cybox:Object id="citizenlab:DomainName-4e2e0b4c-8e54-40bc-9432-152d34b9980b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">24.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4168,30 +4168,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-823b71a4-5bcc-4c16-bd79-816b1b6e70d9" timestamp="2016-11-04T00:44:30+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-823b71a4-5bcc-4c16-bd79-816b1b6e70d9" timestamp="2016-11-04T00:44:30+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: justicia-desvinculados.com (MISP Attribute #647)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: justicia-desvinculados.com (MISP Attribute #647)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-823b71a4-5bcc-4c16-bd79-816b1b6e70d9">
-                                        <cybox:Object id=":DomainName-823b71a4-5bcc-4c16-bd79-816b1b6e70d9">
+                                    <indicator:Observable id="citizenlab:observable-823b71a4-5bcc-4c16-bd79-816b1b6e70d9">
+                                        <cybox:Object id="citizenlab:DomainName-823b71a4-5bcc-4c16-bd79-816b1b6e70d9">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">justicia-desvinculados.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4207,30 +4207,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-c891c678-1cf0-4842-bcec-fe93b9479a28" timestamp="2016-11-08T16:25:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-c891c678-1cf0-4842-bcec-fe93b9479a28" timestamp="2016-11-08T16:25:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 50.62.133.49 (MISP Attribute #648)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 50.62.133.49 (MISP Attribute #648)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-c891c678-1cf0-4842-bcec-fe93b9479a28">
-                                        <cybox:Object id=":Address-c891c678-1cf0-4842-bcec-fe93b9479a28">
+                                    <indicator:Observable id="citizenlab:observable-c891c678-1cf0-4842-bcec-fe93b9479a28">
+                                        <cybox:Object id="citizenlab:Address-c891c678-1cf0-4842-bcec-fe93b9479a28">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">50.62.133.49</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:25:43+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -4240,30 +4240,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-89db0f38-a183-45b8-9503-69828bf29412" timestamp="2016-11-08T16:26:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-89db0f38-a183-45b8-9503-69828bf29412" timestamp="2016-11-08T16:26:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 192.169.243.65 (MISP Attribute #649)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 192.169.243.65 (MISP Attribute #649)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-89db0f38-a183-45b8-9503-69828bf29412">
-                                        <cybox:Object id=":Address-89db0f38-a183-45b8-9503-69828bf29412">
+                                    <indicator:Observable id="citizenlab:observable-89db0f38-a183-45b8-9503-69828bf29412">
+                                        <cybox:Object id="citizenlab:Address-89db0f38-a183-45b8-9503-69828bf29412">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">192.169.243.65</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:26:04+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -4273,30 +4273,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-9e0ea90e-1dae-4fd3-9fe2-a95bf8ff29c7" timestamp="2016-11-04T00:44:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-9e0ea90e-1dae-4fd3-9fe2-a95bf8ff29c7" timestamp="2016-11-04T00:44:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 190.210.180.181 (MISP Attribute #650)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 190.210.180.181 (MISP Attribute #650)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-9e0ea90e-1dae-4fd3-9fe2-a95bf8ff29c7">
-                                        <cybox:Object id=":Address-9e0ea90e-1dae-4fd3-9fe2-a95bf8ff29c7">
+                                    <indicator:Observable id="citizenlab:observable-9e0ea90e-1dae-4fd3-9fe2-a95bf8ff29c7">
+                                        <cybox:Object id="citizenlab:Address-9e0ea90e-1dae-4fd3-9fe2-a95bf8ff29c7">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">190.210.180.181</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4312,30 +4312,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-080d5bfb-0924-48a0-8b75-37104a301e1c" timestamp="2016-11-04T00:44:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-080d5bfb-0924-48a0-8b75-37104a301e1c" timestamp="2016-11-04T00:44:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 201.52.24.126 (MISP Attribute #651)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 201.52.24.126 (MISP Attribute #651)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-080d5bfb-0924-48a0-8b75-37104a301e1c">
-                                        <cybox:Object id=":Address-080d5bfb-0924-48a0-8b75-37104a301e1c">
+                                    <indicator:Observable id="citizenlab:observable-080d5bfb-0924-48a0-8b75-37104a301e1c">
+                                        <cybox:Object id="citizenlab:Address-080d5bfb-0924-48a0-8b75-37104a301e1c">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">201.52.24.126</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4351,30 +4351,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7a948702-dd5c-46da-93e6-37d7bc088693" timestamp="2016-11-04T00:44:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7a948702-dd5c-46da-93e6-37d7bc088693" timestamp="2016-11-04T00:44:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 190.20.180.181 (MISP Attribute #652)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 190.20.180.181 (MISP Attribute #652)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7a948702-dd5c-46da-93e6-37d7bc088693">
-                                        <cybox:Object id=":Address-7a948702-dd5c-46da-93e6-37d7bc088693">
+                                    <indicator:Observable id="citizenlab:observable-7a948702-dd5c-46da-93e6-37d7bc088693">
+                                        <cybox:Object id="citizenlab:Address-7a948702-dd5c-46da-93e6-37d7bc088693">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">190.20.180.181</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4390,30 +4390,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-d736d788-19c3-47d3-85ba-6f1b8a3f0897" timestamp="2016-11-04T00:44:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-d736d788-19c3-47d3-85ba-6f1b8a3f0897" timestamp="2016-11-04T00:44:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 186.220.1.84 (MISP Attribute #653)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 186.220.1.84 (MISP Attribute #653)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-d736d788-19c3-47d3-85ba-6f1b8a3f0897">
-                                        <cybox:Object id=":Address-d736d788-19c3-47d3-85ba-6f1b8a3f0897">
+                                    <indicator:Observable id="citizenlab:observable-d736d788-19c3-47d3-85ba-6f1b8a3f0897">
+                                        <cybox:Object id="citizenlab:Address-d736d788-19c3-47d3-85ba-6f1b8a3f0897">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">186.220.1.84</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4429,30 +4429,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-f4ce5713-8486-4eff-be64-f04899ad0e63" timestamp="2016-11-04T00:44:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-f4ce5713-8486-4eff-be64-f04899ad0e63" timestamp="2016-11-04T00:44:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 186.220.11.67 (MISP Attribute #654)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 186.220.11.67 (MISP Attribute #654)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-f4ce5713-8486-4eff-be64-f04899ad0e63">
-                                        <cybox:Object id=":Address-f4ce5713-8486-4eff-be64-f04899ad0e63">
+                                    <indicator:Observable id="citizenlab:observable-f4ce5713-8486-4eff-be64-f04899ad0e63">
+                                        <cybox:Object id="citizenlab:Address-f4ce5713-8486-4eff-be64-f04899ad0e63">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">186.220.11.67</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4468,30 +4468,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-0a4ead27-a700-45f4-bcd0-b469d002b231" timestamp="2016-11-04T00:44:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-0a4ead27-a700-45f4-bcd0-b469d002b231" timestamp="2016-11-04T00:44:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 189.100.148.188 (MISP Attribute #655)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 189.100.148.188 (MISP Attribute #655)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-0a4ead27-a700-45f4-bcd0-b469d002b231">
-                                        <cybox:Object id=":Address-0a4ead27-a700-45f4-bcd0-b469d002b231">
+                                    <indicator:Observable id="citizenlab:observable-0a4ead27-a700-45f4-bcd0-b469d002b231">
+                                        <cybox:Object id="citizenlab:Address-0a4ead27-a700-45f4-bcd0-b469d002b231">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">189.100.148.188</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4507,30 +4507,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-56e407af-b034-469f-833e-4261d12f4e3f" timestamp="2016-11-04T00:44:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-56e407af-b034-469f-833e-4261d12f4e3f" timestamp="2016-11-04T00:44:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 179.208.187.216 (MISP Attribute #656)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 179.208.187.216 (MISP Attribute #656)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-56e407af-b034-469f-833e-4261d12f4e3f">
-                                        <cybox:Object id=":Address-56e407af-b034-469f-833e-4261d12f4e3f">
+                                    <indicator:Observable id="citizenlab:observable-56e407af-b034-469f-833e-4261d12f4e3f">
+                                        <cybox:Object id="citizenlab:Address-56e407af-b034-469f-833e-4261d12f4e3f">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">179.208.187.216</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4546,30 +4546,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-2de6d004-f85c-4967-9aaf-f6a2bd9f4349" timestamp="2016-11-04T00:44:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-2de6d004-f85c-4967-9aaf-f6a2bd9f4349" timestamp="2016-11-04T00:44:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 46.246.89.246 (MISP Attribute #657)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 46.246.89.246 (MISP Attribute #657)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-2de6d004-f85c-4967-9aaf-f6a2bd9f4349">
-                                        <cybox:Object id=":Address-2de6d004-f85c-4967-9aaf-f6a2bd9f4349">
+                                    <indicator:Observable id="citizenlab:observable-2de6d004-f85c-4967-9aaf-f6a2bd9f4349">
+                                        <cybox:Object id="citizenlab:Address-2de6d004-f85c-4967-9aaf-f6a2bd9f4349">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">46.246.89.246</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4585,30 +4585,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-1c9844bb-53a7-4c6d-859a-864d802fb755" timestamp="2016-11-04T00:44:38+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-1c9844bb-53a7-4c6d-859a-864d802fb755" timestamp="2016-11-04T00:44:38+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 198.12.150.249 (MISP Attribute #658)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 198.12.150.249 (MISP Attribute #658)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-1c9844bb-53a7-4c6d-859a-864d802fb755">
-                                        <cybox:Object id=":Address-1c9844bb-53a7-4c6d-859a-864d802fb755">
+                                    <indicator:Observable id="citizenlab:observable-1c9844bb-53a7-4c6d-859a-864d802fb755">
+                                        <cybox:Object id="citizenlab:Address-1c9844bb-53a7-4c6d-859a-864d802fb755">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">198.12.150.249</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4624,30 +4624,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-63f47613-ca7a-4a85-859b-55acf0440a1a" timestamp="2016-11-04T00:44:38+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-63f47613-ca7a-4a85-859b-55acf0440a1a" timestamp="2016-11-04T00:44:38+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 50.63.202.57 (MISP Attribute #659)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 50.63.202.57 (MISP Attribute #659)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-63f47613-ca7a-4a85-859b-55acf0440a1a">
-                                        <cybox:Object id=":Address-63f47613-ca7a-4a85-859b-55acf0440a1a">
+                                    <indicator:Observable id="citizenlab:observable-63f47613-ca7a-4a85-859b-55acf0440a1a">
+                                        <cybox:Object id="citizenlab:Address-63f47613-ca7a-4a85-859b-55acf0440a1a">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">50.63.202.57</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4663,30 +4663,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-8149df18-d5b8-4b8f-9ebf-48676f586058" timestamp="2016-11-04T00:44:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-8149df18-d5b8-4b8f-9ebf-48676f586058" timestamp="2016-11-04T00:44:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 193.105.134.27 (MISP Attribute #660)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 193.105.134.27 (MISP Attribute #660)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-8149df18-d5b8-4b8f-9ebf-48676f586058">
-                                        <cybox:Object id=":Address-8149df18-d5b8-4b8f-9ebf-48676f586058">
+                                    <indicator:Observable id="citizenlab:observable-8149df18-d5b8-4b8f-9ebf-48676f586058">
+                                        <cybox:Object id="citizenlab:Address-8149df18-d5b8-4b8f-9ebf-48676f586058">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">193.105.134.27</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4702,30 +4702,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-3b6d91fc-6693-453e-b8d0-9a0955b12a9c" timestamp="2016-11-04T00:44:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-3b6d91fc-6693-453e-b8d0-9a0955b12a9c" timestamp="2016-11-04T00:44:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://ecuadorenvivo.com/videos/el-meme-que-volvio-loco-a-correa.html (MISP Attribute #661)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://ecuadorenvivo.com/videos/el-meme-que-volvio-loco-a-correa.html (MISP Attribute #661)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-3b6d91fc-6693-453e-b8d0-9a0955b12a9c">
-                                        <cybox:Object id=":URI-3b6d91fc-6693-453e-b8d0-9a0955b12a9c">
+                                    <indicator:Observable id="citizenlab:observable-3b6d91fc-6693-453e-b8d0-9a0955b12a9c">
+                                        <cybox:Object id="citizenlab:URI-3b6d91fc-6693-453e-b8d0-9a0955b12a9c">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://ecuadorenvivo.com/videos/el-meme-que-volvio-loco-a-correa.html</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4741,30 +4741,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-0e4cc2f6-8b32-489a-8f86-6279b96ff313" timestamp="2016-11-04T00:44:41+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-0e4cc2f6-8b32-489a-8f86-6279b96ff313" timestamp="2016-11-04T00:44:41+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://ecuadorenvivo.co/videos/el-meme-que-volvio-loco-a-correa.html (MISP Attribute #662)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://ecuadorenvivo.co/videos/el-meme-que-volvio-loco-a-correa.html (MISP Attribute #662)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-0e4cc2f6-8b32-489a-8f86-6279b96ff313">
-                                        <cybox:Object id=":URI-0e4cc2f6-8b32-489a-8f86-6279b96ff313">
+                                    <indicator:Observable id="citizenlab:observable-0e4cc2f6-8b32-489a-8f86-6279b96ff313">
+                                        <cybox:Object id="citizenlab:URI-0e4cc2f6-8b32-489a-8f86-6279b96ff313">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://ecuadorenvivo.co/videos/el-meme-que-volvio-loco-a-correa.html</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4780,30 +4780,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-809f7cd8-5a6f-4e4e-baca-d148180828b7" timestamp="2016-11-04T00:44:41+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-809f7cd8-5a6f-4e4e-baca-d148180828b7" timestamp="2016-11-04T00:44:41+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://mail.asambleanacional.gob.ec (MISP Attribute #663)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://mail.asambleanacional.gob.ec (MISP Attribute #663)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-809f7cd8-5a6f-4e4e-baca-d148180828b7">
-                                        <cybox:Object id=":URI-809f7cd8-5a6f-4e4e-baca-d148180828b7">
+                                    <indicator:Observable id="citizenlab:observable-809f7cd8-5a6f-4e4e-baca-d148180828b7">
+                                        <cybox:Object id="citizenlab:URI-809f7cd8-5a6f-4e4e-baca-d148180828b7">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://mail.asambleanacional.gob.ec</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4819,30 +4819,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-521771b2-16c0-44e8-b1c6-0dedfe52a93f" timestamp="2016-11-04T00:44:42+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-521771b2-16c0-44e8-b1c6-0dedfe52a93f" timestamp="2016-11-04T00:44:42+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://pancaliente.info/los-negocios-secretos-de-leocenis-garcia-y-gonzalo-tirado (MISP Attribute #664)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://pancaliente.info/los-negocios-secretos-de-leocenis-garcia-y-gonzalo-tirado (MISP Attribute #664)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-521771b2-16c0-44e8-b1c6-0dedfe52a93f">
-                                        <cybox:Object id=":URI-521771b2-16c0-44e8-b1c6-0dedfe52a93f">
+                                    <indicator:Observable id="citizenlab:observable-521771b2-16c0-44e8-b1c6-0dedfe52a93f">
+                                        <cybox:Object id="citizenlab:URI-521771b2-16c0-44e8-b1c6-0dedfe52a93f">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://pancaliente.info/los-negocios-secretos-de-leocenis-garcia-y-gonzalo-tirado</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4858,30 +4858,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-8ea723f1-5e6d-4984-80a1-c844988006d9" timestamp="2016-11-04T00:44:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-8ea723f1-5e6d-4984-80a1-c844988006d9" timestamp="2016-11-04T00:44:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://venezuela365.com/wp-content/uploads/2014/10/tirado-g-300×169.jpg (MISP Attribute #665)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://venezuela365.com/wp-content/uploads/2014/10/tirado-g-300×169.jpg (MISP Attribute #665)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-8ea723f1-5e6d-4984-80a1-c844988006d9">
-                                        <cybox:Object id=":URI-8ea723f1-5e6d-4984-80a1-c844988006d9">
+                                    <indicator:Observable id="citizenlab:observable-8ea723f1-5e6d-4984-80a1-c844988006d9">
+                                        <cybox:Object id="citizenlab:URI-8ea723f1-5e6d-4984-80a1-c844988006d9">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://venezuela365.com/wp-content/uploads/2014/10/tirado-g-300×169.jpg</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -4897,14 +4897,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-9f3c0a52-cf4e-434c-852b-a93df8a857e1" timestamp="2016-11-08T16:24:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-9f3c0a52-cf4e-434c-852b-a93df8a857e1" timestamp="2016-11-08T16:24:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: claudiobonadio88@gmail.com (MISP Attribute #666)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: claudiobonadio88@gmail.com (MISP Attribute #666)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-9f3c0a52-cf4e-434c-852b-a93df8a857e1">
-                                        <cybox:Object id=":EmailMessage-9f3c0a52-cf4e-434c-852b-a93df8a857e1">
+                                    <indicator:Observable id="citizenlab:observable-9f3c0a52-cf4e-434c-852b-a93df8a857e1">
+                                        <cybox:Object id="citizenlab:EmailMessage-9f3c0a52-cf4e-434c-852b-a93df8a857e1">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -4915,16 +4915,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:24:09+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -4934,14 +4934,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-ced4acdc-8a7e-4766-b6c6-431b37b0e332" timestamp="2016-11-08T16:25:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-ced4acdc-8a7e-4766-b6c6-431b37b0e332" timestamp="2016-11-08T16:25:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: cfed.bonadio@gmail.com (MISP Attribute #667)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: cfed.bonadio@gmail.com (MISP Attribute #667)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-ced4acdc-8a7e-4766-b6c6-431b37b0e332">
-                                        <cybox:Object id=":EmailMessage-ced4acdc-8a7e-4766-b6c6-431b37b0e332">
+                                    <indicator:Observable id="citizenlab:observable-ced4acdc-8a7e-4766-b6c6-431b37b0e332">
+                                        <cybox:Object id="citizenlab:EmailMessage-ced4acdc-8a7e-4766-b6c6-431b37b0e332">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -4952,16 +4952,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:25:19+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -4971,14 +4971,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-88a1c5b7-d445-49fc-aa75-7ee28b069510" timestamp="2016-11-04T00:44:45+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-88a1c5b7-d445-49fc-aa75-7ee28b069510" timestamp="2016-11-04T00:44:45+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: focusedtior1@gmail.com (MISP Attribute #668)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: focusedtior1@gmail.com (MISP Attribute #668)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-88a1c5b7-d445-49fc-aa75-7ee28b069510">
-                                        <cybox:Object id=":EmailMessage-88a1c5b7-d445-49fc-aa75-7ee28b069510">
+                                    <indicator:Observable id="citizenlab:observable-88a1c5b7-d445-49fc-aa75-7ee28b069510">
+                                        <cybox:Object id="citizenlab:EmailMessage-88a1c5b7-d445-49fc-aa75-7ee28b069510">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -4989,16 +4989,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -5014,14 +5014,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-e4567864-ed20-4a52-8ebc-280bb84bc259" timestamp="2016-11-04T00:44:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-e4567864-ed20-4a52-8ebc-280bb84bc259" timestamp="2016-11-04T00:44:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: no.response.delivery.es@gmail.com (MISP Attribute #669)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: no.response.delivery.es@gmail.com (MISP Attribute #669)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-e4567864-ed20-4a52-8ebc-280bb84bc259">
-                                        <cybox:Object id=":EmailMessage-e4567864-ed20-4a52-8ebc-280bb84bc259">
+                                    <indicator:Observable id="citizenlab:observable-e4567864-ed20-4a52-8ebc-280bb84bc259">
+                                        <cybox:Object id="citizenlab:EmailMessage-e4567864-ed20-4a52-8ebc-280bb84bc259">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -5032,16 +5032,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -5057,14 +5057,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-438fd35d-28ff-4669-a2c6-d3606ad95501" timestamp="2016-11-04T00:44:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-438fd35d-28ff-4669-a2c6-d3606ad95501" timestamp="2016-11-04T00:44:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: enripintos123@outlook.es (MISP Attribute #670)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: enripintos123@outlook.es (MISP Attribute #670)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-438fd35d-28ff-4669-a2c6-d3606ad95501">
-                                        <cybox:Object id=":EmailMessage-438fd35d-28ff-4669-a2c6-d3606ad95501">
+                                    <indicator:Observable id="citizenlab:observable-438fd35d-28ff-4669-a2c6-d3606ad95501">
+                                        <cybox:Object id="citizenlab:EmailMessage-438fd35d-28ff-4669-a2c6-d3606ad95501">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -5075,16 +5075,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -5100,14 +5100,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-55bc7d1d-b8c1-404a-ba53-0e81f893bf4f" timestamp="2016-11-04T00:44:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-55bc7d1d-b8c1-404a-ba53-0e81f893bf4f" timestamp="2016-11-04T00:44:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: movimiento.anti.correista@gmail.com (MISP Attribute #671)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: movimiento.anti.correista@gmail.com (MISP Attribute #671)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-55bc7d1d-b8c1-404a-ba53-0e81f893bf4f">
-                                        <cybox:Object id=":EmailMessage-55bc7d1d-b8c1-404a-ba53-0e81f893bf4f">
+                                    <indicator:Observable id="citizenlab:observable-55bc7d1d-b8c1-404a-ba53-0e81f893bf4f">
+                                        <cybox:Object id="citizenlab:EmailMessage-55bc7d1d-b8c1-404a-ba53-0e81f893bf4f">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -5118,16 +5118,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -5143,14 +5143,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-4982d975-2425-4c0e-8709-8ea8c3743372" timestamp="2016-11-04T00:44:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-4982d975-2425-4c0e-8709-8ea8c3743372" timestamp="2016-11-04T00:44:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: no-responder@supportgmai1.com (MISP Attribute #672)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: no-responder@supportgmai1.com (MISP Attribute #672)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-4982d975-2425-4c0e-8709-8ea8c3743372">
-                                        <cybox:Object id=":EmailMessage-4982d975-2425-4c0e-8709-8ea8c3743372">
+                                    <indicator:Observable id="citizenlab:observable-4982d975-2425-4c0e-8709-8ea8c3743372">
+                                        <cybox:Object id="citizenlab:EmailMessage-4982d975-2425-4c0e-8709-8ea8c3743372">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -5161,16 +5161,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Handling>
                                         <marking:Marking>
@@ -5188,19 +5188,19 @@
                         <incident:Leveraged_TTPs>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-582243bb-0f34-4775-9d56-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-582243bb-c8d8-4986-a6f6-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-582243bb-f194-4e73-8e86-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-582243bb-28a4-4ba0-bb04-49798e96ca05" timestamp="2016-11-08T16:29:31+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                         </incident:Leveraged_TTPs>
                         <incident:History>

--- a/201603_Shifting_Tactics/stix.xml
+++ b/201603_Shifting_Tactics/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,20 +59,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-dab87d63-6901-4da5-b7ba-2088de90f322" version="1.1.1" timestamp="2016-11-10T21:17:23.793648+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-dab87d63-6901-4da5-b7ba-2088de90f322" version="1.1.1" timestamp="2016-11-10T21:17:23.793648+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-581c1131-3fec-4068-bb74-49798e96ca05" version="1.1.1" timestamp="2016-11-10T16:14:39+00:00">
+            <stix:Package id="citizenlab:STIXPackage-581c1131-3fec-4068-bb74-49798e96ca05" version="1.1.1" timestamp="2016-11-10T16:14:39+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Shifting Tactics: Tracking changes in years-long espionage campaign against Tibetans (MISP Event #11)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:TTPs>
-                    <stix:TTP id=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: FakeM (MISP Attribute #1875)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -84,7 +84,7 @@
                     </stix:TTP>
                 </stix:TTPs>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-581c1131-3fec-4068-bb74-49798e96ca05" timestamp="2016-11-10T16:15:08+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-581c1131-3fec-4068-bb74-49798e96ca05" timestamp="2016-11-10T16:15:08+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Shifting Tactics: Tracking changes in years-long espionage campaign against Tibetans</incident:Title>
                         <incident:External_ID source="MISP Event">11</incident:External_ID>
                         <incident:Time>
@@ -95,14 +95,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5824e149-ba7c-4e04-b905-69fe8e96ca05" timestamp="2016-11-10T16:06:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5824e149-ba7c-4e04-b905-69fe8e96ca05" timestamp="2016-11-10T16:06:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: ea45265fe98b25e719d5a9cc3b412d66 (MISP Attribute #1873)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: ea45265fe98b25e719d5a9cc3b412d66 (MISP Attribute #1873)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5824e149-ba7c-4e04-b905-69fe8e96ca05">
-                                        <cybox:Object id=":File-5824e149-ba7c-4e04-b905-69fe8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5824e149-ba7c-4e04-b905-69fe8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5824e149-ba7c-4e04-b905-69fe8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -114,7 +114,7 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:06:17+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -124,13 +124,13 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5824e1e5-e340-40b0-b3fa-69fe8e96ca05" timestamp="2016-11-10T16:08:53+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5824e1e5-e340-40b0-b3fa-69fe8e96ca05" timestamp="2016-11-10T16:08:53+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: Scarlet Mimic (MISP Attribute #1874)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: Scarlet Mimic (MISP Attribute #1874)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:08:53+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -140,21 +140,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-6308d2e1-a83a-44b2-b96f-267bc24efbd1" timestamp="2016-11-10T16:07:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-6308d2e1-a83a-44b2-b96f-267bc24efbd1" timestamp="2016-11-10T16:07:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: filegoogle.firewall-gateway.com (MISP Attribute #499)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: filegoogle.firewall-gateway.com (MISP Attribute #499)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-6308d2e1-a83a-44b2-b96f-267bc24efbd1">
-                                        <cybox:Object id=":DomainName-6308d2e1-a83a-44b2-b96f-267bc24efbd1">
+                                    <indicator:Observable id="citizenlab:observable-6308d2e1-a83a-44b2-b96f-267bc24efbd1">
+                                        <cybox:Object id="citizenlab:DomainName-6308d2e1-a83a-44b2-b96f-267bc24efbd1">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">filegoogle.firewall-gateway.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:07:04+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -164,21 +164,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-26fb914b-1601-4049-a8b5-c9afc3a16bc0" timestamp="2016-11-10T16:07:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-26fb914b-1601-4049-a8b5-c9afc3a16bc0" timestamp="2016-11-10T16:07:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accountgoogle.firewall-gateway.com (MISP Attribute #500)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accountgoogle.firewall-gateway.com (MISP Attribute #500)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-26fb914b-1601-4049-a8b5-c9afc3a16bc0">
-                                        <cybox:Object id=":DomainName-26fb914b-1601-4049-a8b5-c9afc3a16bc0">
+                                    <indicator:Observable id="citizenlab:observable-26fb914b-1601-4049-a8b5-c9afc3a16bc0">
+                                        <cybox:Object id="citizenlab:DomainName-26fb914b-1601-4049-a8b5-c9afc3a16bc0">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accountgoogle.firewall-gateway.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:07:11+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -188,21 +188,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-11cf9c54-4d35-4a58-8128-a1076025ff25" timestamp="2016-11-10T16:06:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-11cf9c54-4d35-4a58-8128-a1076025ff25" timestamp="2016-11-10T16:06:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: sys.firewall-gateway.net (MISP Attribute #501)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: sys.firewall-gateway.net (MISP Attribute #501)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-11cf9c54-4d35-4a58-8128-a1076025ff25">
-                                        <cybox:Object id=":DomainName-11cf9c54-4d35-4a58-8128-a1076025ff25">
+                                    <indicator:Observable id="citizenlab:observable-11cf9c54-4d35-4a58-8128-a1076025ff25">
+                                        <cybox:Object id="citizenlab:DomainName-11cf9c54-4d35-4a58-8128-a1076025ff25">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">sys.firewall-gateway.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:06:49+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -212,21 +212,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-73e5412a-1252-495d-956d-28cfdd8edaed" timestamp="2016-11-10T16:04:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-73e5412a-1252-495d-956d-28cfdd8edaed" timestamp="2016-11-10T16:04:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: news.firewall-gateway.com (MISP Attribute #502)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: news.firewall-gateway.com (MISP Attribute #502)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-73e5412a-1252-495d-956d-28cfdd8edaed">
-                                        <cybox:Object id=":DomainName-73e5412a-1252-495d-956d-28cfdd8edaed">
+                                    <indicator:Observable id="citizenlab:observable-73e5412a-1252-495d-956d-28cfdd8edaed">
+                                        <cybox:Object id="citizenlab:DomainName-73e5412a-1252-495d-956d-28cfdd8edaed">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">news.firewall-gateway.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:04:39+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -236,21 +236,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-ebbe87e2-7f84-4f68-b766-f63820da7966" timestamp="2016-11-10T16:09:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-ebbe87e2-7f84-4f68-b766-f63820da7966" timestamp="2016-11-10T16:09:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accountsgoogle.firewall-gateway.com (MISP Attribute #503)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accountsgoogle.firewall-gateway.com (MISP Attribute #503)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-ebbe87e2-7f84-4f68-b766-f63820da7966">
-                                        <cybox:Object id=":DomainName-ebbe87e2-7f84-4f68-b766-f63820da7966">
+                                    <indicator:Observable id="citizenlab:observable-ebbe87e2-7f84-4f68-b766-f63820da7966">
+                                        <cybox:Object id="citizenlab:DomainName-ebbe87e2-7f84-4f68-b766-f63820da7966">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accountsgoogle.firewall-gateway.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:09:17+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -260,21 +260,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-3baf841e-c377-44ba-ba20-dcfd7aa8ba22" timestamp="2016-11-10T16:09:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-3baf841e-c377-44ba-ba20-dcfd7aa8ba22" timestamp="2016-11-10T16:09:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-google.firewall-gateway.com (MISP Attribute #504)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-google.firewall-gateway.com (MISP Attribute #504)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-3baf841e-c377-44ba-ba20-dcfd7aa8ba22">
-                                        <cybox:Object id=":DomainName-3baf841e-c377-44ba-ba20-dcfd7aa8ba22">
+                                    <indicator:Observable id="citizenlab:observable-3baf841e-c377-44ba-ba20-dcfd7aa8ba22">
+                                        <cybox:Object id="citizenlab:DomainName-3baf841e-c377-44ba-ba20-dcfd7aa8ba22">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-google.firewall-gateway.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:09:27+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -284,21 +284,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-40edc447-3aaa-4f79-8268-16eddff19b33" timestamp="2016-11-10T16:09:38+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-40edc447-3aaa-4f79-8268-16eddff19b33" timestamp="2016-11-10T16:09:38+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accountsgoogles.firewall-gateway.com (MISP Attribute #505)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accountsgoogles.firewall-gateway.com (MISP Attribute #505)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-40edc447-3aaa-4f79-8268-16eddff19b33">
-                                        <cybox:Object id=":DomainName-40edc447-3aaa-4f79-8268-16eddff19b33">
+                                    <indicator:Observable id="citizenlab:observable-40edc447-3aaa-4f79-8268-16eddff19b33">
+                                        <cybox:Object id="citizenlab:DomainName-40edc447-3aaa-4f79-8268-16eddff19b33">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accountsgoogles.firewall-gateway.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:09:38+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -308,21 +308,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-b84e33b7-1958-4507-b7bb-6bb63304842c" timestamp="2016-11-10T16:09:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-b84e33b7-1958-4507-b7bb-6bb63304842c" timestamp="2016-11-10T16:09:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: googlefile.firewall-gateway.net (MISP Attribute #506)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: googlefile.firewall-gateway.net (MISP Attribute #506)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-b84e33b7-1958-4507-b7bb-6bb63304842c">
-                                        <cybox:Object id=":DomainName-b84e33b7-1958-4507-b7bb-6bb63304842c">
+                                    <indicator:Observable id="citizenlab:observable-b84e33b7-1958-4507-b7bb-6bb63304842c">
+                                        <cybox:Object id="citizenlab:DomainName-b84e33b7-1958-4507-b7bb-6bb63304842c">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">googlefile.firewall-gateway.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:09:47+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -332,21 +332,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-228f765c-d5ab-4fcf-a190-775b9ed2ad70" timestamp="2016-11-10T16:09:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-228f765c-d5ab-4fcf-a190-775b9ed2ad70" timestamp="2016-11-10T16:09:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: firewallupdate.firewall-gateway.com (MISP Attribute #507)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: firewallupdate.firewall-gateway.com (MISP Attribute #507)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-228f765c-d5ab-4fcf-a190-775b9ed2ad70">
-                                        <cybox:Object id=":DomainName-228f765c-d5ab-4fcf-a190-775b9ed2ad70">
+                                    <indicator:Observable id="citizenlab:observable-228f765c-d5ab-4fcf-a190-775b9ed2ad70">
+                                        <cybox:Object id="citizenlab:DomainName-228f765c-d5ab-4fcf-a190-775b9ed2ad70">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">firewallupdate.firewall-gateway.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:09:57+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -356,21 +356,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-35a7486a-38a7-4d3a-bdd8-1284d464484b" timestamp="2016-11-10T16:10:06+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-35a7486a-38a7-4d3a-bdd8-1284d464484b" timestamp="2016-11-10T16:10:06+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: firewallupdate.firewall-gateway.net (MISP Attribute #508)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: firewallupdate.firewall-gateway.net (MISP Attribute #508)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-35a7486a-38a7-4d3a-bdd8-1284d464484b">
-                                        <cybox:Object id=":DomainName-35a7486a-38a7-4d3a-bdd8-1284d464484b">
+                                    <indicator:Observable id="citizenlab:observable-35a7486a-38a7-4d3a-bdd8-1284d464484b">
+                                        <cybox:Object id="citizenlab:DomainName-35a7486a-38a7-4d3a-bdd8-1284d464484b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">firewallupdate.firewall-gateway.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:10:06+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -380,21 +380,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-8b0a371b-0c73-455d-a7ae-d0a530f23b04" timestamp="2016-11-10T16:10:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-8b0a371b-0c73-455d-a7ae-d0a530f23b04" timestamp="2016-11-10T16:10:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drivgoogle.firewall-gateway.com (MISP Attribute #509)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drivgoogle.firewall-gateway.com (MISP Attribute #509)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-8b0a371b-0c73-455d-a7ae-d0a530f23b04">
-                                        <cybox:Object id=":DomainName-8b0a371b-0c73-455d-a7ae-d0a530f23b04">
+                                    <indicator:Observable id="citizenlab:observable-8b0a371b-0c73-455d-a7ae-d0a530f23b04">
+                                        <cybox:Object id="citizenlab:DomainName-8b0a371b-0c73-455d-a7ae-d0a530f23b04">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drivgoogle.firewall-gateway.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:10:18+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -404,21 +404,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-86627daf-07c8-467f-babc-426d586e7d4a" timestamp="2016-11-10T16:05:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-86627daf-07c8-467f-babc-426d586e7d4a" timestamp="2016-11-10T16:05:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: detail43.myfirewall.org (MISP Attribute #510)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: detail43.myfirewall.org (MISP Attribute #510)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-86627daf-07c8-467f-babc-426d586e7d4a">
-                                        <cybox:Object id=":DomainName-86627daf-07c8-467f-babc-426d586e7d4a">
+                                    <indicator:Observable id="citizenlab:observable-86627daf-07c8-467f-babc-426d586e7d4a">
+                                        <cybox:Object id="citizenlab:DomainName-86627daf-07c8-467f-babc-426d586e7d4a">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">detail43.myfirewall.org</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:05:44+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -428,21 +428,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-a31a03ec-f99e-4bec-95dc-3574c3512217" timestamp="2016-11-10T16:11:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-a31a03ec-f99e-4bec-95dc-3574c3512217" timestamp="2016-11-10T16:11:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 95.154.195.159 (MISP Attribute #512)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 95.154.195.159 (MISP Attribute #512)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-a31a03ec-f99e-4bec-95dc-3574c3512217">
-                                        <cybox:Object id=":Address-a31a03ec-f99e-4bec-95dc-3574c3512217">
+                                    <indicator:Observable id="citizenlab:observable-a31a03ec-f99e-4bec-95dc-3574c3512217">
+                                        <cybox:Object id="citizenlab:Address-a31a03ec-f99e-4bec-95dc-3574c3512217">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">95.154.195.159</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:11:07+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -452,21 +452,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-318dd748-c9d9-4f7b-9b42-75a60001f9e1" timestamp="2016-11-10T16:11:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-318dd748-c9d9-4f7b-9b42-75a60001f9e1" timestamp="2016-11-10T16:11:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 95.154.195.171 (MISP Attribute #513)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 95.154.195.171 (MISP Attribute #513)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-318dd748-c9d9-4f7b-9b42-75a60001f9e1">
-                                        <cybox:Object id=":Address-318dd748-c9d9-4f7b-9b42-75a60001f9e1">
+                                    <indicator:Observable id="citizenlab:observable-318dd748-c9d9-4f7b-9b42-75a60001f9e1">
+                                        <cybox:Object id="citizenlab:Address-318dd748-c9d9-4f7b-9b42-75a60001f9e1">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">95.154.195.171</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:11:12+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -476,21 +476,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-1f0bc371-f681-4049-855d-235e6bc5eb8e" timestamp="2016-11-10T16:11:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-1f0bc371-f681-4049-855d-235e6bc5eb8e" timestamp="2016-11-10T16:11:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 5.54.19.17 (MISP Attribute #514)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 5.54.19.17 (MISP Attribute #514)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-1f0bc371-f681-4049-855d-235e6bc5eb8e">
-                                        <cybox:Object id=":Address-1f0bc371-f681-4049-855d-235e6bc5eb8e">
+                                    <indicator:Observable id="citizenlab:observable-1f0bc371-f681-4049-855d-235e6bc5eb8e">
+                                        <cybox:Object id="citizenlab:Address-1f0bc371-f681-4049-855d-235e6bc5eb8e">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">5.54.19.17</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:11:20+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -500,21 +500,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-f48470fd-c782-4831-a20d-4704b62f1358" timestamp="2016-11-10T16:12:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-f48470fd-c782-4831-a20d-4704b62f1358" timestamp="2016-11-10T16:12:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 78.129.252.159 (MISP Attribute #515)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 78.129.252.159 (MISP Attribute #515)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-f48470fd-c782-4831-a20d-4704b62f1358">
-                                        <cybox:Object id=":Address-f48470fd-c782-4831-a20d-4704b62f1358">
+                                    <indicator:Observable id="citizenlab:observable-f48470fd-c782-4831-a20d-4704b62f1358">
+                                        <cybox:Object id="citizenlab:Address-f48470fd-c782-4831-a20d-4704b62f1358">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">78.129.252.159</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:12:49+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -524,21 +524,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-c379b263-55d3-464d-b94f-178f02f883a8" timestamp="2016-11-10T16:12:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-c379b263-55d3-464d-b94f-178f02f883a8" timestamp="2016-11-10T16:12:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 87.117.229.109 (MISP Attribute #516)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 87.117.229.109 (MISP Attribute #516)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-c379b263-55d3-464d-b94f-178f02f883a8">
-                                        <cybox:Object id=":Address-c379b263-55d3-464d-b94f-178f02f883a8">
+                                    <indicator:Observable id="citizenlab:observable-c379b263-55d3-464d-b94f-178f02f883a8">
+                                        <cybox:Object id="citizenlab:Address-c379b263-55d3-464d-b94f-178f02f883a8">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">87.117.229.109</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:12:57+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -548,21 +548,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-ad5c4c3d-6194-4059-9aa1-1593b62d32a9" timestamp="2016-11-10T16:13:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-ad5c4c3d-6194-4059-9aa1-1593b62d32a9" timestamp="2016-11-10T16:13:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 109.169.40.172 (MISP Attribute #517)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 109.169.40.172 (MISP Attribute #517)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-ad5c4c3d-6194-4059-9aa1-1593b62d32a9">
-                                        <cybox:Object id=":Address-ad5c4c3d-6194-4059-9aa1-1593b62d32a9">
+                                    <indicator:Observable id="citizenlab:observable-ad5c4c3d-6194-4059-9aa1-1593b62d32a9">
+                                        <cybox:Object id="citizenlab:Address-ad5c4c3d-6194-4059-9aa1-1593b62d32a9">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">109.169.40.172</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:13:04+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -572,21 +572,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-b2cebdea-e90b-416f-9a0f-94a566b32a2a" timestamp="2016-11-10T16:13:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-b2cebdea-e90b-416f-9a0f-94a566b32a2a" timestamp="2016-11-10T16:13:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 46.127.56.109 (MISP Attribute #518)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 46.127.56.109 (MISP Attribute #518)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-b2cebdea-e90b-416f-9a0f-94a566b32a2a">
-                                        <cybox:Object id=":Address-b2cebdea-e90b-416f-9a0f-94a566b32a2a">
+                                    <indicator:Observable id="citizenlab:observable-b2cebdea-e90b-416f-9a0f-94a566b32a2a">
+                                        <cybox:Object id="citizenlab:Address-b2cebdea-e90b-416f-9a0f-94a566b32a2a">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">46.127.56.109</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:13:12+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -596,21 +596,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-8ce49cb3-e458-4568-b560-04a314ce9539" timestamp="2016-11-10T16:13:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-8ce49cb3-e458-4568-b560-04a314ce9539" timestamp="2016-11-10T16:13:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 192.253.251.118 (MISP Attribute #519)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 192.253.251.118 (MISP Attribute #519)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-8ce49cb3-e458-4568-b560-04a314ce9539">
-                                        <cybox:Object id=":Address-8ce49cb3-e458-4568-b560-04a314ce9539">
+                                    <indicator:Observable id="citizenlab:observable-8ce49cb3-e458-4568-b560-04a314ce9539">
+                                        <cybox:Object id="citizenlab:Address-8ce49cb3-e458-4568-b560-04a314ce9539">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">192.253.251.118</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:13:20+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -620,21 +620,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-53477c01-59ad-47be-b808-4c6b518523fc" timestamp="2016-11-10T16:08:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-53477c01-59ad-47be-b808-4c6b518523fc" timestamp="2016-11-10T16:08:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 109.169.77.230 (MISP Attribute #511)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 109.169.77.230 (MISP Attribute #511)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-53477c01-59ad-47be-b808-4c6b518523fc">
-                                        <cybox:Object id=":Address-53477c01-59ad-47be-b808-4c6b518523fc">
+                                    <indicator:Observable id="citizenlab:observable-53477c01-59ad-47be-b808-4c6b518523fc">
+                                        <cybox:Object id="citizenlab:Address-53477c01-59ad-47be-b808-4c6b518523fc">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">109.169.77.230</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:08:11+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -644,21 +644,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-fc6d0f74-9e43-44a7-b7b8-0ca5c7c487e6" timestamp="2016-11-10T16:12:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-fc6d0f74-9e43-44a7-b7b8-0ca5c7c487e6" timestamp="2016-11-10T16:12:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://filegoogle.firewall-gateway.com/servicelogin (MISP Attribute #520)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://filegoogle.firewall-gateway.com/servicelogin (MISP Attribute #520)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-fc6d0f74-9e43-44a7-b7b8-0ca5c7c487e6">
-                                        <cybox:Object id=":URI-fc6d0f74-9e43-44a7-b7b8-0ca5c7c487e6">
+                                    <indicator:Observable id="citizenlab:observable-fc6d0f74-9e43-44a7-b7b8-0ca5c7c487e6">
+                                        <cybox:Object id="citizenlab:URI-fc6d0f74-9e43-44a7-b7b8-0ca5c7c487e6">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://filegoogle.firewall-gateway.com/servicelogin</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:12:23+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -668,21 +668,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-11bb35af-5ad7-4a10-844c-fb4482603b0b" timestamp="2016-11-10T16:12:41+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-11bb35af-5ad7-4a10-844c-fb4482603b0b" timestamp="2016-11-10T16:12:41+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://accountgoogle.firewall-gateway.com/serviclogin (MISP Attribute #521)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://accountgoogle.firewall-gateway.com/serviclogin (MISP Attribute #521)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-11bb35af-5ad7-4a10-844c-fb4482603b0b">
-                                        <cybox:Object id=":URI-11bb35af-5ad7-4a10-844c-fb4482603b0b">
+                                    <indicator:Observable id="citizenlab:observable-11bb35af-5ad7-4a10-844c-fb4482603b0b">
+                                        <cybox:Object id="citizenlab:URI-11bb35af-5ad7-4a10-844c-fb4482603b0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://accountgoogle.firewall-gateway.com/serviclogin</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:12:41+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -692,21 +692,21 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-cda51492-e33b-4521-be3b-35ec4b8bc9b4" timestamp="2016-11-10T16:12:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-cda51492-e33b-4521-be3b-35ec4b8bc9b4" timestamp="2016-11-10T16:12:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://accountgoogle.firewall-gateway.com/servicclogin (MISP Attribute #522)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://accountgoogle.firewall-gateway.com/servicclogin (MISP Attribute #522)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-cda51492-e33b-4521-be3b-35ec4b8bc9b4">
-                                        <cybox:Object id=":URI-cda51492-e33b-4521-be3b-35ec4b8bc9b4">
+                                    <indicator:Observable id="citizenlab:observable-cda51492-e33b-4521-be3b-35ec4b8bc9b4">
+                                        <cybox:Object id="citizenlab:URI-cda51492-e33b-4521-be3b-35ec4b8bc9b4">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://accountgoogle.firewall-gateway.com/servicclogin</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:12:15+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -716,13 +716,13 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-633179a0-3d6e-4ca5-9b89-02d8522ef275" timestamp="2016-11-10T16:10:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-633179a0-3d6e-4ca5-9b89-02d8522ef275" timestamp="2016-11-10T16:10:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: Reappraisal_of_India_Tibet_Policy.doc (MISP Attribute #530)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Payload delivery: Reappraisal_of_India_Tibet_Policy.doc (MISP Attribute #530)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:10:34+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -732,14 +732,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-99702482-486a-4b63-8fa9-f094835827b2" timestamp="2016-11-10T16:06:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-99702482-486a-4b63-8fa9-f094835827b2" timestamp="2016-11-10T16:06:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 5c030802ad411fea059cc9cc4c118125 (MISP Attribute #531)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 5c030802ad411fea059cc9cc4c118125 (MISP Attribute #531)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-99702482-486a-4b63-8fa9-f094835827b2">
-                                        <cybox:Object id=":File-99702482-486a-4b63-8fa9-f094835827b2">
+                                    <indicator:Observable id="citizenlab:observable-99702482-486a-4b63-8fa9-f094835827b2">
+                                        <cybox:Object id="citizenlab:File-99702482-486a-4b63-8fa9-f094835827b2">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -751,7 +751,7 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:06:29+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -761,14 +761,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-a95b5c9c-7ec9-42ff-a12c-075b3255de77" timestamp="2016-11-10T16:05:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-a95b5c9c-7ec9-42ff-a12c-075b3255de77" timestamp="2016-11-10T16:05:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 7735e571d0450e2a31e97e4f8e0f66fa (MISP Attribute #532)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 7735e571d0450e2a31e97e4f8e0f66fa (MISP Attribute #532)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-a95b5c9c-7ec9-42ff-a12c-075b3255de77">
-                                        <cybox:Object id=":File-a95b5c9c-7ec9-42ff-a12c-075b3255de77">
+                                    <indicator:Observable id="citizenlab:observable-a95b5c9c-7ec9-42ff-a12c-075b3255de77">
+                                        <cybox:Object id="citizenlab:File-a95b5c9c-7ec9-42ff-a12c-075b3255de77">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -780,7 +780,7 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:05:58+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -790,14 +790,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-baf16087-e811-438d-bcdd-9779043dfb06" timestamp="2016-11-10T16:05:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-baf16087-e811-438d-bcdd-9779043dfb06" timestamp="2016-11-10T16:05:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: d2e9412428c3bcf3ec98dba8a78adb7b (MISP Attribute #533)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: d2e9412428c3bcf3ec98dba8a78adb7b (MISP Attribute #533)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-baf16087-e811-438d-bcdd-9779043dfb06">
-                                        <cybox:Object id=":File-baf16087-e811-438d-bcdd-9779043dfb06">
+                                    <indicator:Observable id="citizenlab:observable-baf16087-e811-438d-bcdd-9779043dfb06">
+                                        <cybox:Object id="citizenlab:File-baf16087-e811-438d-bcdd-9779043dfb06">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -809,7 +809,7 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:05:33+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -819,14 +819,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-712c9cc1-2b2b-4636-87d2-12bd313376dc" timestamp="2016-11-10T16:05:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-712c9cc1-2b2b-4636-87d2-12bd313376dc" timestamp="2016-11-10T16:05:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 1bf438b5744db73eea58379a3b9f30e5 (MISP Attribute #534)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 1bf438b5744db73eea58379a3b9f30e5 (MISP Attribute #534)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-712c9cc1-2b2b-4636-87d2-12bd313376dc">
-                                        <cybox:Object id=":File-712c9cc1-2b2b-4636-87d2-12bd313376dc">
+                                    <indicator:Observable id="citizenlab:observable-712c9cc1-2b2b-4636-87d2-12bd313376dc">
+                                        <cybox:Object id="citizenlab:File-712c9cc1-2b2b-4636-87d2-12bd313376dc">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -838,7 +838,7 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:05:20+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -848,14 +848,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-6d15c4fe-2de7-4abc-9593-c9eeae9b928f" timestamp="2016-11-10T16:05:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-6d15c4fe-2de7-4abc-9593-c9eeae9b928f" timestamp="2016-11-10T16:05:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 3b869c8e23d66ad0527882fc79ff7237 (MISP Attribute #535)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 3b869c8e23d66ad0527882fc79ff7237 (MISP Attribute #535)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-6d15c4fe-2de7-4abc-9593-c9eeae9b928f">
-                                        <cybox:Object id=":File-6d15c4fe-2de7-4abc-9593-c9eeae9b928f">
+                                    <indicator:Observable id="citizenlab:observable-6d15c4fe-2de7-4abc-9593-c9eeae9b928f">
+                                        <cybox:Object id="citizenlab:File-6d15c4fe-2de7-4abc-9593-c9eeae9b928f">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -867,7 +867,7 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:05:09+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -877,14 +877,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-23403344-c52e-4c19-9f7b-f5291b451bee" timestamp="2016-11-10T16:04:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-23403344-c52e-4c19-9f7b-f5291b451bee" timestamp="2016-11-10T16:04:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: fef27f432e0ae8218143bc410fda340e (MISP Attribute #536)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: fef27f432e0ae8218143bc410fda340e (MISP Attribute #536)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-23403344-c52e-4c19-9f7b-f5291b451bee">
-                                        <cybox:Object id=":File-23403344-c52e-4c19-9f7b-f5291b451bee">
+                                    <indicator:Observable id="citizenlab:observable-23403344-c52e-4c19-9f7b-f5291b451bee">
+                                        <cybox:Object id="citizenlab:File-23403344-c52e-4c19-9f7b-f5291b451bee">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -896,7 +896,7 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:04:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -906,14 +906,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-dbabd2ee-213d-4b02-951f-a020cfc3582e" timestamp="2016-11-10T16:07:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-dbabd2ee-213d-4b02-951f-a020cfc3582e" timestamp="2016-11-10T16:07:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 8b83fc5d3a6a80281269f9e337fe3fff (MISP Attribute #537)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 8b83fc5d3a6a80281269f9e337fe3fff (MISP Attribute #537)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-dbabd2ee-213d-4b02-951f-a020cfc3582e">
-                                        <cybox:Object id=":File-dbabd2ee-213d-4b02-951f-a020cfc3582e">
+                                    <indicator:Observable id="citizenlab:observable-dbabd2ee-213d-4b02-951f-a020cfc3582e">
+                                        <cybox:Object id="citizenlab:File-dbabd2ee-213d-4b02-951f-a020cfc3582e">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -925,7 +925,7 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T16:07:46+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -937,7 +937,7 @@
                         <incident:Leveraged_TTPs>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-5824e33f-4c08-4b5f-8092-497a8e96ca05" timestamp="2016-11-10T16:14:39+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                         </incident:Leveraged_TTPs>
                         <incident:History>

--- a/201604_UP007_SLServer/stix.xml
+++ b/201604_UP007_SLServer/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,20 +59,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-c2b4b6fc-b3a6-407c-b4dc-da81c5b00eec" version="1.1.1" timestamp="2016-11-10T20:57:45.659431+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-c2b4b6fc-b3a6-407c-b4dc-da81c5b00eec" version="1.1.1" timestamp="2016-11-10T20:57:45.659431+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-581ba774-6db4-441c-b981-49798e96ca05" version="1.1.1" timestamp="2016-11-10T15:54:41+00:00">
+            <stix:Package id="citizenlab:STIXPackage-581ba774-6db4-441c-b981-49798e96ca05" version="1.1.1" timestamp="2016-11-10T15:54:41+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Tracking UP007 and SLServer Espionage Campaigns (MISP Event #2)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:TTPs>
-                    <stix:TTP id=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: UP007 (MISP Attribute #30)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -82,7 +82,7 @@
                             </ttp:Malware>
                         </ttp:Behavior>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: SLServer (MISP Attribute #52)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -94,7 +94,7 @@
                     </stix:TTP>
                 </stix:TTPs>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-581ba774-6db4-441c-b981-49798e96ca05" timestamp="2016-11-10T15:57:11+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-581ba774-6db4-441c-b981-49798e96ca05" timestamp="2016-11-10T15:57:11+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Tracking UP007 and SLServer Espionage Campaigns</incident:Title>
                         <incident:External_ID source="MISP Event">2</incident:External_ID>
                         <incident:Time>
@@ -105,24 +105,24 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba833-5f7c-40f0-b2d4-497a8e96ca05" timestamp="2016-11-03T17:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba833-5f7c-40f0-b2d4-497a8e96ca05" timestamp="2016-11-03T17:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: safetyssl.security-centers.com (MISP Attribute #45)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: safetyssl.security-centers.com (MISP Attribute #45)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba833-5f7c-40f0-b2d4-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-581ba833-5f7c-40f0-b2d4-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba833-5f7c-40f0-b2d4-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581ba833-5f7c-40f0-b2d4-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">safetyssl.security-centers.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:12:19+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -132,24 +132,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba833-2410-4a7c-a67f-497a8e96ca05" timestamp="2016-11-03T17:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba833-2410-4a7c-a67f-497a8e96ca05" timestamp="2016-11-03T17:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: computer.security-centers.com (MISP Attribute #46)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: computer.security-centers.com (MISP Attribute #46)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba833-2410-4a7c-a67f-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-581ba833-2410-4a7c-a67f-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba833-2410-4a7c-a67f-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581ba833-2410-4a7c-a67f-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">computer.security-centers.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:12:19+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -159,24 +159,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba833-6060-4ce6-b102-497a8e96ca05" timestamp="2016-11-03T17:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba833-6060-4ce6-b102-497a8e96ca05" timestamp="2016-11-03T17:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hkemail.f3322.org (MISP Attribute #47)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hkemail.f3322.org (MISP Attribute #47)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba833-6060-4ce6-b102-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-581ba833-6060-4ce6-b102-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba833-6060-4ce6-b102-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581ba833-6060-4ce6-b102-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hkemail.f3322.org</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:12:19+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -186,24 +186,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba833-71b8-4f00-b1f8-497a8e96ca05" timestamp="2016-11-03T17:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba833-71b8-4f00-b1f8-497a8e96ca05" timestamp="2016-11-03T17:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.olinaodi.com (MISP Attribute #48)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.olinaodi.com (MISP Attribute #48)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba833-71b8-4f00-b1f8-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-581ba833-71b8-4f00-b1f8-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba833-71b8-4f00-b1f8-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581ba833-71b8-4f00-b1f8-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.olinaodi.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:12:19+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -213,24 +213,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba833-4eb8-4589-ad6e-497a8e96ca05" timestamp="2016-11-03T17:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba833-4eb8-4589-ad6e-497a8e96ca05" timestamp="2016-11-03T17:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tenday.mysecondarydns.com (MISP Attribute #49)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tenday.mysecondarydns.com (MISP Attribute #49)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba833-4eb8-4589-ad6e-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-581ba833-4eb8-4589-ad6e-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba833-4eb8-4589-ad6e-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-581ba833-4eb8-4589-ad6e-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tenday.mysecondarydns.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:12:19+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -240,24 +240,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba849-3730-4528-a94e-49798e96ca05" timestamp="2016-11-10T15:54:41+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba849-3730-4528-a94e-49798e96ca05" timestamp="2016-11-10T15:54:41+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 59.188.12.123 (MISP Attribute #50)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 59.188.12.123 (MISP Attribute #50)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba849-3730-4528-a94e-49798e96ca05">
-                                        <cybox:Object id=":Address-581ba849-3730-4528-a94e-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba849-3730-4528-a94e-49798e96ca05">
+                                        <cybox:Object id="citizenlab:Address-581ba849-3730-4528-a94e-49798e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">59.188.12.123</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T15:54:41+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -267,24 +267,24 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba849-a850-4cbf-a6b2-49798e96ca05" timestamp="2016-11-10T15:54:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba849-a850-4cbf-a6b2-49798e96ca05" timestamp="2016-11-10T15:54:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 210.61.12.153 (MISP Attribute #51)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 210.61.12.153 (MISP Attribute #51)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba849-a850-4cbf-a6b2-49798e96ca05">
-                                        <cybox:Object id=":Address-581ba849-a850-4cbf-a6b2-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba849-a850-4cbf-a6b2-49798e96ca05">
+                                        <cybox:Object id="citizenlab:Address-581ba849-a850-4cbf-a6b2-49798e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">210.61.12.153</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T15:54:32+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -294,14 +294,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-d2a4-4dcb-b1b3-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-d2a4-4dcb-b1b3-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: d579d7a42ff140952da57264614c37bc (MISP Attribute #31)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: d579d7a42ff140952da57264614c37bc (MISP Attribute #31)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-d2a4-4dcb-b1b3-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-d2a4-4dcb-b1b3-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-d2a4-4dcb-b1b3-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-d2a4-4dcb-b1b3-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -313,10 +313,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -326,14 +326,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-1d18-4479-997f-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-1d18-4479-997f-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: d8becbd6f188e3fb2c4d23a2d36d137b (MISP Attribute #32)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: d8becbd6f188e3fb2c4d23a2d36d137b (MISP Attribute #32)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-1d18-4479-997f-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-1d18-4479-997f-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-1d18-4479-997f-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-1d18-4479-997f-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -345,10 +345,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -358,14 +358,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-2ce0-4046-9865-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-2ce0-4046-9865-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 09ddd70517cb48a46d9f93644b29c72f (MISP Attribute #33)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 09ddd70517cb48a46d9f93644b29c72f (MISP Attribute #33)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-2ce0-4046-9865-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-2ce0-4046-9865-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-2ce0-4046-9865-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-2ce0-4046-9865-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -377,10 +377,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -390,14 +390,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-91f4-4e92-9164-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-91f4-4e92-9164-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: f70b295c6a5121b918682310ce0c2165 (MISP Attribute #34)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: f70b295c6a5121b918682310ce0c2165 (MISP Attribute #34)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-91f4-4e92-9164-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-91f4-4e92-9164-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-91f4-4e92-9164-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-91f4-4e92-9164-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -409,10 +409,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -422,14 +422,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-cf4c-42ae-b661-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-cf4c-42ae-b661-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: f80edbb0fcfe7cec17592f61a06e4df2 (MISP Attribute #35)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: f80edbb0fcfe7cec17592f61a06e4df2 (MISP Attribute #35)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-cf4c-42ae-b661-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-cf4c-42ae-b661-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-cf4c-42ae-b661-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-cf4c-42ae-b661-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -441,10 +441,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -454,14 +454,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-8d0c-4716-90dc-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-8d0c-4716-90dc-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: d8ede9e6c3a1a30398b0b98130ee3b38 (MISP Attribute #36)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: d8ede9e6c3a1a30398b0b98130ee3b38 (MISP Attribute #36)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-8d0c-4716-90dc-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-8d0c-4716-90dc-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-8d0c-4716-90dc-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-8d0c-4716-90dc-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -473,10 +473,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -486,14 +486,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-5a08-4dff-a2d8-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-5a08-4dff-a2d8-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: ce8ec932be16b69ffa06626b3b423395 (MISP Attribute #37)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: ce8ec932be16b69ffa06626b3b423395 (MISP Attribute #37)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-5a08-4dff-a2d8-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-5a08-4dff-a2d8-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-5a08-4dff-a2d8-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-5a08-4dff-a2d8-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -505,10 +505,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -518,14 +518,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-0954-44a7-afce-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-0954-44a7-afce-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 6a541de84074a2c4ff99eb43252d9030 (MISP Attribute #38)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 6a541de84074a2c4ff99eb43252d9030 (MISP Attribute #38)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-0954-44a7-afce-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-0954-44a7-afce-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-0954-44a7-afce-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-0954-44a7-afce-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -537,10 +537,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -550,14 +550,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-c96c-4e46-bd92-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-c96c-4e46-bd92-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: e0eb981ad6be0bd16246d5d442028687 (MISP Attribute #39)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: e0eb981ad6be0bd16246d5d442028687 (MISP Attribute #39)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-c96c-4e46-bd92-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-c96c-4e46-bd92-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-c96c-4e46-bd92-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-c96c-4e46-bd92-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -569,10 +569,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -582,14 +582,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-ad74-4d70-bc5a-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-ad74-4d70-bc5a-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 639c7239f40d95f677a99abb059e8338 (MISP Attribute #40)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 639c7239f40d95f677a99abb059e8338 (MISP Attribute #40)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-ad74-4d70-bc5a-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-ad74-4d70-bc5a-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-ad74-4d70-bc5a-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-ad74-4d70-bc5a-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -601,10 +601,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -614,14 +614,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-9adc-4354-9b03-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-9adc-4354-9b03-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: d07b2738840ce3419df651d3a0a3a246 (MISP Attribute #41)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: d07b2738840ce3419df651d3a0a3a246 (MISP Attribute #41)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-9adc-4354-9b03-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-9adc-4354-9b03-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-9adc-4354-9b03-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-9adc-4354-9b03-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -633,10 +633,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -646,14 +646,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-8010-4c55-a7c9-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-8010-4c55-a7c9-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 397021af7c0284c28db65297a6711235 (MISP Attribute #42)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 397021af7c0284c28db65297a6711235 (MISP Attribute #42)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-8010-4c55-a7c9-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-8010-4c55-a7c9-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-8010-4c55-a7c9-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-8010-4c55-a7c9-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -665,10 +665,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -678,14 +678,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-4924-41de-9ce9-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-4924-41de-9ce9-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: dc195d814ec16fe91690b7e949e696f6 (MISP Attribute #43)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: dc195d814ec16fe91690b7e949e696f6 (MISP Attribute #43)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-4924-41de-9ce9-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-4924-41de-9ce9-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-4924-41de-9ce9-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-4924-41de-9ce9-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -697,10 +697,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -710,14 +710,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581ba817-1620-457c-ae64-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581ba817-1620-457c-ae64-49798e96ca05" timestamp="2016-11-03T17:11:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: cfcd2a90e87156e1a811f9c7b0051002 (MISP Attribute #44)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: cfcd2a90e87156e1a811f9c7b0051002 (MISP Attribute #44)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-581ba817-1620-457c-ae64-49798e96ca05">
-                                        <cybox:Object id=":File-581ba817-1620-457c-ae64-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-581ba817-1620-457c-ae64-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-581ba817-1620-457c-ae64-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -729,10 +729,10 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-03T17:11:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -744,11 +744,11 @@
                         <incident:Leveraged_TTPs>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-581ba7b8-59f4-402f-95d9-497a8e96ca05" timestamp="2016-11-03T17:10:16+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-581ba88c-c144-41d1-ad67-497a8e96ca05" timestamp="2016-11-03T17:13:48+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                         </incident:Leveraged_TTPs>
                         <incident:History>

--- a/201605_Stealth_Falcon/stix.xml
+++ b/201605_Stealth_Falcon/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,20 +59,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-7e377b3f-5c5a-403a-9575-64593685b0a8" version="1.1.1" timestamp="2016-11-08T21:57:05.578284+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-7e377b3f-5c5a-403a-9575-64593685b0a8" version="1.1.1" timestamp="2016-11-08T21:57:05.578284+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-581c05a7-1888-402a-b435-49798e96ca05" version="1.1.1" timestamp="2016-11-08T16:56:04+00:00">
+            <stix:Package id="citizenlab:STIXPackage-581c05a7-1888-402a-b435-49798e96ca05" version="1.1.1" timestamp="2016-11-08T16:56:04+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Keep Calm and (Don’t) Enable Macros: A New Threat Actor Targets UAE Dissidents (MISP Event #8)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-581c05a7-1888-402a-b435-49798e96ca05" timestamp="2016-11-08T16:56:19+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-581c05a7-1888-402a-b435-49798e96ca05" timestamp="2016-11-08T16:56:19+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Keep Calm and (Don’t) Enable Macros: A New Threat Actor Targets UAE Dissidents</incident:Title>
                         <incident:External_ID source="MISP Event">8</incident:External_ID>
                         <incident:Time>
@@ -83,7 +83,7 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58224765-51f8-4d28-9040-49798e96ca05" timestamp="2016-11-08T16:45:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58224765-51f8-4d28-9040-49798e96ca05" timestamp="2016-11-08T16:45:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: Stealth Falcon (MISP Attribute #1354)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: Stealth Falcon (MISP Attribute #1354)</indicator:Description>
@@ -96,14 +96,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5822492e-087c-4fa8-afe1-49798e96ca05" timestamp="2016-11-08T16:52:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5822492e-087c-4fa8-afe1-49798e96ca05" timestamp="2016-11-08T16:52:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: simpleadbanners.com (MISP Attribute #1358)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: simpleadbanners.com (MISP Attribute #1358)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5822492e-087c-4fa8-afe1-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5822492e-087c-4fa8-afe1-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5822492e-087c-4fa8-afe1-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5822492e-087c-4fa8-afe1-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">simpleadbanners.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -117,14 +117,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5822492e-1d40-4098-a87b-49798e96ca05" timestamp="2016-11-08T16:52:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5822492e-1d40-4098-a87b-49798e96ca05" timestamp="2016-11-08T16:52:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: clickstatistic.com (MISP Attribute #1359)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: clickstatistic.com (MISP Attribute #1359)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5822492e-1d40-4098-a87b-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5822492e-1d40-4098-a87b-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5822492e-1d40-4098-a87b-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5822492e-1d40-4098-a87b-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">clickstatistic.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -138,14 +138,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5822492e-7490-4c3f-9a10-49798e96ca05" timestamp="2016-11-08T16:52:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5822492e-7490-4c3f-9a10-49798e96ca05" timestamp="2016-11-08T16:52:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: bestairlinepricetags.com (MISP Attribute #1360)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: bestairlinepricetags.com (MISP Attribute #1360)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5822492e-7490-4c3f-9a10-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5822492e-7490-4c3f-9a10-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5822492e-7490-4c3f-9a10-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5822492e-7490-4c3f-9a10-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bestairlinepricetags.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -159,14 +159,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5822492e-d888-418e-906d-49798e96ca05" timestamp="2016-11-08T16:52:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5822492e-d888-418e-906d-49798e96ca05" timestamp="2016-11-08T16:52:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fasttravelclearance.com (MISP Attribute #1361)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fasttravelclearance.com (MISP Attribute #1361)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5822492e-d888-418e-906d-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5822492e-d888-418e-906d-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5822492e-d888-418e-906d-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5822492e-d888-418e-906d-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fasttravelclearance.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -180,14 +180,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5822494d-792c-4d8c-9be0-49798e96ca05" timestamp="2016-11-08T16:53:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5822494d-792c-4d8c-9be0-49798e96ca05" timestamp="2016-11-08T16:53:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: airlineadverts.com (MISP Attribute #1362)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: airlineadverts.com (MISP Attribute #1362)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5822494d-792c-4d8c-9be0-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5822494d-792c-4d8c-9be0-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5822494d-792c-4d8c-9be0-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5822494d-792c-4d8c-9be0-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">airlineadverts.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -201,14 +201,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5822494d-7ab0-42bd-bd9d-49798e96ca05" timestamp="2016-11-08T16:53:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5822494d-7ab0-42bd-bd9d-49798e96ca05" timestamp="2016-11-08T16:53:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ministrynewschannel.com (MISP Attribute #1363)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ministrynewschannel.com (MISP Attribute #1363)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5822494d-7ab0-42bd-bd9d-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5822494d-7ab0-42bd-bd9d-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5822494d-7ab0-42bd-bd9d-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5822494d-7ab0-42bd-bd9d-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ministrynewschannel.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -222,14 +222,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5822494d-bf14-4b41-803a-49798e96ca05" timestamp="2016-11-08T16:53:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5822494d-bf14-4b41-803a-49798e96ca05" timestamp="2016-11-08T16:53:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ministrynewsinfo.com (MISP Attribute #1364)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ministrynewsinfo.com (MISP Attribute #1364)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5822494d-bf14-4b41-803a-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5822494d-bf14-4b41-803a-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5822494d-bf14-4b41-803a-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5822494d-bf14-4b41-803a-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ministrynewsinfo.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -243,14 +243,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-3813bc78-21d9-40a2-b76e-61016eb71ccb" timestamp="2016-11-08T16:48:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-3813bc78-21d9-40a2-b76e-61016eb71ccb" timestamp="2016-11-08T16:48:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: adhostingcache.com (MISP Attribute #425)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: adhostingcache.com (MISP Attribute #425)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-3813bc78-21d9-40a2-b76e-61016eb71ccb">
-                                        <cybox:Object id=":DomainName-3813bc78-21d9-40a2-b76e-61016eb71ccb">
+                                    <indicator:Observable id="citizenlab:observable-3813bc78-21d9-40a2-b76e-61016eb71ccb">
+                                        <cybox:Object id="citizenlab:DomainName-3813bc78-21d9-40a2-b76e-61016eb71ccb">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">adhostingcache.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -264,14 +264,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-d9a62cda-db4c-4d70-858c-6bbaaa041e63" timestamp="2016-11-08T16:49:00+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-d9a62cda-db4c-4d70-858c-6bbaaa041e63" timestamp="2016-11-08T16:49:00+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: adhostingcaches.com (MISP Attribute #426)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: adhostingcaches.com (MISP Attribute #426)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-d9a62cda-db4c-4d70-858c-6bbaaa041e63">
-                                        <cybox:Object id=":DomainName-d9a62cda-db4c-4d70-858c-6bbaaa041e63">
+                                    <indicator:Observable id="citizenlab:observable-d9a62cda-db4c-4d70-858c-6bbaaa041e63">
+                                        <cybox:Object id="citizenlab:DomainName-d9a62cda-db4c-4d70-858c-6bbaaa041e63">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">adhostingcaches.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -285,14 +285,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-35aa025c-2f62-4f9d-9fb7-391542226a7a" timestamp="2016-11-08T16:54:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-35aa025c-2f62-4f9d-9fb7-391542226a7a" timestamp="2016-11-08T16:54:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: optimizedimghosting.com (MISP Attribute #427)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: optimizedimghosting.com (MISP Attribute #427)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-35aa025c-2f62-4f9d-9fb7-391542226a7a">
-                                        <cybox:Object id=":DomainName-35aa025c-2f62-4f9d-9fb7-391542226a7a">
+                                    <indicator:Observable id="citizenlab:observable-35aa025c-2f62-4f9d-9fb7-391542226a7a">
+                                        <cybox:Object id="citizenlab:DomainName-35aa025c-2f62-4f9d-9fb7-391542226a7a">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">optimizedimghosting.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -306,14 +306,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-8682a3ad-80da-4732-bf5a-e675e27c56fe" timestamp="2016-11-08T16:54:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-8682a3ad-80da-4732-bf5a-e675e27c56fe" timestamp="2016-11-08T16:54:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: edgecacheimagehosting.com (MISP Attribute #428)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: edgecacheimagehosting.com (MISP Attribute #428)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-8682a3ad-80da-4732-bf5a-e675e27c56fe">
-                                        <cybox:Object id=":DomainName-8682a3ad-80da-4732-bf5a-e675e27c56fe">
+                                    <indicator:Observable id="citizenlab:observable-8682a3ad-80da-4732-bf5a-e675e27c56fe">
+                                        <cybox:Object id="citizenlab:DomainName-8682a3ad-80da-4732-bf5a-e675e27c56fe">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">edgecacheimagehosting.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -327,14 +327,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-8010c934-027b-40c5-ba1e-3efca8e52d5a" timestamp="2016-11-08T16:49:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-8010c934-027b-40c5-ba1e-3efca8e52d5a" timestamp="2016-11-08T16:49:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: incapsulawebcache.com (MISP Attribute #429)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: incapsulawebcache.com (MISP Attribute #429)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-8010c934-027b-40c5-ba1e-3efca8e52d5a">
-                                        <cybox:Object id=":DomainName-8010c934-027b-40c5-ba1e-3efca8e52d5a">
+                                    <indicator:Observable id="citizenlab:observable-8010c934-027b-40c5-ba1e-3efca8e52d5a">
+                                        <cybox:Object id="citizenlab:DomainName-8010c934-027b-40c5-ba1e-3efca8e52d5a">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">incapsulawebcache.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -348,14 +348,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-45dbee97-3aa0-487d-bd73-a3c10a511403" timestamp="2016-11-08T16:48:42+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-45dbee97-3aa0-487d-bd73-a3c10a511403" timestamp="2016-11-08T16:48:42+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 95.215.44.37 (MISP Attribute #430)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 95.215.44.37 (MISP Attribute #430)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-45dbee97-3aa0-487d-bd73-a3c10a511403">
-                                        <cybox:Object id=":Address-45dbee97-3aa0-487d-bd73-a3c10a511403">
+                                    <indicator:Observable id="citizenlab:observable-45dbee97-3aa0-487d-bd73-a3c10a511403">
+                                        <cybox:Object id="citizenlab:Address-45dbee97-3aa0-487d-bd73-a3c10a511403">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">95.215.44.37</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -369,14 +369,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-decfcbf1-1331-4624-88b7-a88c94637dd0" timestamp="2016-11-08T16:55:41+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-decfcbf1-1331-4624-88b7-a88c94637dd0" timestamp="2016-11-08T16:55:41+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://adhostingcache.com/ehhe/eh4g4/adcache.txt (MISP Attribute #432)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://adhostingcache.com/ehhe/eh4g4/adcache.txt (MISP Attribute #432)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-decfcbf1-1331-4624-88b7-a88c94637dd0">
-                                        <cybox:Object id=":URI-decfcbf1-1331-4624-88b7-a88c94637dd0">
+                                    <indicator:Observable id="citizenlab:observable-decfcbf1-1331-4624-88b7-a88c94637dd0">
+                                        <cybox:Object id="citizenlab:URI-decfcbf1-1331-4624-88b7-a88c94637dd0">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://adhostingcache.com/ehhe/eh4g4/adcache.txt</URIObj:Value>
                                             </cybox:Properties>
@@ -390,14 +390,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7fd6e683-9615-4f4e-b901-03e7dbb81337" timestamp="2016-11-08T16:49:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7fd6e683-9615-4f4e-b901-03e7dbb81337" timestamp="2016-11-08T16:49:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://incapsulawebcache.com/cache/cache.nfo (MISP Attribute #433)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://incapsulawebcache.com/cache/cache.nfo (MISP Attribute #433)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7fd6e683-9615-4f4e-b901-03e7dbb81337">
-                                        <cybox:Object id=":URI-7fd6e683-9615-4f4e-b901-03e7dbb81337">
+                                    <indicator:Observable id="citizenlab:observable-7fd6e683-9615-4f4e-b901-03e7dbb81337">
+                                        <cybox:Object id="citizenlab:URI-7fd6e683-9615-4f4e-b901-03e7dbb81337">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://incapsulawebcache.com/cache/cache.nfo</URIObj:Value>
                                             </cybox:Properties>
@@ -411,14 +411,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-e8f3b924-1221-4d08-8fef-f689529a7b6d" timestamp="2016-11-08T16:49:42+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-e8f3b924-1221-4d08-8fef-f689529a7b6d" timestamp="2016-11-08T16:49:42+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://aax.me/redirect.js (MISP Attribute #434)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://aax.me/redirect.js (MISP Attribute #434)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-e8f3b924-1221-4d08-8fef-f689529a7b6d">
-                                        <cybox:Object id=":URI-e8f3b924-1221-4d08-8fef-f689529a7b6d">
+                                    <indicator:Observable id="citizenlab:observable-e8f3b924-1221-4d08-8fef-f689529a7b6d">
+                                        <cybox:Object id="citizenlab:URI-e8f3b924-1221-4d08-8fef-f689529a7b6d">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://aax.me/redirect.js</URIObj:Value>
                                             </cybox:Properties>
@@ -432,14 +432,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-537df72e-b2b9-4016-b337-06930c42c455" timestamp="2016-11-08T16:50:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-537df72e-b2b9-4016-b337-06930c42c455" timestamp="2016-11-08T16:50:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://goo.gl/60HAqJ (MISP Attribute #435)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://goo.gl/60HAqJ (MISP Attribute #435)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-537df72e-b2b9-4016-b337-06930c42c455">
-                                        <cybox:Object id=":URI-537df72e-b2b9-4016-b337-06930c42c455">
+                                    <indicator:Observable id="citizenlab:observable-537df72e-b2b9-4016-b337-06930c42c455">
+                                        <cybox:Object id="citizenlab:URI-537df72e-b2b9-4016-b337-06930c42c455">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://goo.gl/60HAqJ</URIObj:Value>
                                             </cybox:Properties>
@@ -453,14 +453,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-007694f1-b73a-40a5-bcf5-dded27746669" timestamp="2016-11-08T16:51:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-007694f1-b73a-40a5-bcf5-dded27746669" timestamp="2016-11-08T16:51:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://aax.me/0b152 (MISP Attribute #436)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://aax.me/0b152 (MISP Attribute #436)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-007694f1-b73a-40a5-bcf5-dded27746669">
-                                        <cybox:Object id=":URI-007694f1-b73a-40a5-bcf5-dded27746669">
+                                    <indicator:Observable id="citizenlab:observable-007694f1-b73a-40a5-bcf5-dded27746669">
+                                        <cybox:Object id="citizenlab:URI-007694f1-b73a-40a5-bcf5-dded27746669">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://aax.me/0b152</URIObj:Value>
                                             </cybox:Properties>
@@ -474,14 +474,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-62fcd7b4-5d95-49bd-a9ff-3c2e1854839b" timestamp="2016-11-08T16:55:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-62fcd7b4-5d95-49bd-a9ff-3c2e1854839b" timestamp="2016-11-08T16:55:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://optimizedimghosting.com/wddf/hrrw/ggrr.txt (MISP Attribute #437)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://optimizedimghosting.com/wddf/hrrw/ggrr.txt (MISP Attribute #437)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-62fcd7b4-5d95-49bd-a9ff-3c2e1854839b">
-                                        <cybox:Object id=":URI-62fcd7b4-5d95-49bd-a9ff-3c2e1854839b">
+                                    <indicator:Observable id="citizenlab:observable-62fcd7b4-5d95-49bd-a9ff-3c2e1854839b">
+                                        <cybox:Object id="citizenlab:URI-62fcd7b4-5d95-49bd-a9ff-3c2e1854839b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://optimizedimghosting.com/wddf/hrrw/ggrr.txt</URIObj:Value>
                                             </cybox:Properties>
@@ -495,14 +495,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-f0215c0c-b708-43d8-873e-80a3e8e54cfa" timestamp="2016-11-08T16:56:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-f0215c0c-b708-43d8-873e-80a3e8e54cfa" timestamp="2016-11-08T16:56:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://edgecacheimagehosting.com/images/image.nfo (MISP Attribute #438)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://edgecacheimagehosting.com/images/image.nfo (MISP Attribute #438)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-f0215c0c-b708-43d8-873e-80a3e8e54cfa">
-                                        <cybox:Object id=":URI-f0215c0c-b708-43d8-873e-80a3e8e54cfa">
+                                    <indicator:Observable id="citizenlab:observable-f0215c0c-b708-43d8-873e-80a3e8e54cfa">
+                                        <cybox:Object id="citizenlab:URI-f0215c0c-b708-43d8-873e-80a3e8e54cfa">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://edgecacheimagehosting.com/images/image.nfo</URIObj:Value>
                                             </cybox:Properties>
@@ -516,14 +516,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582247a8-11b4-4da0-9ca1-69fe8e96ca05" timestamp="2016-11-08T16:46:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582247a8-11b4-4da0-9ca1-69fe8e96ca05" timestamp="2016-11-08T16:46:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: aax.me (MISP Attribute #1355)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: aax.me (MISP Attribute #1355)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582247a8-11b4-4da0-9ca1-69fe8e96ca05">
-                                        <cybox:Object id=":DomainName-582247a8-11b4-4da0-9ca1-69fe8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582247a8-11b4-4da0-9ca1-69fe8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582247a8-11b4-4da0-9ca1-69fe8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">aax.me</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -537,14 +537,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-bc8e2ca7-cd3c-4205-9028-b8b106f12389" timestamp="2016-11-08T16:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-bc8e2ca7-cd3c-4205-9028-b8b106f12389" timestamp="2016-11-08T16:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: the_right_to_fight@openmailbox.org (MISP Attribute #439)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: the_right_to_fight@openmailbox.org (MISP Attribute #439)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-bc8e2ca7-cd3c-4205-9028-b8b106f12389">
-                                        <cybox:Object id=":EmailMessage-bc8e2ca7-cd3c-4205-9028-b8b106f12389">
+                                    <indicator:Observable id="citizenlab:observable-bc8e2ca7-cd3c-4205-9028-b8b106f12389">
+                                        <cybox:Object id="citizenlab:EmailMessage-bc8e2ca7-cd3c-4205-9028-b8b106f12389">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -562,14 +562,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-280056b8-69aa-432c-9826-6d5b820eb44e" timestamp="2016-11-08T16:50:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-280056b8-69aa-432c-9826-6d5b820eb44e" timestamp="2016-11-08T16:50:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: andrew.dwight389@outlook.com (MISP Attribute #440)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: andrew.dwight389@outlook.com (MISP Attribute #440)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-280056b8-69aa-432c-9826-6d5b820eb44e">
-                                        <cybox:Object id=":EmailMessage-280056b8-69aa-432c-9826-6d5b820eb44e">
+                                    <indicator:Observable id="citizenlab:observable-280056b8-69aa-432c-9826-6d5b820eb44e">
+                                        <cybox:Object id="citizenlab:EmailMessage-280056b8-69aa-432c-9826-6d5b820eb44e">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -587,14 +587,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-f4f40c31-dd17-4dc6-baa3-6beb35c04c00" timestamp="2016-11-08T16:47:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-f4f40c31-dd17-4dc6-baa3-6beb35c04c00" timestamp="2016-11-08T16:47:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 80e8ef78b9e28015cde4205aaa65da97 (MISP Attribute #441)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 80e8ef78b9e28015cde4205aaa65da97 (MISP Attribute #441)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-f4f40c31-dd17-4dc6-baa3-6beb35c04c00">
-                                        <cybox:Object id=":File-f4f40c31-dd17-4dc6-baa3-6beb35c04c00">
+                                    <indicator:Observable id="citizenlab:observable-f4f40c31-dd17-4dc6-baa3-6beb35c04c00">
+                                        <cybox:Object id="citizenlab:File-f4f40c31-dd17-4dc6-baa3-6beb35c04c00">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -613,14 +613,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-9ca61973-d717-496a-a158-82d9b2e37965" timestamp="2016-11-08T16:53:31+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-9ca61973-d717-496a-a158-82d9b2e37965" timestamp="2016-11-08T16:53:31+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 87e1df6f36b96b56186444e37e2a1ef5 (MISP Attribute #442)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 87e1df6f36b96b56186444e37e2a1ef5 (MISP Attribute #442)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-9ca61973-d717-496a-a158-82d9b2e37965">
-                                        <cybox:Object id=":File-9ca61973-d717-496a-a158-82d9b2e37965">
+                                    <indicator:Observable id="citizenlab:observable-9ca61973-d717-496a-a158-82d9b2e37965">
+                                        <cybox:Object id="citizenlab:File-9ca61973-d717-496a-a158-82d9b2e37965">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -639,14 +639,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-cd191e4e-a5a1-4009-93b7-92cc6a3d6984" timestamp="2016-11-08T16:47:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-cd191e4e-a5a1-4009-93b7-92cc6a3d6984" timestamp="2016-11-08T16:47:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: f25466e4820404c817eaf75818b7177891735886 (MISP Attribute #443)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: f25466e4820404c817eaf75818b7177891735886 (MISP Attribute #443)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-cd191e4e-a5a1-4009-93b7-92cc6a3d6984">
-                                        <cybox:Object id=":File-cd191e4e-a5a1-4009-93b7-92cc6a3d6984">
+                                    <indicator:Observable id="citizenlab:observable-cd191e4e-a5a1-4009-93b7-92cc6a3d6984">
+                                        <cybox:Object id="citizenlab:File-cd191e4e-a5a1-4009-93b7-92cc6a3d6984">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -665,14 +665,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-41c48554-6911-48eb-88a0-411dc4bd9047" timestamp="2016-11-08T16:53:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-41c48554-6911-48eb-88a0-411dc4bd9047" timestamp="2016-11-08T16:53:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 1c3757006f972ca957d925accf8bbb3023550d1b (MISP Attribute #444)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 1c3757006f972ca957d925accf8bbb3023550d1b (MISP Attribute #444)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-41c48554-6911-48eb-88a0-411dc4bd9047">
-                                        <cybox:Object id=":File-41c48554-6911-48eb-88a0-411dc4bd9047">
+                                    <indicator:Observable id="citizenlab:observable-41c48554-6911-48eb-88a0-411dc4bd9047">
+                                        <cybox:Object id="citizenlab:File-41c48554-6911-48eb-88a0-411dc4bd9047">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -691,14 +691,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-70881ae4-3da1-409e-8bd3-7f508092a2c9" timestamp="2016-11-08T16:48:02+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-70881ae4-3da1-409e-8bd3-7f508092a2c9" timestamp="2016-11-08T16:48:02+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 5a372b45285fe6f3df3ba277ee2de55d4a30fc8ef05de729cf464103632db40f (MISP Attribute #445)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 5a372b45285fe6f3df3ba277ee2de55d4a30fc8ef05de729cf464103632db40f (MISP Attribute #445)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-70881ae4-3da1-409e-8bd3-7f508092a2c9">
-                                        <cybox:Object id=":File-70881ae4-3da1-409e-8bd3-7f508092a2c9">
+                                    <indicator:Observable id="citizenlab:observable-70881ae4-3da1-409e-8bd3-7f508092a2c9">
+                                        <cybox:Object id="citizenlab:File-70881ae4-3da1-409e-8bd3-7f508092a2c9">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -717,14 +717,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-19e97c58-4992-4f0b-8f49-6a6378a289eb" timestamp="2016-11-08T16:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-19e97c58-4992-4f0b-8f49-6a6378a289eb" timestamp="2016-11-08T16:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 4320204d577ef8b939115d16110e97ff04cb4f7d1e77ba5ce011d43f74abc7be (MISP Attribute #446)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 4320204d577ef8b939115d16110e97ff04cb4f7d1e77ba5ce011d43f74abc7be (MISP Attribute #446)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-19e97c58-4992-4f0b-8f49-6a6378a289eb">
-                                        <cybox:Object id=":File-19e97c58-4992-4f0b-8f49-6a6378a289eb">
+                                    <indicator:Observable id="citizenlab:observable-19e97c58-4992-4f0b-8f49-6a6378a289eb">
+                                        <cybox:Object id="citizenlab:File-19e97c58-4992-4f0b-8f49-6a6378a289eb">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -743,14 +743,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582247d0-d7a0-49c3-a6ae-69fe8e96ca05" timestamp="2016-11-08T16:46:56+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582247d0-d7a0-49c3-a6ae-69fe8e96ca05" timestamp="2016-11-08T16:46:56+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://aax.me/a6faa (MISP Attribute #1356)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://aax.me/a6faa (MISP Attribute #1356)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582247d0-d7a0-49c3-a6ae-69fe8e96ca05">
-                                        <cybox:Object id=":URI-582247d0-d7a0-49c3-a6ae-69fe8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582247d0-d7a0-49c3-a6ae-69fe8e96ca05">
+                                        <cybox:Object id="citizenlab:URI-582247d0-d7a0-49c3-a6ae-69fe8e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://aax.me/a6faa</URIObj:Value>
                                             </cybox:Properties>
@@ -764,14 +764,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582247f6-eeec-47b0-b6d8-69fe8e96ca05" timestamp="2016-11-08T16:47:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582247f6-eeec-47b0-b6d8-69fe8e96ca05" timestamp="2016-11-08T16:47:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://cloud.openmailbox.org/index.php/s/ujDNWMmg8pdG3AL/authenticate (MISP Attribute #1357)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://cloud.openmailbox.org/index.php/s/ujDNWMmg8pdG3AL/authenticate (MISP Attribute #1357)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582247f6-eeec-47b0-b6d8-69fe8e96ca05">
-                                        <cybox:Object id=":URI-582247f6-eeec-47b0-b6d8-69fe8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582247f6-eeec-47b0-b6d8-69fe8e96ca05">
+                                        <cybox:Object id="citizenlab:URI-582247f6-eeec-47b0-b6d8-69fe8e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://cloud.openmailbox.org/index.php/s/ujDNWMmg8pdG3AL/authenticate</URIObj:Value>
                                             </cybox:Properties>
@@ -785,14 +785,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-6c1856f6-0068-4c83-8aba-9fd4bb4277a1" timestamp="2016-11-08T16:45:55+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-6c1856f6-0068-4c83-8aba-9fd4bb4277a1" timestamp="2016-11-08T16:45:55+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://aax.me/d0dde (MISP Attribute #447)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://aax.me/d0dde (MISP Attribute #447)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-6c1856f6-0068-4c83-8aba-9fd4bb4277a1">
-                                        <cybox:Object id=":URI-6c1856f6-0068-4c83-8aba-9fd4bb4277a1">
+                                    <indicator:Observable id="citizenlab:observable-6c1856f6-0068-4c83-8aba-9fd4bb4277a1">
+                                        <cybox:Object id="citizenlab:URI-6c1856f6-0068-4c83-8aba-9fd4bb4277a1">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://aax.me/d0dde</URIObj:Value>
                                             </cybox:Properties>

--- a/201608_Group5/stix.xml
+++ b/201608_Group5/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,24 +59,24 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-2e541d2a-b044-433a-b2fd-9be56b16a6ea" version="1.1.1" timestamp="2016-11-08T21:13:59.714482+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-2e541d2a-b044-433a-b2fd-9be56b16a6ea" version="1.1.1" timestamp="2016-11-08T21:13:59.714482+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-581c0e7b-7ec8-40ad-b52a-49798e96ca05" version="1.1.1" timestamp="2016-11-08T16:13:14+00:00">
+            <stix:Package id="citizenlab:STIXPackage-581c0e7b-7ec8-40ad-b52a-49798e96ca05" version="1.1.1" timestamp="2016-11-08T16:13:14+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Group5: Syria and the Iranian Connection (MISP Event #9)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:TTPs>
-                    <stix:TTP id=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload delivery: CVE-2014-4114 (MISP Attribute #1345)</ttp:Title>
                         <ttp:Exploit_Targets>
                             <ttp:Exploit_Target>
-                                <stixCommon:Exploit_Target id=":et-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='et:ExploitTargetType'>
+                                <stixCommon:Exploit_Target id="citizenlab:et-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='et:ExploitTargetType'>
                                     <et:Title>Vulnerability CVE-2014-4114</et:Title>
                                     <et:Vulnerability>
                                         <et:CVE_ID>CVE-2014-4114</et:CVE_ID>
@@ -85,7 +85,7 @@
                             </ttp:Exploit_Target>
                         </ttp:Exploit_Targets>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: njRat (MISP Attribute #1346)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -95,7 +95,7 @@
                             </ttp:Malware>
                         </ttp:Behavior>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: NanoCore RAT (MISP Attribute #1347)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -105,7 +105,7 @@
                             </ttp:Malware>
                         </ttp:Behavior>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: DroidJack (MISP Attribute #1348)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -117,7 +117,7 @@
                     </stix:TTP>
                 </stix:TTPs>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-581c0e7b-7ec8-40ad-b52a-49798e96ca05" timestamp="2016-11-08T16:13:31+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-581c0e7b-7ec8-40ad-b52a-49798e96ca05" timestamp="2016-11-08T16:13:31+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Group5: Syria and the Iranian Connection</incident:Title>
                         <incident:External_ID source="MISP Event">9</incident:External_ID>
                         <incident:Time>
@@ -128,30 +128,30 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58223cbc-ec7c-43f6-a95a-69fe8e96ca05" timestamp="2016-11-08T15:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58223cbc-ec7c-43f6-a95a-69fe8e96ca05" timestamp="2016-11-08T15:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: assadcrimes.info (MISP Attribute #1344)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: assadcrimes.info (MISP Attribute #1344)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58223cbc-ec7c-43f6-a95a-69fe8e96ca05">
-                                        <cybox:Object id=":DomainName-58223cbc-ec7c-43f6-a95a-69fe8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58223cbc-ec7c-43f6-a95a-69fe8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58223cbc-ec7c-43f6-a95a-69fe8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">assadcrimes.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:59:40+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -161,30 +161,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58223f8a-1820-476b-823c-497a8e96ca05" timestamp="2016-11-08T16:11:38+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58223f8a-1820-476b-823c-497a8e96ca05" timestamp="2016-11-08T16:11:38+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 212.7.195.171 (MISP Attribute #1349)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 212.7.195.171 (MISP Attribute #1349)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58223f8a-1820-476b-823c-497a8e96ca05">
-                                        <cybox:Object id=":Address-58223f8a-1820-476b-823c-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58223f8a-1820-476b-823c-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-58223f8a-1820-476b-823c-497a8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">212.7.195.171</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:11:38+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -194,30 +194,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-3f6407bd-cfd7-4bb6-9338-34132bdc3c62" timestamp="2016-11-08T16:06:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-3f6407bd-cfd7-4bb6-9338-34132bdc3c62" timestamp="2016-11-08T16:06:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 88.198.222.163 (MISP Attribute #449)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 88.198.222.163 (MISP Attribute #449)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-3f6407bd-cfd7-4bb6-9338-34132bdc3c62">
-                                        <cybox:Object id=":Address-3f6407bd-cfd7-4bb6-9338-34132bdc3c62">
+                                    <indicator:Observable id="citizenlab:observable-3f6407bd-cfd7-4bb6-9338-34132bdc3c62">
+                                        <cybox:Object id="citizenlab:Address-3f6407bd-cfd7-4bb6-9338-34132bdc3c62">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">88.198.222.163</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:06:52+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -227,14 +227,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58223ba8-5da0-4111-8b1b-69fe8e96ca05" timestamp="2016-11-08T15:55:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58223ba8-5da0-4111-8b1b-69fe8e96ca05" timestamp="2016-11-08T15:55:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: office@assadcrimes.info (MISP Attribute #1343)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: office@assadcrimes.info (MISP Attribute #1343)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58223ba8-5da0-4111-8b1b-69fe8e96ca05">
-                                        <cybox:Object id=":EmailMessage-58223ba8-5da0-4111-8b1b-69fe8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58223ba8-5da0-4111-8b1b-69fe8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-58223ba8-5da0-4111-8b1b-69fe8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -245,16 +245,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:55:04+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -264,14 +264,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-b98003bc-640e-442e-99ec-8ab90190bd4c" timestamp="2016-11-08T16:12:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-b98003bc-640e-442e-99ec-8ab90190bd4c" timestamp="2016-11-08T16:12:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 366908f6c5c4f4329478d60586eca5bc (MISP Attribute #450)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 366908f6c5c4f4329478d60586eca5bc (MISP Attribute #450)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-b98003bc-640e-442e-99ec-8ab90190bd4c">
-                                        <cybox:Object id=":File-b98003bc-640e-442e-99ec-8ab90190bd4c">
+                                    <indicator:Observable id="citizenlab:observable-b98003bc-640e-442e-99ec-8ab90190bd4c">
+                                        <cybox:Object id="citizenlab:File-b98003bc-640e-442e-99ec-8ab90190bd4c">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -283,16 +283,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:12:52+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -302,14 +302,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7aa1122f-33ee-422b-acae-8820e0664fdb" timestamp="2016-11-08T16:08:53+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7aa1122f-33ee-422b-acae-8820e0664fdb" timestamp="2016-11-08T16:08:53+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 7d898530d2e77f15f5badce8d7df215e (MISP Attribute #451)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 7d898530d2e77f15f5badce8d7df215e (MISP Attribute #451)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7aa1122f-33ee-422b-acae-8820e0664fdb">
-                                        <cybox:Object id=":File-7aa1122f-33ee-422b-acae-8820e0664fdb">
+                                    <indicator:Observable id="citizenlab:observable-7aa1122f-33ee-422b-acae-8820e0664fdb">
+                                        <cybox:Object id="citizenlab:File-7aa1122f-33ee-422b-acae-8820e0664fdb">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -321,16 +321,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:08:53+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -340,14 +340,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588e5189-3408-4430-b4de-7f3a04c1107b" timestamp="2016-11-08T16:07:21+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588e5189-3408-4430-b4de-7f3a04c1107b" timestamp="2016-11-08T16:07:21+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: a4f1f4921bb11ff9d22fad89b19b155d (MISP Attribute #452)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: a4f1f4921bb11ff9d22fad89b19b155d (MISP Attribute #452)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588e5189-3408-4430-b4de-7f3a04c1107b">
-                                        <cybox:Object id=":File-588e5189-3408-4430-b4de-7f3a04c1107b">
+                                    <indicator:Observable id="citizenlab:observable-588e5189-3408-4430-b4de-7f3a04c1107b">
+                                        <cybox:Object id="citizenlab:File-588e5189-3408-4430-b4de-7f3a04c1107b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -359,16 +359,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:07:21+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -378,14 +378,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-e900b943-c875-4125-b4a7-f53de2620468" timestamp="2016-11-08T16:09:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-e900b943-c875-4125-b4a7-f53de2620468" timestamp="2016-11-08T16:09:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: dd5bedd915967c5efe00733cf7478cb4 (MISP Attribute #453)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: dd5bedd915967c5efe00733cf7478cb4 (MISP Attribute #453)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-e900b943-c875-4125-b4a7-f53de2620468">
-                                        <cybox:Object id=":File-e900b943-c875-4125-b4a7-f53de2620468">
+                                    <indicator:Observable id="citizenlab:observable-e900b943-c875-4125-b4a7-f53de2620468">
+                                        <cybox:Object id="citizenlab:File-e900b943-c875-4125-b4a7-f53de2620468">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -397,16 +397,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:09:49+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -416,14 +416,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-dc028130-bdaf-462a-acd8-81f8ea0eec51" timestamp="2016-11-08T15:56:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-dc028130-bdaf-462a-acd8-81f8ea0eec51" timestamp="2016-11-08T15:56:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: f1f84ea3229dca0ccacb7381a2f49f99 (MISP Attribute #454)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: f1f84ea3229dca0ccacb7381a2f49f99 (MISP Attribute #454)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-dc028130-bdaf-462a-acd8-81f8ea0eec51">
-                                        <cybox:Object id=":File-dc028130-bdaf-462a-acd8-81f8ea0eec51">
+                                    <indicator:Observable id="citizenlab:observable-dc028130-bdaf-462a-acd8-81f8ea0eec51">
+                                        <cybox:Object id="citizenlab:File-dc028130-bdaf-462a-acd8-81f8ea0eec51">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -435,16 +435,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:56:20+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -454,14 +454,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-e03c93a5-5b27-4242-8725-e82079d84a02" timestamp="2016-11-08T16:01:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-e03c93a5-5b27-4242-8725-e82079d84a02" timestamp="2016-11-08T16:01:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 30bb678db3ad0140fc33acd9803385c3 (MISP Attribute #455)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 30bb678db3ad0140fc33acd9803385c3 (MISP Attribute #455)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-e03c93a5-5b27-4242-8725-e82079d84a02">
-                                        <cybox:Object id=":File-e03c93a5-5b27-4242-8725-e82079d84a02">
+                                    <indicator:Observable id="citizenlab:observable-e03c93a5-5b27-4242-8725-e82079d84a02">
+                                        <cybox:Object id="citizenlab:File-e03c93a5-5b27-4242-8725-e82079d84a02">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -473,16 +473,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:01:01+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -492,14 +492,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7af948f4-01b5-43f9-b9be-3746a9ce0fcf" timestamp="2016-11-08T16:07:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7af948f4-01b5-43f9-b9be-3746a9ce0fcf" timestamp="2016-11-08T16:07:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 6161083021b695814434450c1882f9f3 (MISP Attribute #457)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 6161083021b695814434450c1882f9f3 (MISP Attribute #457)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7af948f4-01b5-43f9-b9be-3746a9ce0fcf">
-                                        <cybox:Object id=":File-7af948f4-01b5-43f9-b9be-3746a9ce0fcf">
+                                    <indicator:Observable id="citizenlab:observable-7af948f4-01b5-43f9-b9be-3746a9ce0fcf">
+                                        <cybox:Object id="citizenlab:File-7af948f4-01b5-43f9-b9be-3746a9ce0fcf">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -511,16 +511,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:07:32+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -530,14 +530,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-b02858c1-6bfb-4097-a00e-98182b0ec121" timestamp="2016-11-08T16:10:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-b02858c1-6bfb-4097-a00e-98182b0ec121" timestamp="2016-11-08T16:10:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: b4121c3a1892332402000ef0d587c0ee (MISP Attribute #458)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: b4121c3a1892332402000ef0d587c0ee (MISP Attribute #458)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-b02858c1-6bfb-4097-a00e-98182b0ec121">
-                                        <cybox:Object id=":File-b02858c1-6bfb-4097-a00e-98182b0ec121">
+                                    <indicator:Observable id="citizenlab:observable-b02858c1-6bfb-4097-a00e-98182b0ec121">
+                                        <cybox:Object id="citizenlab:File-b02858c1-6bfb-4097-a00e-98182b0ec121">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -549,16 +549,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:10:47+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -568,14 +568,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-dd6a607c-1ffb-4f02-bf84-3cc3292f66b7" timestamp="2016-11-08T16:01:21+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-dd6a607c-1ffb-4f02-bf84-3cc3292f66b7" timestamp="2016-11-08T16:01:21+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 2fc276e1c06c3c78c6d7b66a141213be (MISP Attribute #459)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 2fc276e1c06c3c78c6d7b66a141213be (MISP Attribute #459)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-dd6a607c-1ffb-4f02-bf84-3cc3292f66b7">
-                                        <cybox:Object id=":File-dd6a607c-1ffb-4f02-bf84-3cc3292f66b7">
+                                    <indicator:Observable id="citizenlab:observable-dd6a607c-1ffb-4f02-bf84-3cc3292f66b7">
+                                        <cybox:Object id="citizenlab:File-dd6a607c-1ffb-4f02-bf84-3cc3292f66b7">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -587,16 +587,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:01:21+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -606,14 +606,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-87004645-e8b6-4b7e-a79b-ca643e1446ec" timestamp="2016-11-08T16:13:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-87004645-e8b6-4b7e-a79b-ca643e1446ec" timestamp="2016-11-08T16:13:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 494bab7fd0b42b0b14051ed9abbd651f (MISP Attribute #460)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 494bab7fd0b42b0b14051ed9abbd651f (MISP Attribute #460)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-87004645-e8b6-4b7e-a79b-ca643e1446ec">
-                                        <cybox:Object id=":File-87004645-e8b6-4b7e-a79b-ca643e1446ec">
+                                    <indicator:Observable id="citizenlab:observable-87004645-e8b6-4b7e-a79b-ca643e1446ec">
+                                        <cybox:Object id="citizenlab:File-87004645-e8b6-4b7e-a79b-ca643e1446ec">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -625,16 +625,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:13:14+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -644,14 +644,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-47690aa0-910d-478d-b0ea-fff1f40631ee" timestamp="2016-11-08T16:12:00+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-47690aa0-910d-478d-b0ea-fff1f40631ee" timestamp="2016-11-08T16:12:00+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 8ebeb3f91cda8e985a9c61beb8cdde9d (MISP Attribute #461)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 8ebeb3f91cda8e985a9c61beb8cdde9d (MISP Attribute #461)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-47690aa0-910d-478d-b0ea-fff1f40631ee">
-                                        <cybox:Object id=":File-47690aa0-910d-478d-b0ea-fff1f40631ee">
+                                    <indicator:Observable id="citizenlab:observable-47690aa0-910d-478d-b0ea-fff1f40631ee">
+                                        <cybox:Object id="citizenlab:File-47690aa0-910d-478d-b0ea-fff1f40631ee">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -663,16 +663,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T16:12:00+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -682,14 +682,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-4bf52b9f-f004-4793-a0ba-bf1e211c089d" timestamp="2016-11-08T15:55:56+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-4bf52b9f-f004-4793-a0ba-bf1e211c089d" timestamp="2016-11-08T15:55:56+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 76f8142b4e52c671871b3df87f10c30c (MISP Attribute #462)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 76f8142b4e52c671871b3df87f10c30c (MISP Attribute #462)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-4bf52b9f-f004-4793-a0ba-bf1e211c089d">
-                                        <cybox:Object id=":File-4bf52b9f-f004-4793-a0ba-bf1e211c089d">
+                                    <indicator:Observable id="citizenlab:observable-4bf52b9f-f004-4793-a0ba-bf1e211c089d">
+                                        <cybox:Object id="citizenlab:File-4bf52b9f-f004-4793-a0ba-bf1e211c089d">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -701,16 +701,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:55:56+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -722,19 +722,19 @@
                         <incident:Leveraged_TTPs>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-58223d3d-5864-453a-8c70-69fe8e96ca05" timestamp="2016-11-08T16:01:49+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-58223dcd-63c0-45f1-9516-69fe8e96ca05" timestamp="2016-11-08T16:04:13+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-58223dd5-ca58-4ad4-98d6-69fe8e96ca05" timestamp="2016-11-08T16:04:21+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-58223e40-64f4-47ca-b56b-69fe8e96ca05" timestamp="2016-11-08T16:06:08+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                         </incident:Leveraged_TTPs>
                         <incident:History>

--- a/201608_NSO_Group/stix.xml
+++ b/201608_NSO_Group/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,25 +59,25 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-d63348c4-4789-48f2-9a41-ede3e7dfe251" version="1.1.1" timestamp="2016-11-08T20:32:24.541089+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-d63348c4-4789-48f2-9a41-ede3e7dfe251" version="1.1.1" timestamp="2016-11-08T20:32:24.541089+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-581c1022-5c68-4617-9ea4-497a8e96ca05" version="1.1.1" timestamp="2016-11-08T15:29:20+00:00">
+            <stix:Package id="citizenlab:STIXPackage-581c1022-5c68-4617-9ea4-497a8e96ca05" version="1.1.1" timestamp="2016-11-08T15:29:20+00:00">
                 <stix:STIX_Header>
                     <stix:Title>The Million Dollar Dissident: NSO Group’s iPhone Zero-Days used against a UAE Human Rights Defender (MISP Event #10)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:TTPs>
-                    <stix:TTP id=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>External analysis: CVE-2016-4656 (MISP Attribute #463)</ttp:Title>
                         <ttp:Description>An application may be able to execute arbitrary code with kernel privileges</ttp:Description>
                         <ttp:Exploit_Targets>
                             <ttp:Exploit_Target>
-                                <stixCommon:Exploit_Target id=":et-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='et:ExploitTargetType'>
+                                <stixCommon:Exploit_Target id="citizenlab:et-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='et:ExploitTargetType'>
                                     <et:Title>An application may be able to execute arbitrary code with kernel privileges</et:Title>
                                     <et:Vulnerability>
                                         <et:CVE_ID>CVE-2016-4656</et:CVE_ID>
@@ -86,12 +86,12 @@
                             </ttp:Exploit_Target>
                         </ttp:Exploit_Targets>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>External analysis: CVE-2016-4655 (MISP Attribute #464)</ttp:Title>
                         <ttp:Description>An application may be able to disclose kernel memory</ttp:Description>
                         <ttp:Exploit_Targets>
                             <ttp:Exploit_Target>
-                                <stixCommon:Exploit_Target id=":et-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='et:ExploitTargetType'>
+                                <stixCommon:Exploit_Target id="citizenlab:et-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='et:ExploitTargetType'>
                                     <et:Title>An application may be able to disclose kernel memory</et:Title>
                                     <et:Vulnerability>
                                         <et:CVE_ID>CVE-2016-4655</et:CVE_ID>
@@ -100,12 +100,12 @@
                             </ttp:Exploit_Target>
                         </ttp:Exploit_Targets>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>External analysis: CVE-2016-4657 (MISP Attribute #465)</ttp:Title>
                         <ttp:Description>Visiting a maliciously crafted website may lead to arbitrary code execution</ttp:Description>
                         <ttp:Exploit_Targets>
                             <ttp:Exploit_Target>
-                                <stixCommon:Exploit_Target id=":et-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='et:ExploitTargetType'>
+                                <stixCommon:Exploit_Target id="citizenlab:et-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='et:ExploitTargetType'>
                                     <et:Title>Visiting a maliciously crafted website may lead to arbitrary code execution</et:Title>
                                     <et:Vulnerability>
                                         <et:CVE_ID>CVE-2016-4657</et:CVE_ID>
@@ -114,7 +114,7 @@
                             </ttp:Exploit_Target>
                         </ttp:Exploit_Targets>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: Pegasus (MISP Attribute #1313)</ttp:Title>
                         <ttp:Description>NSO Group product</ttp:Description>
                         <ttp:Behavior>
@@ -127,7 +127,7 @@
                     </stix:TTP>
                 </stix:TTPs>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-581c1022-5c68-4617-9ea4-497a8e96ca05" timestamp="2016-11-08T15:31:51+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-581c1022-5c68-4617-9ea4-497a8e96ca05" timestamp="2016-11-08T15:31:51+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>The Million Dollar Dissident: NSO Group’s iPhone Zero-Days used against a UAE Human Rights Defender</incident:Title>
                         <incident:External_ID source="MISP Event">10</incident:External_ID>
                         <incident:Time>
@@ -138,22 +138,22 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-581c106f-cf04-43a6-88e8-497a8e96ca05" timestamp="2016-11-04T00:37:03+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-581c106f-cf04-43a6-88e8-497a8e96ca05" timestamp="2016-11-04T00:37:03+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: NSO Group (MISP Attribute #498)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: NSO Group (MISP Attribute #498)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-04T00:37:03+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -163,30 +163,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58223036-8d6c-4c3e-a427-497a8e96ca05" timestamp="2016-11-08T15:06:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58223036-8d6c-4c3e-a427-497a8e96ca05" timestamp="2016-11-08T15:06:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: alljazeera.co (MISP Attribute #1314)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: alljazeera.co (MISP Attribute #1314)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58223036-8d6c-4c3e-a427-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-58223036-8d6c-4c3e-a427-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58223036-8d6c-4c3e-a427-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58223036-8d6c-4c3e-a427-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">alljazeera.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:06:14+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -196,30 +196,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-6748-496e-a951-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-6748-496e-a951-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: bbc-africa.com (MISP Attribute #1315)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: bbc-africa.com (MISP Attribute #1315)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-6748-496e-a951-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-6748-496e-a951-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-6748-496e-a951-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-6748-496e-a951-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bbc-africa.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -229,30 +229,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-839c-4f04-949e-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-839c-4f04-949e-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: cnn-africa.co (MISP Attribute #1316)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: cnn-africa.co (MISP Attribute #1316)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-839c-4f04-949e-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-839c-4f04-949e-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-839c-4f04-949e-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-839c-4f04-949e-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">cnn-africa.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -262,30 +262,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-e9e0-4a50-b94c-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-e9e0-4a50-b94c-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: unonoticias.net (MISP Attribute #1317)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: unonoticias.net (MISP Attribute #1317)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-e9e0-4a50-b94c-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-e9e0-4a50-b94c-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-e9e0-4a50-b94c-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-e9e0-4a50-b94c-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">unonoticias.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -295,30 +295,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-2670-47d2-8389-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-2670-47d2-8389-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: univision.click (MISP Attribute #1318)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: univision.click (MISP Attribute #1318)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-2670-47d2-8389-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-2670-47d2-8389-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-2670-47d2-8389-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-2670-47d2-8389-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">univision.click</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -328,30 +328,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-ceec-4dcb-8c51-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-ceec-4dcb-8c51-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: track-your-fedex-package.org (MISP Attribute #1319)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: track-your-fedex-package.org (MISP Attribute #1319)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-ceec-4dcb-8c51-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-ceec-4dcb-8c51-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-ceec-4dcb-8c51-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-ceec-4dcb-8c51-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">track-your-fedex-package.org</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -361,30 +361,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-8640-4db9-8cdf-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-8640-4db9-8cdf-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mz-vodacom.info (MISP Attribute #1320)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mz-vodacom.info (MISP Attribute #1320)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-8640-4db9-8cdf-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-8640-4db9-8cdf-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-8640-4db9-8cdf-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-8640-4db9-8cdf-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mz-vodacom.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -394,30 +394,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-93cc-4f2b-8ae4-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-93cc-4f2b-8ae4-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: iusacell-movil.com.mx (MISP Attribute #1321)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: iusacell-movil.com.mx (MISP Attribute #1321)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-93cc-4f2b-8ae4-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-93cc-4f2b-8ae4-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-93cc-4f2b-8ae4-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-93cc-4f2b-8ae4-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">iusacell-movil.com.mx</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -427,30 +427,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-c5ac-4743-862b-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-c5ac-4743-862b-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: sabafon.info (MISP Attribute #1322)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: sabafon.info (MISP Attribute #1322)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-c5ac-4743-862b-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-c5ac-4743-862b-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-c5ac-4743-862b-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-c5ac-4743-862b-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">sabafon.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -460,30 +460,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-3754-42c7-af73-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-3754-42c7-af73-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: newtarrifs.net (MISP Attribute #1323)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: newtarrifs.net (MISP Attribute #1323)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-3754-42c7-af73-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-3754-42c7-af73-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-3754-42c7-af73-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-3754-42c7-af73-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">newtarrifs.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -493,30 +493,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-aa70-4ee9-8fad-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-aa70-4ee9-8fad-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: y0utube.com.mx (MISP Attribute #1324)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: y0utube.com.mx (MISP Attribute #1324)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-aa70-4ee9-8fad-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-aa70-4ee9-8fad-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-aa70-4ee9-8fad-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-aa70-4ee9-8fad-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">y0utube.com.mx</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -526,30 +526,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-7c38-47df-b3b1-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-7c38-47df-b3b1-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fb-accounts.com (MISP Attribute #1325)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fb-accounts.com (MISP Attribute #1325)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-7c38-47df-b3b1-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-7c38-47df-b3b1-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-7c38-47df-b3b1-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-7c38-47df-b3b1-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fb-accounts.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -559,30 +559,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-049c-47ec-90e2-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-049c-47ec-90e2-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: googleplay-store.com (MISP Attribute #1326)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: googleplay-store.com (MISP Attribute #1326)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-049c-47ec-90e2-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-049c-47ec-90e2-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-049c-47ec-90e2-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-049c-47ec-90e2-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">googleplay-store.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -592,30 +592,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-fbc0-42e5-b56c-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-fbc0-42e5-b56c-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: whatsapp-app.com (MISP Attribute #1327)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: whatsapp-app.com (MISP Attribute #1327)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-fbc0-42e5-b56c-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-fbc0-42e5-b56c-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-fbc0-42e5-b56c-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-fbc0-42e5-b56c-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">whatsapp-app.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -625,30 +625,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-e524-449e-8e0c-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-e524-449e-8e0c-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts.mx (MISP Attribute #1328)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts.mx (MISP Attribute #1328)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-e524-449e-8e0c-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-e524-449e-8e0c-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-e524-449e-8e0c-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-e524-449e-8e0c-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts.mx</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -658,30 +658,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-ecc8-4bce-966d-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-ecc8-4bce-966d-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: adjust-local-settings.com (MISP Attribute #1329)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: adjust-local-settings.com (MISP Attribute #1329)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-ecc8-4bce-966d-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-ecc8-4bce-966d-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-ecc8-4bce-966d-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-ecc8-4bce-966d-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">adjust-local-settings.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -691,30 +691,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-8440-4d71-97b4-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-8440-4d71-97b4-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emiratesfoundation.net (MISP Attribute #1330)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emiratesfoundation.net (MISP Attribute #1330)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-8440-4d71-97b4-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-8440-4d71-97b4-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-8440-4d71-97b4-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-8440-4d71-97b4-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emiratesfoundation.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -724,30 +724,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-0cf8-4c54-8e57-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-0cf8-4c54-8e57-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: checkinonlinehere.com (MISP Attribute #1331)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: checkinonlinehere.com (MISP Attribute #1331)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-0cf8-4c54-8e57-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-0cf8-4c54-8e57-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-0cf8-4c54-8e57-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-0cf8-4c54-8e57-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">checkinonlinehere.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -757,30 +757,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-36e4-4843-93db-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-36e4-4843-93db-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: turkishairines.info (MISP Attribute #1332)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: turkishairines.info (MISP Attribute #1332)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-36e4-4843-93db-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-36e4-4843-93db-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-36e4-4843-93db-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-36e4-4843-93db-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">turkishairines.info</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -790,30 +790,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-0880-4c1c-a507-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-0880-4c1c-a507-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: bulbazaur.com (MISP Attribute #1333)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: bulbazaur.com (MISP Attribute #1333)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-0880-4c1c-a507-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-0880-4c1c-a507-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-0880-4c1c-a507-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-0880-4c1c-a507-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bulbazaur.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -823,30 +823,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582230b8-a9f4-4590-bb10-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582230b8-a9f4-4590-bb10-497a8e96ca05" timestamp="2016-11-08T15:08:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: pickuchu.com (MISP Attribute #1334)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: pickuchu.com (MISP Attribute #1334)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582230b8-a9f4-4590-bb10-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-582230b8-a9f4-4590-bb10-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582230b8-a9f4-4590-bb10-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582230b8-a9f4-4590-bb10-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">pickuchu.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:08:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -856,30 +856,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58223264-6050-4883-8676-497a8e96ca05" timestamp="2016-11-08T15:15:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58223264-6050-4883-8676-497a8e96ca05" timestamp="2016-11-08T15:15:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: damanhealth.online (MISP Attribute #1335)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: damanhealth.online (MISP Attribute #1335)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58223264-6050-4883-8676-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-58223264-6050-4883-8676-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58223264-6050-4883-8676-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58223264-6050-4883-8676-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">damanhealth.online</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:15:32+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -889,30 +889,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5822327c-2050-46cb-b310-497a8e96ca05" timestamp="2016-11-08T15:15:56+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5822327c-2050-46cb-b310-497a8e96ca05" timestamp="2016-11-08T15:15:56+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: uaenews.online (MISP Attribute #1336)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: uaenews.online (MISP Attribute #1336)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5822327c-2050-46cb-b310-497a8e96ca05">
-                                        <cybox:Object id=":DomainName-5822327c-2050-46cb-b310-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5822327c-2050-46cb-b310-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5822327c-2050-46cb-b310-497a8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">uaenews.online</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:15:56+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -922,30 +922,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582233c5-8108-41eb-ba12-49798e96ca05" timestamp="2016-11-08T15:21:25+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582233c5-8108-41eb-ba12-49798e96ca05" timestamp="2016-11-08T15:21:25+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ideas-telcel.com.mx (MISP Attribute #1340)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ideas-telcel.com.mx (MISP Attribute #1340)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582233c5-8108-41eb-ba12-49798e96ca05">
-                                        <cybox:Object id=":DomainName-582233c5-8108-41eb-ba12-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582233c5-8108-41eb-ba12-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582233c5-8108-41eb-ba12-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ideas-telcel.com.mx</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:21:25+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -955,30 +955,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582235a0-ea0c-4301-b87b-49798e96ca05" timestamp="2016-11-08T15:29:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582235a0-ea0c-4301-b87b-49798e96ca05" timestamp="2016-11-08T15:29:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: nation-news.com (MISP Attribute #1342)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: nation-news.com (MISP Attribute #1342)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582235a0-ea0c-4301-b87b-49798e96ca05">
-                                        <cybox:Object id=":DomainName-582235a0-ea0c-4301-b87b-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582235a0-ea0c-4301-b87b-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-582235a0-ea0c-4301-b87b-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">nation-news.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:29:20+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -988,30 +988,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-f13b8f95-e6ca-47a8-8c25-fe1f4817a439" timestamp="2016-11-08T14:28:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-f13b8f95-e6ca-47a8-8c25-fe1f4817a439" timestamp="2016-11-08T14:28:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webadv.co (MISP Attribute #466)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webadv.co (MISP Attribute #466)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-f13b8f95-e6ca-47a8-8c25-fe1f4817a439">
-                                        <cybox:Object id=":DomainName-f13b8f95-e6ca-47a8-8c25-fe1f4817a439">
+                                    <indicator:Observable id="citizenlab:observable-f13b8f95-e6ca-47a8-8c25-fe1f4817a439">
+                                        <cybox:Object id="citizenlab:DomainName-f13b8f95-e6ca-47a8-8c25-fe1f4817a439">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webadv.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:28:07+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1021,30 +1021,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-2ad610a4-2177-4e7f-b525-8621a80e2ebe" timestamp="2016-11-08T14:29:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-2ad610a4-2177-4e7f-b525-8621a80e2ebe" timestamp="2016-11-08T14:29:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: icloudcacher.com (MISP Attribute #469)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: icloudcacher.com (MISP Attribute #469)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-2ad610a4-2177-4e7f-b525-8621a80e2ebe">
-                                        <cybox:Object id=":DomainName-2ad610a4-2177-4e7f-b525-8621a80e2ebe">
+                                    <indicator:Observable id="citizenlab:observable-2ad610a4-2177-4e7f-b525-8621a80e2ebe">
+                                        <cybox:Object id="citizenlab:DomainName-2ad610a4-2177-4e7f-b525-8621a80e2ebe">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">icloudcacher.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:29:23+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1054,30 +1054,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-9c494d42-797d-4c62-978a-8a888fb179c8" timestamp="2016-11-08T14:31:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-9c494d42-797d-4c62-978a-8a888fb179c8" timestamp="2016-11-08T14:31:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: asrarrarabiya.com (MISP Attribute #470)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: asrarrarabiya.com (MISP Attribute #470)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-9c494d42-797d-4c62-978a-8a888fb179c8">
-                                        <cybox:Object id=":DomainName-9c494d42-797d-4c62-978a-8a888fb179c8">
+                                    <indicator:Observable id="citizenlab:observable-9c494d42-797d-4c62-978a-8a888fb179c8">
+                                        <cybox:Object id="citizenlab:DomainName-9c494d42-797d-4c62-978a-8a888fb179c8">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">asrarrarabiya.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:31:33+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1087,30 +1087,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-325e4a00-7b2f-4c27-bff2-89f390e3c13c" timestamp="2016-11-08T14:35:10+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-325e4a00-7b2f-4c27-bff2-89f390e3c13c" timestamp="2016-11-08T14:35:10+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: asrararabiya.co (MISP Attribute #471)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: asrararabiya.co (MISP Attribute #471)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-325e4a00-7b2f-4c27-bff2-89f390e3c13c">
-                                        <cybox:Object id=":DomainName-325e4a00-7b2f-4c27-bff2-89f390e3c13c">
+                                    <indicator:Observable id="citizenlab:observable-325e4a00-7b2f-4c27-bff2-89f390e3c13c">
+                                        <cybox:Object id="citizenlab:DomainName-325e4a00-7b2f-4c27-bff2-89f390e3c13c">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">asrararabiya.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:35:10+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1120,30 +1120,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-9a804548-73c4-4258-9b88-51f952f75d17" timestamp="2016-11-08T14:45:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-9a804548-73c4-4258-9b88-51f952f75d17" timestamp="2016-11-08T14:45:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: asrararablya.com (MISP Attribute #472)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: asrararablya.com (MISP Attribute #472)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-9a804548-73c4-4258-9b88-51f952f75d17">
-                                        <cybox:Object id=":DomainName-9a804548-73c4-4258-9b88-51f952f75d17">
+                                    <indicator:Observable id="citizenlab:observable-9a804548-73c4-4258-9b88-51f952f75d17">
+                                        <cybox:Object id="citizenlab:DomainName-9a804548-73c4-4258-9b88-51f952f75d17">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">asrararablya.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:45:48+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1153,30 +1153,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-cd9ef05f-b3ea-41c2-a750-a431f9dfb508" timestamp="2016-11-08T14:46:00+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-cd9ef05f-b3ea-41c2-a750-a431f9dfb508" timestamp="2016-11-08T14:46:00+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: smser.net (MISP Attribute #473)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: smser.net (MISP Attribute #473)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-cd9ef05f-b3ea-41c2-a750-a431f9dfb508">
-                                        <cybox:Object id=":DomainName-cd9ef05f-b3ea-41c2-a750-a431f9dfb508">
+                                    <indicator:Observable id="citizenlab:observable-cd9ef05f-b3ea-41c2-a750-a431f9dfb508">
+                                        <cybox:Object id="citizenlab:DomainName-cd9ef05f-b3ea-41c2-a750-a431f9dfb508">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">smser.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:46:00+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1186,30 +1186,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-17a374eb-20d6-4790-bee4-45b7073115f1" timestamp="2016-11-08T14:46:06+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-17a374eb-20d6-4790-bee4-45b7073115f1" timestamp="2016-11-08T14:46:06+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: icrcworld.com (MISP Attribute #474)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: icrcworld.com (MISP Attribute #474)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-17a374eb-20d6-4790-bee4-45b7073115f1">
-                                        <cybox:Object id=":DomainName-17a374eb-20d6-4790-bee4-45b7073115f1">
+                                    <indicator:Observable id="citizenlab:observable-17a374eb-20d6-4790-bee4-45b7073115f1">
+                                        <cybox:Object id="citizenlab:DomainName-17a374eb-20d6-4790-bee4-45b7073115f1">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">icrcworld.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:46:06+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1219,30 +1219,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-0d1164d5-7670-41da-8857-1247d0b67561" timestamp="2016-11-08T14:46:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-0d1164d5-7670-41da-8857-1247d0b67561" timestamp="2016-11-08T14:46:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: redcrossworld.com (MISP Attribute #475)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: redcrossworld.com (MISP Attribute #475)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-0d1164d5-7670-41da-8857-1247d0b67561">
-                                        <cybox:Object id=":DomainName-0d1164d5-7670-41da-8857-1247d0b67561">
+                                    <indicator:Observable id="citizenlab:observable-0d1164d5-7670-41da-8857-1247d0b67561">
+                                        <cybox:Object id="citizenlab:DomainName-0d1164d5-7670-41da-8857-1247d0b67561">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">redcrossworld.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:46:12+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1252,30 +1252,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-0f203872-71ec-4b51-ba56-c50918f71f39" timestamp="2016-11-08T14:46:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-0f203872-71ec-4b51-ba56-c50918f71f39" timestamp="2016-11-08T14:46:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: topcontactco.com (MISP Attribute #476)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: topcontactco.com (MISP Attribute #476)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-0f203872-71ec-4b51-ba56-c50918f71f39">
-                                        <cybox:Object id=":DomainName-0f203872-71ec-4b51-ba56-c50918f71f39">
+                                    <indicator:Observable id="citizenlab:observable-0f203872-71ec-4b51-ba56-c50918f71f39">
+                                        <cybox:Object id="citizenlab:DomainName-0f203872-71ec-4b51-ba56-c50918f71f39">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">topcontactco.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:46:18+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1285,30 +1285,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-a2f8ef48-d6f7-46b1-9ee0-71fcb1c65cb9" timestamp="2016-11-08T14:46:26+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-a2f8ef48-d6f7-46b1-9ee0-71fcb1c65cb9" timestamp="2016-11-08T14:46:26+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: thainews.asia (MISP Attribute #477)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: thainews.asia (MISP Attribute #477)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-a2f8ef48-d6f7-46b1-9ee0-71fcb1c65cb9">
-                                        <cybox:Object id=":DomainName-a2f8ef48-d6f7-46b1-9ee0-71fcb1c65cb9">
+                                    <indicator:Observable id="citizenlab:observable-a2f8ef48-d6f7-46b1-9ee0-71fcb1c65cb9">
+                                        <cybox:Object id="citizenlab:DomainName-a2f8ef48-d6f7-46b1-9ee0-71fcb1c65cb9">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">thainews.asia</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:46:26+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1318,30 +1318,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-126c3480-6ad3-417f-9855-4e915b9ae528" timestamp="2016-11-08T14:46:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-126c3480-6ad3-417f-9855-4e915b9ae528" timestamp="2016-11-08T14:46:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: kenyasms.org (MISP Attribute #478)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: kenyasms.org (MISP Attribute #478)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-126c3480-6ad3-417f-9855-4e915b9ae528">
-                                        <cybox:Object id=":DomainName-126c3480-6ad3-417f-9855-4e915b9ae528">
+                                    <indicator:Observable id="citizenlab:observable-126c3480-6ad3-417f-9855-4e915b9ae528">
+                                        <cybox:Object id="citizenlab:DomainName-126c3480-6ad3-417f-9855-4e915b9ae528">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">kenyasms.org</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:46:34+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1351,30 +1351,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7d63d6cb-90dc-454c-a505-a313150c1426" timestamp="2016-11-08T14:46:41+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7d63d6cb-90dc-454c-a505-a313150c1426" timestamp="2016-11-08T14:46:41+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: qaintqa.com (MISP Attribute #479)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: qaintqa.com (MISP Attribute #479)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7d63d6cb-90dc-454c-a505-a313150c1426">
-                                        <cybox:Object id=":DomainName-7d63d6cb-90dc-454c-a505-a313150c1426">
+                                    <indicator:Observable id="citizenlab:observable-7d63d6cb-90dc-454c-a505-a313150c1426">
+                                        <cybox:Object id="citizenlab:DomainName-7d63d6cb-90dc-454c-a505-a313150c1426">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">qaintqa.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:46:41+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1384,30 +1384,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-812c4cbf-60a7-431d-ae7a-a9fd1d6044aa" timestamp="2016-11-08T14:46:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-812c4cbf-60a7-431d-ae7a-a9fd1d6044aa" timestamp="2016-11-08T14:46:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: nsoqa.com (MISP Attribute #480)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: nsoqa.com (MISP Attribute #480)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-812c4cbf-60a7-431d-ae7a-a9fd1d6044aa">
-                                        <cybox:Object id=":DomainName-812c4cbf-60a7-431d-ae7a-a9fd1d6044aa">
+                                    <indicator:Observable id="citizenlab:observable-812c4cbf-60a7-431d-ae7a-a9fd1d6044aa">
+                                        <cybox:Object id="citizenlab:DomainName-812c4cbf-60a7-431d-ae7a-a9fd1d6044aa">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">nsoqa.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:46:49+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1417,30 +1417,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-9be3a48f-e540-43f8-a2c0-8dc915a3dd48" timestamp="2016-11-08T14:54:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-9be3a48f-e540-43f8-a2c0-8dc915a3dd48" timestamp="2016-11-08T14:54:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ooredoodeals.com (MISP Attribute #481)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ooredoodeals.com (MISP Attribute #481)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-9be3a48f-e540-43f8-a2c0-8dc915a3dd48">
-                                        <cybox:Object id=":DomainName-9be3a48f-e540-43f8-a2c0-8dc915a3dd48">
+                                    <indicator:Observable id="citizenlab:observable-9be3a48f-e540-43f8-a2c0-8dc915a3dd48">
+                                        <cybox:Object id="citizenlab:DomainName-9be3a48f-e540-43f8-a2c0-8dc915a3dd48">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ooredoodeals.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:54:16+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1450,30 +1450,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-252cc33c-8786-4dee-b77a-af52acb1661b" timestamp="2016-11-08T14:54:21+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-252cc33c-8786-4dee-b77a-af52acb1661b" timestamp="2016-11-08T14:54:21+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: alawaeltech.com (MISP Attribute #482)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: alawaeltech.com (MISP Attribute #482)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-252cc33c-8786-4dee-b77a-af52acb1661b">
-                                        <cybox:Object id=":DomainName-252cc33c-8786-4dee-b77a-af52acb1661b">
+                                    <indicator:Observable id="citizenlab:observable-252cc33c-8786-4dee-b77a-af52acb1661b">
+                                        <cybox:Object id="citizenlab:DomainName-252cc33c-8786-4dee-b77a-af52acb1661b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">alawaeltech.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:54:21+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1483,30 +1483,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-14df3986-e958-4612-ba2f-daa9fd95b868" timestamp="2016-11-08T14:54:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-14df3986-e958-4612-ba2f-daa9fd95b868" timestamp="2016-11-08T14:54:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: bahrainsms.co (MISP Attribute #483)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: bahrainsms.co (MISP Attribute #483)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-14df3986-e958-4612-ba2f-daa9fd95b868">
-                                        <cybox:Object id=":DomainName-14df3986-e958-4612-ba2f-daa9fd95b868">
+                                    <indicator:Observable id="citizenlab:observable-14df3986-e958-4612-ba2f-daa9fd95b868">
+                                        <cybox:Object id="citizenlab:DomainName-14df3986-e958-4612-ba2f-daa9fd95b868">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bahrainsms.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:54:27+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1516,30 +1516,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-6540311c-8872-47a3-ada2-24757eaa35ee" timestamp="2016-11-08T14:54:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-6540311c-8872-47a3-ada2-24757eaa35ee" timestamp="2016-11-08T14:54:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: turkeynewsupdates.com (MISP Attribute #484)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: turkeynewsupdates.com (MISP Attribute #484)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-6540311c-8872-47a3-ada2-24757eaa35ee">
-                                        <cybox:Object id=":DomainName-6540311c-8872-47a3-ada2-24757eaa35ee">
+                                    <indicator:Observable id="citizenlab:observable-6540311c-8872-47a3-ada2-24757eaa35ee">
+                                        <cybox:Object id="citizenlab:DomainName-6540311c-8872-47a3-ada2-24757eaa35ee">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">turkeynewsupdates.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:54:33+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1549,30 +1549,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-340ccd5a-2520-4ccb-abeb-b264fb2bf645" timestamp="2016-11-08T15:13:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-340ccd5a-2520-4ccb-abeb-b264fb2bf645" timestamp="2016-11-08T15:13:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail1.nsogroup.com (MISP Attribute #486)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail1.nsogroup.com (MISP Attribute #486)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-340ccd5a-2520-4ccb-abeb-b264fb2bf645">
-                                        <cybox:Object id=":DomainName-340ccd5a-2520-4ccb-abeb-b264fb2bf645">
+                                    <indicator:Observable id="citizenlab:observable-340ccd5a-2520-4ccb-abeb-b264fb2bf645">
+                                        <cybox:Object id="citizenlab:DomainName-340ccd5a-2520-4ccb-abeb-b264fb2bf645">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail1.nsogroup.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:13:37+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1582,30 +1582,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-029c89df-139e-463a-b1f1-c259b913d05f" timestamp="2016-11-08T15:09:41+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-029c89df-139e-463a-b1f1-c259b913d05f" timestamp="2016-11-08T15:09:41+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 52.8.153.44 (MISP Attribute #487)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 52.8.153.44 (MISP Attribute #487)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-029c89df-139e-463a-b1f1-c259b913d05f">
-                                        <cybox:Object id=":Address-029c89df-139e-463a-b1f1-c259b913d05f">
+                                    <indicator:Observable id="citizenlab:observable-029c89df-139e-463a-b1f1-c259b913d05f">
+                                        <cybox:Object id="citizenlab:Address-029c89df-139e-463a-b1f1-c259b913d05f">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">52.8.153.44</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:09:41+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1615,30 +1615,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-2f6d312b-8db7-4fa0-9522-cc68090b4a3b" timestamp="2016-11-08T15:10:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-2f6d312b-8db7-4fa0-9522-cc68090b4a3b" timestamp="2016-11-08T15:10:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 52.8.52.166 (MISP Attribute #488)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 52.8.52.166 (MISP Attribute #488)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-2f6d312b-8db7-4fa0-9522-cc68090b4a3b">
-                                        <cybox:Object id=":Address-2f6d312b-8db7-4fa0-9522-cc68090b4a3b">
+                                    <indicator:Observable id="citizenlab:observable-2f6d312b-8db7-4fa0-9522-cc68090b4a3b">
+                                        <cybox:Object id="citizenlab:Address-2f6d312b-8db7-4fa0-9522-cc68090b4a3b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">52.8.52.166</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:10:11+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1648,30 +1648,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-cb442bf4-0d18-4d60-b1a7-e0fe5c7614fa" timestamp="2016-11-08T15:10:28+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-cb442bf4-0d18-4d60-b1a7-e0fe5c7614fa" timestamp="2016-11-08T15:10:28+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 162.209.103.68 (MISP Attribute #489)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 162.209.103.68 (MISP Attribute #489)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-cb442bf4-0d18-4d60-b1a7-e0fe5c7614fa">
-                                        <cybox:Object id=":Address-cb442bf4-0d18-4d60-b1a7-e0fe5c7614fa">
+                                    <indicator:Observable id="citizenlab:observable-cb442bf4-0d18-4d60-b1a7-e0fe5c7614fa">
+                                        <cybox:Object id="citizenlab:Address-cb442bf4-0d18-4d60-b1a7-e0fe5c7614fa">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">162.209.103.68</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:10:28+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1681,30 +1681,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7db51886-46b4-496f-86fd-6b75a7b5f8c8" timestamp="2016-11-08T15:11:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7db51886-46b4-496f-86fd-6b75a7b5f8c8" timestamp="2016-11-08T15:11:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 82.80.202.200 (MISP Attribute #490)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 82.80.202.200 (MISP Attribute #490)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7db51886-46b4-496f-86fd-6b75a7b5f8c8">
-                                        <cybox:Object id=":Address-7db51886-46b4-496f-86fd-6b75a7b5f8c8">
+                                    <indicator:Observable id="citizenlab:observable-7db51886-46b4-496f-86fd-6b75a7b5f8c8">
+                                        <cybox:Object id="citizenlab:Address-7db51886-46b4-496f-86fd-6b75a7b5f8c8">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">82.80.202.200</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:11:17+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1714,30 +1714,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-27a5b383-3c23-4f93-9341-8dd8d90575f6" timestamp="2016-11-08T15:12:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-27a5b383-3c23-4f93-9341-8dd8d90575f6" timestamp="2016-11-08T15:12:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 82.80.202.204 (MISP Attribute #491)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 82.80.202.204 (MISP Attribute #491)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-27a5b383-3c23-4f93-9341-8dd8d90575f6">
-                                        <cybox:Object id=":Address-27a5b383-3c23-4f93-9341-8dd8d90575f6">
+                                    <indicator:Observable id="citizenlab:observable-27a5b383-3c23-4f93-9341-8dd8d90575f6">
+                                        <cybox:Object id="citizenlab:Address-27a5b383-3c23-4f93-9341-8dd8d90575f6">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">82.80.202.204</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:12:35+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1747,30 +1747,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-208dbaaf-39c3-4930-8304-1c76e9b1e7b8" timestamp="2016-11-08T15:12:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-208dbaaf-39c3-4930-8304-1c76e9b1e7b8" timestamp="2016-11-08T15:12:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 54.251.49.214 (MISP Attribute #492)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 54.251.49.214 (MISP Attribute #492)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-208dbaaf-39c3-4930-8304-1c76e9b1e7b8">
-                                        <cybox:Object id=":Address-208dbaaf-39c3-4930-8304-1c76e9b1e7b8">
+                                    <indicator:Observable id="citizenlab:observable-208dbaaf-39c3-4930-8304-1c76e9b1e7b8">
+                                        <cybox:Object id="citizenlab:Address-208dbaaf-39c3-4930-8304-1c76e9b1e7b8">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">54.251.49.214</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:12:44+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1780,30 +1780,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-96bd845b-b8a7-4c91-92e1-c9060cc01239" timestamp="2016-11-08T15:05:00+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-96bd845b-b8a7-4c91-92e1-c9060cc01239" timestamp="2016-11-08T15:05:00+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://smser.net/9918216t/ (MISP Attribute #493)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://smser.net/9918216t/ (MISP Attribute #493)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-96bd845b-b8a7-4c91-92e1-c9060cc01239">
-                                        <cybox:Object id=":URI-96bd845b-b8a7-4c91-92e1-c9060cc01239">
+                                    <indicator:Observable id="citizenlab:observable-96bd845b-b8a7-4c91-92e1-c9060cc01239">
+                                        <cybox:Object id="citizenlab:URI-96bd845b-b8a7-4c91-92e1-c9060cc01239">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smser.net/9918216t/</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:05:00+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1813,30 +1813,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-c9181cb8-1400-47e1-b45b-fc4d17cebe52" timestamp="2016-11-08T15:04:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-c9181cb8-1400-47e1-b45b-fc4d17cebe52" timestamp="2016-11-08T15:04:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://smser.net/redirect.aspx (MISP Attribute #494)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://smser.net/redirect.aspx (MISP Attribute #494)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-c9181cb8-1400-47e1-b45b-fc4d17cebe52">
-                                        <cybox:Object id=":URI-c9181cb8-1400-47e1-b45b-fc4d17cebe52">
+                                    <indicator:Observable id="citizenlab:observable-c9181cb8-1400-47e1-b45b-fc4d17cebe52">
+                                        <cybox:Object id="citizenlab:URI-c9181cb8-1400-47e1-b45b-fc4d17cebe52">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smser.net/redirect.aspx</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:04:49+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1846,30 +1846,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-cdde7699-d231-458d-80a5-338b9e985702" timestamp="2016-11-08T15:01:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-cdde7699-d231-458d-80a5-338b9e985702" timestamp="2016-11-08T15:01:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: aalaan.tv (MISP Attribute #467)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: aalaan.tv (MISP Attribute #467)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-cdde7699-d231-458d-80a5-338b9e985702">
-                                        <cybox:Object id=":DomainName-cdde7699-d231-458d-80a5-338b9e985702">
+                                    <indicator:Observable id="citizenlab:observable-cdde7699-d231-458d-80a5-338b9e985702">
+                                        <cybox:Object id="citizenlab:DomainName-cdde7699-d231-458d-80a5-338b9e985702">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">aalaan.tv</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:01:36+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1879,30 +1879,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-73293a7a-acd5-47a0-81b6-a73f6dde67e1" timestamp="2016-11-08T15:01:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-73293a7a-acd5-47a0-81b6-a73f6dde67e1" timestamp="2016-11-08T15:01:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: manoraonline.net (MISP Attribute #468)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: manoraonline.net (MISP Attribute #468)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-73293a7a-acd5-47a0-81b6-a73f6dde67e1">
-                                        <cybox:Object id=":DomainName-73293a7a-acd5-47a0-81b6-a73f6dde67e1">
+                                    <indicator:Observable id="citizenlab:observable-73293a7a-acd5-47a0-81b6-a73f6dde67e1">
+                                        <cybox:Object id="citizenlab:DomainName-73293a7a-acd5-47a0-81b6-a73f6dde67e1">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">manoraonline.net</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:01:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1912,30 +1912,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-ca1121b7-d273-4aac-83e8-e69b4bce5604" timestamp="2016-11-08T14:57:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-ca1121b7-d273-4aac-83e8-e69b4bce5604" timestamp="2016-11-08T14:57:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: sms.webadv.co (MISP Attribute #485)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: sms.webadv.co (MISP Attribute #485)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-ca1121b7-d273-4aac-83e8-e69b4bce5604">
-                                        <cybox:Object id=":DomainName-ca1121b7-d273-4aac-83e8-e69b4bce5604">
+                                    <indicator:Observable id="citizenlab:observable-ca1121b7-d273-4aac-83e8-e69b4bce5604">
+                                        <cybox:Object id="citizenlab:DomainName-ca1121b7-d273-4aac-83e8-e69b4bce5604">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">sms.webadv.co</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:57:37+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1945,14 +1945,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-6fad387c-a58a-4689-97d0-f87a42dee5b0" timestamp="2016-11-08T15:04:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-6fad387c-a58a-4689-97d0-f87a42dee5b0" timestamp="2016-11-08T15:04:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: pn1g3p@sigaint.org (MISP Attribute #497)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: pn1g3p@sigaint.org (MISP Attribute #497)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-6fad387c-a58a-4689-97d0-f87a42dee5b0">
-                                        <cybox:Object id=":EmailMessage-6fad387c-a58a-4689-97d0-f87a42dee5b0">
+                                    <indicator:Observable id="citizenlab:observable-6fad387c-a58a-4689-97d0-f87a42dee5b0">
+                                        <cybox:Object id="citizenlab:EmailMessage-6fad387c-a58a-4689-97d0-f87a42dee5b0">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1963,16 +1963,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:04:09+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -1982,30 +1982,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58222e62-1020-4d67-b83f-49798e96ca05" timestamp="2016-11-08T14:58:26+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58222e62-1020-4d67-b83f-49798e96ca05" timestamp="2016-11-08T14:58:26+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://sms.webadv.co/3589003s/ (MISP Attribute #1311)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://sms.webadv.co/3589003s/ (MISP Attribute #1311)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58222e62-1020-4d67-b83f-49798e96ca05">
-                                        <cybox:Object id=":URI-58222e62-1020-4d67-b83f-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58222e62-1020-4d67-b83f-49798e96ca05">
+                                        <cybox:Object id="citizenlab:URI-58222e62-1020-4d67-b83f-49798e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://sms.webadv.co/3589003s/</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:58:26+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2015,30 +2015,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58222e78-135c-434e-966e-49798e96ca05" timestamp="2016-11-08T14:58:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58222e78-135c-434e-966e-49798e96ca05" timestamp="2016-11-08T14:58:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://sms.webadv.co/9573305s/ (MISP Attribute #1312)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://sms.webadv.co/9573305s/ (MISP Attribute #1312)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58222e78-135c-434e-966e-49798e96ca05">
-                                        <cybox:Object id=":URI-58222e78-135c-434e-966e-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58222e78-135c-434e-966e-49798e96ca05">
+                                        <cybox:Object id="citizenlab:URI-58222e78-135c-434e-966e-49798e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://sms.webadv.co/9573305s/</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T14:58:48+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2048,30 +2048,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58223346-c23c-4751-9d82-69fe8e96ca05" timestamp="2016-11-08T15:19:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58223346-c23c-4751-9d82-69fe8e96ca05" timestamp="2016-11-08T15:19:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://fb-accounts.com/2408931s/ (MISP Attribute #1337)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://fb-accounts.com/2408931s/ (MISP Attribute #1337)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58223346-c23c-4751-9d82-69fe8e96ca05">
-                                        <cybox:Object id=":URI-58223346-c23c-4751-9d82-69fe8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58223346-c23c-4751-9d82-69fe8e96ca05">
+                                        <cybox:Object id="citizenlab:URI-58223346-c23c-4751-9d82-69fe8e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://fb-accounts.com/2408931s/</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:19:18+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2081,30 +2081,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58223375-b860-4462-9d5a-49798e96ca05" timestamp="2016-11-08T15:20:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58223375-b860-4462-9d5a-49798e96ca05" timestamp="2016-11-08T15:20:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://unonoticias.net/1867745s/ (MISP Attribute #1338)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://unonoticias.net/1867745s/ (MISP Attribute #1338)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58223375-b860-4462-9d5a-49798e96ca05">
-                                        <cybox:Object id=":URI-58223375-b860-4462-9d5a-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58223375-b860-4462-9d5a-49798e96ca05">
+                                        <cybox:Object id="citizenlab:URI-58223375-b860-4462-9d5a-49798e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://unonoticias.net/1867745s/</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:20:05+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2114,30 +2114,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582233be-b3c8-4238-82b5-49798e96ca05" timestamp="2016-11-08T15:21:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582233be-b3c8-4238-82b5-49798e96ca05" timestamp="2016-11-08T15:21:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://ideas-telcel.com.mx/3975827s/ (MISP Attribute #1339)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://ideas-telcel.com.mx/3975827s/ (MISP Attribute #1339)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582233be-b3c8-4238-82b5-49798e96ca05">
-                                        <cybox:Object id=":URI-582233be-b3c8-4238-82b5-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582233be-b3c8-4238-82b5-49798e96ca05">
+                                        <cybox:Object id="citizenlab:URI-582233be-b3c8-4238-82b5-49798e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://ideas-telcel.com.mx/3975827s/</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:21:18+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2147,30 +2147,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58223592-ad84-44d5-9e29-49798e96ca05" timestamp="2016-11-08T15:29:06+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58223592-ad84-44d5-9e29-49798e96ca05" timestamp="2016-11-08T15:29:06+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: nation-news.com/4077017s/ (MISP Attribute #1341)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: nation-news.com/4077017s/ (MISP Attribute #1341)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58223592-ad84-44d5-9e29-49798e96ca05">
-                                        <cybox:Object id=":URI-58223592-ad84-44d5-9e29-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58223592-ad84-44d5-9e29-49798e96ca05">
+                                        <cybox:Object id="citizenlab:URI-58223592-ad84-44d5-9e29-49798e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">nation-news.com/4077017s/</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:29:06+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2180,30 +2180,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-7dd57279-a151-44d4-a21d-bb62ee3435aa" timestamp="2016-11-08T15:18:53+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-7dd57279-a151-44d4-a21d-bb62ee3435aa" timestamp="2016-11-08T15:18:53+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://fb-accounts.com/1074139s/ (MISP Attribute #495)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://fb-accounts.com/1074139s/ (MISP Attribute #495)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-7dd57279-a151-44d4-a21d-bb62ee3435aa">
-                                        <cybox:Object id=":URI-7dd57279-a151-44d4-a21d-bb62ee3435aa">
+                                    <indicator:Observable id="citizenlab:observable-7dd57279-a151-44d4-a21d-bb62ee3435aa">
+                                        <cybox:Object id="citizenlab:URI-7dd57279-a151-44d4-a21d-bb62ee3435aa">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://fb-accounts.com/1074139s/</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:18:53+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2213,30 +2213,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-eed4deb8-c8a8-4722-8e29-8ba5772e3059" timestamp="2016-11-08T15:19:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-eed4deb8-c8a8-4722-8e29-8ba5772e3059" timestamp="2016-11-08T15:19:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://unonoticias.net/3423768s/ (MISP Attribute #496)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://unonoticias.net/3423768s/ (MISP Attribute #496)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-eed4deb8-c8a8-4722-8e29-8ba5772e3059">
-                                        <cybox:Object id=":URI-eed4deb8-c8a8-4722-8e29-8ba5772e3059">
+                                    <indicator:Observable id="citizenlab:observable-eed4deb8-c8a8-4722-8e29-8ba5772e3059">
+                                        <cybox:Object id="citizenlab:URI-eed4deb8-c8a8-4722-8e29-8ba5772e3059">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://unonoticias.net/3423768s/</URIObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-08T15:19:49+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -2248,19 +2248,19 @@
                         <incident:Leveraged_TTPs>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>External analysis</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-268f13bd-3b4b-4ff5-88c1-bbf33405bb3c" timestamp="2016-11-08T14:28:46+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>External analysis</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-aa080850-113d-4a41-bb48-5be41d23061d" timestamp="2016-11-08T14:28:41+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>External analysis</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-4d37d443-08ae-4c04-a8d7-9e27a8b73e35" timestamp="2016-11-08T14:28:36+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-58222ea5-3130-41cc-a8e2-49798e96ca05" timestamp="2016-11-08T14:59:39+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                         </incident:Leveraged_TTPs>
                         <incident:History>

--- a/201611_KeyBoy/stix.xml
+++ b/201611_KeyBoy/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,25 +59,25 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-7cef25ee-341b-4d14-a63b-2af874baade1" version="1.1.1" timestamp="2016-11-16T20:25:14.935544+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-7cef25ee-341b-4d14-a63b-2af874baade1" version="1.1.1" timestamp="2016-11-16T20:25:14.935544+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-5820aa49-6a40-4e51-86f9-497a8e96ca05" version="1.1.1" timestamp="2016-11-16T15:02:43+00:00">
+            <stix:Package id="citizenlab:STIXPackage-5820aa49-6a40-4e51-86f9-497a8e96ca05" version="1.1.1" timestamp="2016-11-16T15:02:43+00:00">
                 <stix:STIX_Header>
                     <stix:Title>It’s Parliamentary: KeyBoy and the targeting of the Tibetan Community (MISP Event #17)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:TTPs>
-                    <stix:TTP id=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload delivery: CVE-2012-0158 (MISP Attribute #811)</ttp:Title>
                         <ttp:Description>8307e444cad98b1b59568ad2eba5f201</ttp:Description>
                         <ttp:Exploit_Targets>
                             <ttp:Exploit_Target>
-                                <stixCommon:Exploit_Target id=":et-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='et:ExploitTargetType'>
+                                <stixCommon:Exploit_Target id="citizenlab:et-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='et:ExploitTargetType'>
                                     <et:Title>8307e444cad98b1b59568ad2eba5f201</et:Title>
                                     <et:Vulnerability>
                                         <et:CVE_ID>CVE-2012-0158</et:CVE_ID>
@@ -86,11 +86,11 @@
                             </ttp:Exploit_Target>
                         </ttp:Exploit_Targets>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload delivery: CVE-2014-4114 (MISP Attribute #832)</ttp:Title>
                         <ttp:Exploit_Targets>
                             <ttp:Exploit_Target>
-                                <stixCommon:Exploit_Target id=":et-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='et:ExploitTargetType'>
+                                <stixCommon:Exploit_Target id="citizenlab:et-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='et:ExploitTargetType'>
                                     <et:Title>Vulnerability CVE-2014-4114</et:Title>
                                     <et:Vulnerability>
                                         <et:CVE_ID>CVE-2014-4114</et:CVE_ID>
@@ -99,11 +99,11 @@
                             </ttp:Exploit_Target>
                         </ttp:Exploit_Targets>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload delivery: CVE-2015-1641 (MISP Attribute #1374)</ttp:Title>
                         <ttp:Exploit_Targets>
                             <ttp:Exploit_Target>
-                                <stixCommon:Exploit_Target id=":et-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='et:ExploitTargetType'>
+                                <stixCommon:Exploit_Target id="citizenlab:et-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='et:ExploitTargetType'>
                                     <et:Title>Vulnerability CVE-2015-1641</et:Title>
                                     <et:Vulnerability>
                                         <et:CVE_ID>CVE-2015-1641</et:CVE_ID>
@@ -112,7 +112,7 @@
                             </ttp:Exploit_Target>
                         </ttp:Exploit_Targets>
                     </stix:TTP>
-                    <stix:TTP id=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'>
+                    <stix:TTP id="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'>
                         <ttp:Title>Payload type: KeyBoy (MISP Attribute #809)</ttp:Title>
                         <ttp:Behavior>
                             <ttp:Malware>
@@ -124,7 +124,7 @@
                     </stix:TTP>
                 </stix:TTPs>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-5820aa49-6a40-4e51-86f9-497a8e96ca05" timestamp="2016-11-16T15:02:57+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-5820aa49-6a40-4e51-86f9-497a8e96ca05" timestamp="2016-11-16T15:02:57+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>It’s Parliamentary: KeyBoy and the targeting of the Tibetan Community</incident:Title>
                         <incident:External_ID source="MISP Event">17</incident:External_ID>
                         <incident:Time>
@@ -135,14 +135,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ab69-8e78-4925-8f07-497a8e96ca05" timestamp="2016-11-07T11:27:21+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ab69-8e78-4925-8f07-497a8e96ca05" timestamp="2016-11-07T11:27:21+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 8f08609e4e0b3d26814b3073a42df415 (MISP Attribute #813)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 8f08609e4e0b3d26814b3073a42df415 (MISP Attribute #813)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ab69-8e78-4925-8f07-497a8e96ca05">
-                                        <cybox:Object id=":File-5820ab69-8e78-4925-8f07-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ab69-8e78-4925-8f07-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820ab69-8e78-4925-8f07-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -154,16 +154,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:27:21+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -173,14 +173,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ab7b-5a8c-4164-8113-49798e96ca05" timestamp="2016-11-07T11:37:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ab7b-5a8c-4164-8113-49798e96ca05" timestamp="2016-11-07T11:37:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 495adb1b9777002ecfe22aaf52fcee93 (MISP Attribute #814)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 495adb1b9777002ecfe22aaf52fcee93 (MISP Attribute #814)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ab7b-5a8c-4164-8113-49798e96ca05">
-                                        <cybox:Object id=":File-5820ab7b-5a8c-4164-8113-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ab7b-5a8c-4164-8113-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820ab7b-5a8c-4164-8113-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -192,16 +192,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:37:43+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -211,14 +211,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ac1b-05c0-4d60-8fc5-497a8e96ca05" timestamp="2016-11-07T11:33:10+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ac1b-05c0-4d60-8fc5-497a8e96ca05" timestamp="2016-11-07T11:33:10+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 0c7e55509e0b6d4277b3facf864af018 (MISP Attribute #822)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 0c7e55509e0b6d4277b3facf864af018 (MISP Attribute #822)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ac1b-05c0-4d60-8fc5-497a8e96ca05">
-                                        <cybox:Object id=":File-5820ac1b-05c0-4d60-8fc5-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ac1b-05c0-4d60-8fc5-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820ac1b-05c0-4d60-8fc5-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -230,16 +230,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:33:10+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -249,14 +249,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ac71-ff98-486d-b2e6-49798e96ca05" timestamp="2016-11-07T11:32:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ac71-ff98-486d-b2e6-49798e96ca05" timestamp="2016-11-07T11:32:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 98977426d544bd145979f65f0322ae30 (MISP Attribute #827)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 98977426d544bd145979f65f0322ae30 (MISP Attribute #827)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ac71-ff98-486d-b2e6-49798e96ca05">
-                                        <cybox:Object id=":File-5820ac71-ff98-486d-b2e6-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ac71-ff98-486d-b2e6-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820ac71-ff98-486d-b2e6-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -268,16 +268,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:32:01+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -287,14 +287,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ad9c-c3c4-455e-a5f2-497a8e96ca05" timestamp="2016-11-07T11:36:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ad9c-c3c4-455e-a5f2-497a8e96ca05" timestamp="2016-11-07T11:36:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: c5b5f01ba24d6c02636388809f44472e (MISP Attribute #833)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: c5b5f01ba24d6c02636388809f44472e (MISP Attribute #833)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ad9c-c3c4-455e-a5f2-497a8e96ca05">
-                                        <cybox:Object id=":File-5820ad9c-c3c4-455e-a5f2-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ad9c-c3c4-455e-a5f2-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820ad9c-c3c4-455e-a5f2-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -306,16 +306,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:36:44+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -325,14 +325,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820adb2-5520-499c-95d3-49798e96ca05" timestamp="2016-11-07T11:37:06+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820adb2-5520-499c-95d3-49798e96ca05" timestamp="2016-11-07T11:37:06+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 371bc132499f455f06fa80696db0df27 (MISP Attribute #834)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 371bc132499f455f06fa80696db0df27 (MISP Attribute #834)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820adb2-5520-499c-95d3-49798e96ca05">
-                                        <cybox:Object id=":File-5820adb2-5520-499c-95d3-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820adb2-5520-499c-95d3-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820adb2-5520-499c-95d3-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -344,16 +344,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:37:06+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -363,14 +363,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58239987-0038-44ba-997f-49798e96ca05" timestamp="2016-11-09T16:47:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58239987-0038-44ba-997f-49798e96ca05" timestamp="2016-11-09T16:47:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 087bffa8a570079948310dc9731c5709 (MISP Attribute #1372)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 087bffa8a570079948310dc9731c5709 (MISP Attribute #1372)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58239987-0038-44ba-997f-49798e96ca05">
-                                        <cybox:Object id=":File-58239987-0038-44ba-997f-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58239987-0038-44ba-997f-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-58239987-0038-44ba-997f-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -382,16 +382,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-09T16:47:51+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -401,14 +401,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58235402-9d54-437c-b845-69fe8e96ca05" timestamp="2016-11-16T11:56:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58235402-9d54-437c-b845-69fe8e96ca05" timestamp="2016-11-16T11:56:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Ver (MISP Attribute #1365)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Host Characteristics</indicator:Type>
                                     <indicator:Description>Artifacts dropped: HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Ver (MISP Attribute #1365)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58235402-9d54-437c-b845-69fe8e96ca05">
-                                        <cybox:Object id=":WinRegistryKey-58235402-9d54-437c-b845-69fe8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58235402-9d54-437c-b845-69fe8e96ca05">
+                                        <cybox:Object id="citizenlab:WinRegistryKey-58235402-9d54-437c-b845-69fe8e96ca05">
                                             <cybox:Properties xsi:type="WinRegistryKeyObj:WindowsRegistryKeyObjectType">
                                                 <WinRegistryKeyObj:Key condition="Equals">Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Ver</WinRegistryKeyObj:Key>
                                                 <WinRegistryKeyObj:Hive condition="Equals">HKEY_CURRENT_USER</WinRegistryKeyObj:Hive>
@@ -416,16 +416,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-16T11:56:27+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -435,14 +435,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582398b8-c1b4-418a-8fe7-49798e96ca05" timestamp="2016-11-09T16:44:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582398b8-c1b4-418a-8fe7-49798e96ca05" timestamp="2016-11-09T16:44:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 58105e9772f6befbc319c147a97faded4fbacf839947b34fe3695ae72771da5d (MISP Attribute #1368)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 58105e9772f6befbc319c147a97faded4fbacf839947b34fe3695ae72771da5d (MISP Attribute #1368)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582398b8-c1b4-418a-8fe7-49798e96ca05">
-                                        <cybox:Object id=":File-582398b8-c1b4-418a-8fe7-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582398b8-c1b4-418a-8fe7-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-582398b8-c1b4-418a-8fe7-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -454,16 +454,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-09T16:44:24+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -473,14 +473,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582398da-78c0-47ed-8bb9-49798e96ca05" timestamp="2016-11-09T16:44:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582398da-78c0-47ed-8bb9-49798e96ca05" timestamp="2016-11-09T16:44:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 9a55577d357922711ab0821bf5379289293c8517ae1d94d48c389f306af57a04 (MISP Attribute #1369)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 9a55577d357922711ab0821bf5379289293c8517ae1d94d48c389f306af57a04 (MISP Attribute #1369)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582398da-78c0-47ed-8bb9-49798e96ca05">
-                                        <cybox:Object id=":File-582398da-78c0-47ed-8bb9-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582398da-78c0-47ed-8bb9-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-582398da-78c0-47ed-8bb9-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -492,16 +492,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-09T16:44:58+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -511,14 +511,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582399a3-04f8-4542-b205-49798e96ca05" timestamp="2016-11-09T16:48:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582399a3-04f8-4542-b205-49798e96ca05" timestamp="2016-11-09T16:48:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 5da2f14c382d7cac8dfa6c86e528a646a81f0b40cfee9611c8cfb4b5d589aa88 (MISP Attribute #1373)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 5da2f14c382d7cac8dfa6c86e528a646a81f0b40cfee9611c8cfb4b5d589aa88 (MISP Attribute #1373)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582399a3-04f8-4542-b205-49798e96ca05">
-                                        <cybox:Object id=":File-582399a3-04f8-4542-b205-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582399a3-04f8-4542-b205-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-582399a3-04f8-4542-b205-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -530,16 +530,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-09T16:48:19+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -549,30 +549,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820aba7-e398-41cb-939b-49798e96ca05" timestamp="2016-11-07T11:28:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820aba7-e398-41cb-939b-49798e96ca05" timestamp="2016-11-07T11:28:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tibetvoices.com (MISP Attribute #817)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tibetvoices.com (MISP Attribute #817)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820aba7-e398-41cb-939b-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5820aba7-e398-41cb-939b-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820aba7-e398-41cb-939b-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5820aba7-e398-41cb-939b-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tibetvoices.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:28:23+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -582,30 +582,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ac33-aa80-4d97-99a2-49798e96ca05" timestamp="2016-11-07T11:35:42+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ac33-aa80-4d97-99a2-49798e96ca05" timestamp="2016-11-07T11:35:42+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.about.jkub.com (MISP Attribute #823)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.about.jkub.com (MISP Attribute #823)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ac33-aa80-4d97-99a2-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5820ac33-aa80-4d97-99a2-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ac33-aa80-4d97-99a2-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5820ac33-aa80-4d97-99a2-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.about.jkub.com</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:35:42+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -615,30 +615,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ac33-586c-4674-b96d-49798e96ca05" timestamp="2016-11-16T12:10:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ac33-586c-4674-b96d-49798e96ca05" timestamp="2016-11-16T12:10:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.eleven.mypop3.org (MISP Attribute #824)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.eleven.mypop3.org (MISP Attribute #824)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ac33-586c-4674-b96d-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5820ac33-586c-4674-b96d-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ac33-586c-4674-b96d-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5820ac33-586c-4674-b96d-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.eleven.mypop3.org</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-16T12:10:12+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -648,30 +648,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ac34-dfc4-4772-8fb6-49798e96ca05" timestamp="2016-11-16T12:10:21+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ac34-dfc4-4772-8fb6-49798e96ca05" timestamp="2016-11-16T12:10:21+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.backus.myftp.name (MISP Attribute #825)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.backus.myftp.name (MISP Attribute #825)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ac34-dfc4-4772-8fb6-49798e96ca05">
-                                        <cybox:Object id=":DomainName-5820ac34-dfc4-4772-8fb6-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ac34-dfc4-4772-8fb6-49798e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5820ac34-dfc4-4772-8fb6-49798e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.backus.myftp.name</DomainNameObj:Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-16T12:10:21+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -681,30 +681,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ab93-ca00-4627-a8e9-497a8e96ca05" timestamp="2016-11-10T12:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ab93-ca00-4627-a8e9-497a8e96ca05" timestamp="2016-11-10T12:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 45.125.12.147 (MISP Attribute #815)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 45.125.12.147 (MISP Attribute #815)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ab93-ca00-4627-a8e9-497a8e96ca05">
-                                        <cybox:Object id=":Address-5820ab93-ca00-4627-a8e9-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ab93-ca00-4627-a8e9-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5820ab93-ca00-4627-a8e9-497a8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">45.125.12.147</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-10T12:24:36+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -714,30 +714,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ab93-8b90-4f61-8591-497a8e96ca05" timestamp="2016-11-16T11:56:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ab93-8b90-4f61-8591-497a8e96ca05" timestamp="2016-11-16T11:56:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 103.40.102.233 (MISP Attribute #816)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 103.40.102.233 (MISP Attribute #816)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ab93-8b90-4f61-8591-497a8e96ca05">
-                                        <cybox:Object id=":Address-5820ab93-8b90-4f61-8591-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ab93-8b90-4f61-8591-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5820ab93-8b90-4f61-8591-497a8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">103.40.102.233</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-16T11:56:01+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -747,30 +747,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820abec-8b88-4398-ba31-497a8e96ca05" timestamp="2016-11-07T11:29:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820abec-8b88-4398-ba31-497a8e96ca05" timestamp="2016-11-07T11:29:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 116.193.154.69 (MISP Attribute #820)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 116.193.154.69 (MISP Attribute #820)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820abec-8b88-4398-ba31-497a8e96ca05">
-                                        <cybox:Object id=":Address-5820abec-8b88-4398-ba31-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820abec-8b88-4398-ba31-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5820abec-8b88-4398-ba31-497a8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">116.193.154.69</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:29:32+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -780,30 +780,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ac98-f508-4869-9701-497a8e96ca05" timestamp="2016-11-16T15:02:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ac98-f508-4869-9701-497a8e96ca05" timestamp="2016-11-16T15:02:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 103.242.134.243 (MISP Attribute #828)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 103.242.134.243 (MISP Attribute #828)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ac98-f508-4869-9701-497a8e96ca05">
-                                        <cybox:Object id=":Address-5820ac98-f508-4869-9701-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ac98-f508-4869-9701-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5820ac98-f508-4869-9701-497a8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">103.242.134.243</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-16T15:02:43+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -813,30 +813,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ad1d-a7c0-4f84-9d29-497a8e96ca05" timestamp="2016-11-07T11:35:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ad1d-a7c0-4f84-9d29-497a8e96ca05" timestamp="2016-11-07T11:35:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 45.32.47.148 (MISP Attribute #829)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 45.32.47.148 (MISP Attribute #829)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ad1d-a7c0-4f84-9d29-497a8e96ca05">
-                                        <cybox:Object id=":Address-5820ad1d-a7c0-4f84-9d29-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ad1d-a7c0-4f84-9d29-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5820ad1d-a7c0-4f84-9d29-497a8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">45.32.47.148</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:35:36+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -846,30 +846,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ad1d-5d34-489f-97b8-497a8e96ca05" timestamp="2016-11-07T11:35:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ad1d-5d34-489f-97b8-497a8e96ca05" timestamp="2016-11-07T11:35:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 157.7.84.81 (MISP Attribute #830)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 157.7.84.81 (MISP Attribute #830)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ad1d-5d34-489f-97b8-497a8e96ca05">
-                                        <cybox:Object id=":Address-5820ad1d-5d34-489f-97b8-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ad1d-5d34-489f-97b8-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5820ad1d-5d34-489f-97b8-497a8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">157.7.84.81</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:35:48+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -879,30 +879,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ad50-de2c-4f26-bd5c-497a8e96ca05" timestamp="2016-11-07T11:35:28+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ad50-de2c-4f26-bd5c-497a8e96ca05" timestamp="2016-11-07T11:35:28+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 192.241.149.43 (MISP Attribute #831)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 192.241.149.43 (MISP Attribute #831)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ad50-de2c-4f26-bd5c-497a8e96ca05">
-                                        <cybox:Object id=":Address-5820ad50-de2c-4f26-bd5c-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ad50-de2c-4f26-bd5c-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5820ad50-de2c-4f26-bd5c-497a8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">192.241.149.43</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:35:28+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -912,30 +912,30 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582c9016-1a1c-471e-890f-69fe8e96ca05" timestamp="2016-11-16T11:57:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582c9016-1a1c-471e-890f-69fe8e96ca05" timestamp="2016-11-16T11:57:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 112.10.117.47 (MISP Attribute #1880)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 112.10.117.47 (MISP Attribute #1880)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582c9016-1a1c-471e-890f-69fe8e96ca05">
-                                        <cybox:Object id=":Address-582c9016-1a1c-471e-890f-69fe8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582c9016-1a1c-471e-890f-69fe8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-582c9016-1a1c-471e-890f-69fe8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">112.10.117.47</AddressObj:Address_Value>
                                             </cybox:Properties>
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-16T11:57:58+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -945,14 +945,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58238a80-e5bc-449f-9440-497a8e96ca05" timestamp="2016-11-09T15:43:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58238a80-e5bc-449f-9440-497a8e96ca05" timestamp="2016-11-09T15:43:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: tibetanparliarnent@yahoo.com (MISP Attribute #1366)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: tibetanparliarnent@yahoo.com (MISP Attribute #1366)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58238a80-e5bc-449f-9440-497a8e96ca05">
-                                        <cybox:Object id=":EmailMessage-58238a80-e5bc-449f-9440-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58238a80-e5bc-449f-9440-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-58238a80-e5bc-449f-9440-497a8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -963,16 +963,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-09T15:43:44+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -982,14 +982,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820aafa-d53c-4131-8582-497a8e96ca05" timestamp="2016-11-07T11:25:30+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820aafa-d53c-4131-8582-497a8e96ca05" timestamp="2016-11-07T11:25:30+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 8307e444cad98b1b59568ad2eba5f201 (MISP Attribute #810)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 8307e444cad98b1b59568ad2eba5f201 (MISP Attribute #810)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820aafa-d53c-4131-8582-497a8e96ca05">
-                                        <cybox:Object id=":File-5820aafa-d53c-4131-8582-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820aafa-d53c-4131-8582-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820aafa-d53c-4131-8582-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1001,16 +1001,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:25:30+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -1020,14 +1020,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ab43-0ce0-46a9-bc84-49798e96ca05" timestamp="2016-11-07T11:26:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ab43-0ce0-46a9-bc84-49798e96ca05" timestamp="2016-11-07T11:26:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 0b4d45db323f68b465ae052d3a872068 (MISP Attribute #812)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 0b4d45db323f68b465ae052d3a872068 (MISP Attribute #812)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ab43-0ce0-46a9-bc84-49798e96ca05">
-                                        <cybox:Object id=":File-5820ab43-0ce0-46a9-bc84-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ab43-0ce0-46a9-bc84-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820ab43-0ce0-46a9-bc84-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1039,16 +1039,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:26:43+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -1058,14 +1058,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820abc0-979c-4a84-8800-497a8e96ca05" timestamp="2016-11-07T11:28:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820abc0-979c-4a84-8800-497a8e96ca05" timestamp="2016-11-07T11:28:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: beadf21b923600554b0ce54df42e78f5 (MISP Attribute #818)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: beadf21b923600554b0ce54df42e78f5 (MISP Attribute #818)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820abc0-979c-4a84-8800-497a8e96ca05">
-                                        <cybox:Object id=":File-5820abc0-979c-4a84-8800-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820abc0-979c-4a84-8800-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820abc0-979c-4a84-8800-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1077,16 +1077,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:28:48+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -1096,14 +1096,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820abd0-acb8-474a-bbf0-49798e96ca05" timestamp="2016-11-07T11:29:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820abd0-acb8-474a-bbf0-49798e96ca05" timestamp="2016-11-07T11:29:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 69df3d3df4d99bc6045d073d89c68697 (MISP Attribute #819)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 69df3d3df4d99bc6045d073d89c68697 (MISP Attribute #819)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820abd0-acb8-474a-bbf0-49798e96ca05">
-                                        <cybox:Object id=":File-5820abd0-acb8-474a-bbf0-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820abd0-acb8-474a-bbf0-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820abd0-acb8-474a-bbf0-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1115,16 +1115,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:29:04+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -1134,14 +1134,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ac07-868c-41f0-85c2-49798e96ca05" timestamp="2016-11-07T11:29:59+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ac07-868c-41f0-85c2-49798e96ca05" timestamp="2016-11-07T11:29:59+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 05b5cf94f07fee666eb086c91182ad25 (MISP Attribute #821)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 05b5cf94f07fee666eb086c91182ad25 (MISP Attribute #821)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ac07-868c-41f0-85c2-49798e96ca05">
-                                        <cybox:Object id=":File-5820ac07-868c-41f0-85c2-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ac07-868c-41f0-85c2-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820ac07-868c-41f0-85c2-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1153,16 +1153,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:29:59+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -1172,14 +1172,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5820ac58-8a88-4011-b491-497a8e96ca05" timestamp="2016-11-07T11:31:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5820ac58-8a88-4011-b491-497a8e96ca05" timestamp="2016-11-07T11:31:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 8846d109b457a2ee44ddbf54d1cf7944 (MISP Attribute #826)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 8846d109b457a2ee44ddbf54d1cf7944 (MISP Attribute #826)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5820ac58-8a88-4011-b491-497a8e96ca05">
-                                        <cybox:Object id=":File-5820ac58-8a88-4011-b491-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5820ac58-8a88-4011-b491-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5820ac58-8a88-4011-b491-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1191,16 +1191,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-07T11:31:20+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -1210,14 +1210,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-582c8ecf-e830-4d88-bbda-497a8e96ca05" timestamp="2016-11-16T11:52:31+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-582c8ecf-e830-4d88-bbda-497a8e96ca05" timestamp="2016-11-16T11:52:31+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 913b82ff8f090670fc6387e3a7bea12d (MISP Attribute #1879)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 913b82ff8f090670fc6387e3a7bea12d (MISP Attribute #1879)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-582c8ecf-e830-4d88-bbda-497a8e96ca05">
-                                        <cybox:Object id=":File-582c8ecf-e830-4d88-bbda-497a8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-582c8ecf-e830-4d88-bbda-497a8e96ca05">
+                                        <cybox:Object id="citizenlab:File-582c8ecf-e830-4d88-bbda-497a8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1229,16 +1229,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-16T11:52:31+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">None</stixCommon:Value>
@@ -1248,14 +1248,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5823990b-db7c-45c9-9afb-69fe8e96ca05" timestamp="2016-11-09T16:46:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5823990b-db7c-45c9-9afb-69fe8e96ca05" timestamp="2016-11-09T16:46:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 23d284245e53ae4fe05c517d807ffccf (MISP Attribute #1370)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 23d284245e53ae4fe05c517d807ffccf (MISP Attribute #1370)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5823990b-db7c-45c9-9afb-69fe8e96ca05">
-                                        <cybox:Object id=":File-5823990b-db7c-45c9-9afb-69fe8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5823990b-db7c-45c9-9afb-69fe8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5823990b-db7c-45c9-9afb-69fe8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1267,16 +1267,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-09T16:46:01+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1286,14 +1286,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5823989b-68f0-4831-b1d8-49798e96ca05" timestamp="2016-11-09T16:43:55+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5823989b-68f0-4831-b1d8-49798e96ca05" timestamp="2016-11-09T16:43:55+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 5f24a5ee9ecfd4a8e5f967ffcf24580a83942cd7b09d310b9525962ed2614a49 (MISP Attribute #1367)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 5f24a5ee9ecfd4a8e5f967ffcf24580a83942cd7b09d310b9525962ed2614a49 (MISP Attribute #1367)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5823989b-68f0-4831-b1d8-49798e96ca05">
-                                        <cybox:Object id=":File-5823989b-68f0-4831-b1d8-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5823989b-68f0-4831-b1d8-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-5823989b-68f0-4831-b1d8-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1305,16 +1305,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-09T16:43:55+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1324,14 +1324,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5823995f-701c-4616-84f5-49798e96ca05" timestamp="2016-11-09T16:47:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5823995f-701c-4616-84f5-49798e96ca05" timestamp="2016-11-09T16:47:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 542c85fda8df8510c1b66a122e459aac8c0919f1fe9fa2c43fd87899cffa05bf (MISP Attribute #1371)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 542c85fda8df8510c1b66a122e459aac8c0919f1fe9fa2c43fd87899cffa05bf (MISP Attribute #1371)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5823995f-701c-4616-84f5-49798e96ca05">
-                                        <cybox:Object id=":File-5823995f-701c-4616-84f5-49798e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5823995f-701c-4616-84f5-49798e96ca05">
+                                        <cybox:Object id="citizenlab:File-5823995f-701c-4616-84f5-49798e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1343,16 +1343,16 @@
                                         </cybox:Object>
                                     </indicator:Observable>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Indicated_TTP>
-                                        <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                        <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                                     </indicator:Indicated_TTP>
                                     <indicator:Confidence timestamp="2016-11-09T16:47:11+00:00">
                                         <stixCommon:Value xsi:type="stixVocabs:HighMediumLowVocab-1.0">High</stixCommon:Value>
@@ -1364,19 +1364,19 @@
                         <incident:Leveraged_TTPs>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-5820ab2e-591c-456f-b2d4-497a8e96ca05" timestamp="2016-11-07T11:26:22+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-5820ad80-c82c-43f9-bece-49798e96ca05" timestamp="2016-11-07T11:36:16+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-5824ad47-8e68-49cd-854f-49798e96ca05" timestamp="2016-11-10T12:24:23+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                             <incident:Leveraged_TTP>
                                 <stixCommon:Relationship>Payload type</stixCommon:Relationship>
-                                <stixCommon:TTP idref=":ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
+                                <stixCommon:TTP idref="citizenlab:ttp-5820aae1-a8d4-4f70-86f5-49798e96ca05" timestamp="2016-11-07T11:25:05+00:00" xsi:type='ttp:TTPType'/>
                             </incident:Leveraged_TTP>
                         </incident:Leveraged_TTPs>
                         <incident:History>

--- a/201702_NilePhish/stix.xml
+++ b/201702_NilePhish/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,20 +59,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-75287c07-daf5-49c6-bf5c-0f33a85d66aa" version="1.1.1" timestamp="2017-02-02T05:22:08.102251+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-75287c07-daf5-49c6-bf5c-0f33a85d66aa" version="1.1.1" timestamp="2017-02-02T05:22:08.102251+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-587cf513-b324-485c-b65e-07298e96ca05" version="1.1.1" timestamp="2017-01-31T12:10:57+00:00">
+            <stix:Package id="citizenlab:STIXPackage-587cf513-b324-485c-b65e-07298e96ca05" version="1.1.1" timestamp="2017-01-31T12:10:57+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Nile Phish - attacks again Egyptian civil society</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-587cf513-b324-485c-b65e-07298e96ca05" timestamp="2017-01-31T13:49:48+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-587cf513-b324-485c-b65e-07298e96ca05" timestamp="2017-01-31T13:49:48+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Nile Phish - attacks again Egyptian civil society</incident:Title>
                         <incident:External_ID source="MISP Event">89</incident:External_ID>
                         <incident:Time>
@@ -83,14 +83,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-cf24-4254-ad98-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-cf24-4254-ad98-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: account-google.serveftp.com (MISP Attribute #15651)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: account-google.serveftp.com (MISP Attribute #15651)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-cf24-4254-ad98-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-cf24-4254-ad98-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-cf24-4254-ad98-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-cf24-4254-ad98-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">account-google.serveftp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -104,14 +104,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-5724-4ccd-b5f0-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-5724-4ccd-b5f0-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: aramex-shipping.servehttp.com (MISP Attribute #15652)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: aramex-shipping.servehttp.com (MISP Attribute #15652)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-5724-4ccd-b5f0-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-5724-4ccd-b5f0-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-5724-4ccd-b5f0-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-5724-4ccd-b5f0-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">aramex-shipping.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -125,14 +125,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-ee60-4f45-8efb-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-ee60-4f45-8efb-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: device-activation.servehttp.com (MISP Attribute #15653)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: device-activation.servehttp.com (MISP Attribute #15653)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-ee60-4f45-8efb-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-ee60-4f45-8efb-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-ee60-4f45-8efb-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-ee60-4f45-8efb-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">device-activation.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -146,14 +146,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-4e10-41de-9d5b-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-4e10-41de-9d5b-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dropbox-service.serveftp.com (MISP Attribute #15654)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dropbox-service.serveftp.com (MISP Attribute #15654)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-4e10-41de-9d5b-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-4e10-41de-9d5b-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-4e10-41de-9d5b-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-4e10-41de-9d5b-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dropbox-service.serveftp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -167,14 +167,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-4184-41bd-932b-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-4184-41bd-932b-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dropbox-sign.servehttp.com (MISP Attribute #15655)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dropbox-sign.servehttp.com (MISP Attribute #15655)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-4184-41bd-932b-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-4184-41bd-932b-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-4184-41bd-932b-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-4184-41bd-932b-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dropbox-sign.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -188,14 +188,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-d7e4-4b55-8b85-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-d7e4-4b55-8b85-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dropboxsupport.servehttp.com (MISP Attribute #15656)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dropboxsupport.servehttp.com (MISP Attribute #15656)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-d7e4-4b55-8b85-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-d7e4-4b55-8b85-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-d7e4-4b55-8b85-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-d7e4-4b55-8b85-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dropboxsupport.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -209,14 +209,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-5614-4198-bfc8-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-5614-4198-bfc8-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fedex-mail.servehttp.com (MISP Attribute #15657)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fedex-mail.servehttp.com (MISP Attribute #15657)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-5614-4198-bfc8-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-5614-4198-bfc8-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-5614-4198-bfc8-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-5614-4198-bfc8-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fedex-mail.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -230,14 +230,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-d37c-406e-8703-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-d37c-406e-8703-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fedex-shipping.servehttp.com (MISP Attribute #15658)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fedex-shipping.servehttp.com (MISP Attribute #15658)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-d37c-406e-8703-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-d37c-406e-8703-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-d37c-406e-8703-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-d37c-406e-8703-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fedex-shipping.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -251,14 +251,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-3f6c-4a59-9c2f-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-3f6c-4a59-9c2f-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fedex-sign.servehttp.com (MISP Attribute #15659)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fedex-sign.servehttp.com (MISP Attribute #15659)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-3f6c-4a59-9c2f-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-3f6c-4a59-9c2f-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-3f6c-4a59-9c2f-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-3f6c-4a59-9c2f-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fedex-sign.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -272,14 +272,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-1708-4caa-bef5-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-1708-4caa-bef5-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: googledriver-sign.ddns.net (MISP Attribute #15660)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: googledriver-sign.ddns.net (MISP Attribute #15660)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-1708-4caa-bef5-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-1708-4caa-bef5-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-1708-4caa-bef5-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-1708-4caa-bef5-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">googledriver-sign.ddns.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -293,14 +293,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-3604-4351-9e9e-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-3604-4351-9e9e-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: googledrive-sign.servehttp.com (MISP Attribute #15661)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: googledrive-sign.servehttp.com (MISP Attribute #15661)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-3604-4351-9e9e-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-3604-4351-9e9e-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-3604-4351-9e9e-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-3604-4351-9e9e-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">googledrive-sign.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -314,14 +314,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-1470-4b9e-a921-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-1470-4b9e-a921-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google-maps.servehttp.com (MISP Attribute #15662)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google-maps.servehttp.com (MISP Attribute #15662)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-1470-4b9e-a921-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-1470-4b9e-a921-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-1470-4b9e-a921-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-1470-4b9e-a921-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google-maps.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -335,14 +335,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-2d08-493e-962a-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-2d08-493e-962a-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: googlesecure-serv.servehttp.com (MISP Attribute #15663)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: googlesecure-serv.servehttp.com (MISP Attribute #15663)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-2d08-493e-962a-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-2d08-493e-962a-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-2d08-493e-962a-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-2d08-493e-962a-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">googlesecure-serv.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -356,14 +356,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-f554-4b11-b19b-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-f554-4b11-b19b-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: googlesignin.servehttp.com (MISP Attribute #15664)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: googlesignin.servehttp.com (MISP Attribute #15664)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-f554-4b11-b19b-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-f554-4b11-b19b-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-f554-4b11-b19b-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-f554-4b11-b19b-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">googlesignin.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -377,14 +377,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-aaf4-49c7-9028-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-aaf4-49c7-9028-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: googleverify-signin.servehttp.com (MISP Attribute #15665)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: googleverify-signin.servehttp.com (MISP Attribute #15665)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-aaf4-49c7-9028-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-aaf4-49c7-9028-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-aaf4-49c7-9028-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-aaf4-49c7-9028-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">googleverify-signin.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -398,14 +398,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-ea9c-4be6-a936-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-ea9c-4be6-a936-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailgooglesign.servehttp.com (MISP Attribute #15666)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailgooglesign.servehttp.com (MISP Attribute #15666)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-ea9c-4be6-a936-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-ea9c-4be6-a936-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-ea9c-4be6-a936-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-ea9c-4be6-a936-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailgooglesign.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -419,14 +419,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-7d08-4995-ae9d-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-7d08-4995-ae9d-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myaccount.servehttp.com (MISP Attribute #15667)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myaccount.servehttp.com (MISP Attribute #15667)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-7d08-4995-ae9d-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-7d08-4995-ae9d-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-7d08-4995-ae9d-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-7d08-4995-ae9d-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myaccount.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -440,14 +440,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-4754-4997-9fdc-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-4754-4997-9fdc-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: secure-team.servehttp.com (MISP Attribute #15668)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: secure-team.servehttp.com (MISP Attribute #15668)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-4754-4997-9fdc-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-4754-4997-9fdc-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-4754-4997-9fdc-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-4754-4997-9fdc-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">secure-team.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -461,14 +461,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-7ff4-4200-a7ee-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-7ff4-4200-a7ee-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: security-myaccount.servehttp.com (MISP Attribute #15669)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: security-myaccount.servehttp.com (MISP Attribute #15669)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-7ff4-4200-a7ee-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-7ff4-4200-a7ee-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-7ff4-4200-a7ee-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-7ff4-4200-a7ee-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">security-myaccount.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -482,14 +482,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588778af-421c-4ab6-8fc9-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588778af-421c-4ab6-8fc9-07288e96ca05" timestamp="2017-01-24T10:54:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: verification-acc.servehttp.com (MISP Attribute #15670)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: verification-acc.servehttp.com (MISP Attribute #15670)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588778af-421c-4ab6-8fc9-07288e96ca05">
-                                        <cybox:Object id=":DomainName-588778af-421c-4ab6-8fc9-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588778af-421c-4ab6-8fc9-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588778af-421c-4ab6-8fc9-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">verification-acc.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -503,14 +503,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877af7-e064-4ea8-8048-07288e96ca05" timestamp="2017-01-24T11:04:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877af7-e064-4ea8-8048-07288e96ca05" timestamp="2017-01-24T11:04:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dropbox-verfy.servehttp.com (MISP Attribute #15671)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dropbox-verfy.servehttp.com (MISP Attribute #15671)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877af7-e064-4ea8-8048-07288e96ca05">
-                                        <cybox:Object id=":DomainName-58877af7-e064-4ea8-8048-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877af7-e064-4ea8-8048-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877af7-e064-4ea8-8048-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dropbox-verfy.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -524,14 +524,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877af7-3218-42ee-ab63-07288e96ca05" timestamp="2017-01-24T11:04:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877af7-3218-42ee-ab63-07288e96ca05" timestamp="2017-01-24T11:04:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fedex-s.servehttp.com (MISP Attribute #15672)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fedex-s.servehttp.com (MISP Attribute #15672)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877af7-3218-42ee-ab63-07288e96ca05">
-                                        <cybox:Object id=":DomainName-58877af7-3218-42ee-ab63-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877af7-3218-42ee-ab63-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877af7-3218-42ee-ab63-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fedex-s.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -545,14 +545,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877af7-c9f8-4198-acf2-07288e96ca05" timestamp="2017-01-24T11:04:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877af7-c9f8-4198-acf2-07288e96ca05" timestamp="2017-01-24T11:04:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: watchyoutube.servehttp.com (MISP Attribute #15673)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: watchyoutube.servehttp.com (MISP Attribute #15673)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877af7-c9f8-4198-acf2-07288e96ca05">
-                                        <cybox:Object id=":DomainName-58877af7-c9f8-4198-acf2-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877af7-c9f8-4198-acf2-07288e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877af7-c9f8-4198-acf2-07288e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">watchyoutube.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -566,14 +566,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877ce3-c1c4-40d8-baa5-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877ce3-c1c4-40d8-baa5-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: verification-team.servehttp.com (MISP Attribute #15674)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: verification-team.servehttp.com (MISP Attribute #15674)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877ce3-c1c4-40d8-baa5-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58877ce3-c1c4-40d8-baa5-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877ce3-c1c4-40d8-baa5-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877ce3-c1c4-40d8-baa5-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">verification-team.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -587,14 +587,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877ce3-2fa4-43b0-9be6-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877ce3-2fa4-43b0-9be6-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: securityteam-notify.servehttp.com (MISP Attribute #15675)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: securityteam-notify.servehttp.com (MISP Attribute #15675)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877ce3-2fa4-43b0-9be6-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58877ce3-2fa4-43b0-9be6-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877ce3-2fa4-43b0-9be6-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877ce3-2fa4-43b0-9be6-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">securityteam-notify.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -608,14 +608,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877ce3-fb60-4972-a691-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877ce3-fb60-4972-a691-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: secure-alert.servehttp.com (MISP Attribute #15676)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: secure-alert.servehttp.com (MISP Attribute #15676)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877ce3-fb60-4972-a691-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58877ce3-fb60-4972-a691-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877ce3-fb60-4972-a691-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877ce3-fb60-4972-a691-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">secure-alert.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -629,14 +629,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877ce3-9b20-4e75-a2f1-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877ce3-9b20-4e75-a2f1-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: quota-notification.servehttp.com (MISP Attribute #15677)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: quota-notification.servehttp.com (MISP Attribute #15677)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877ce3-9b20-4e75-a2f1-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58877ce3-9b20-4e75-a2f1-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877ce3-9b20-4e75-a2f1-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877ce3-9b20-4e75-a2f1-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">quota-notification.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -650,14 +650,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877ce3-e2bc-4fc7-b7a0-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877ce3-e2bc-4fc7-b7a0-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: notification-team.servehttp.com (MISP Attribute #15678)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: notification-team.servehttp.com (MISP Attribute #15678)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877ce3-e2bc-4fc7-b7a0-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58877ce3-e2bc-4fc7-b7a0-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877ce3-e2bc-4fc7-b7a0-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877ce3-e2bc-4fc7-b7a0-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">notification-team.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -671,14 +671,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877ce3-5d28-4361-983f-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877ce3-5d28-4361-983f-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fedex-notification.servehttp.com (MISP Attribute #15679)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fedex-notification.servehttp.com (MISP Attribute #15679)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877ce3-5d28-4361-983f-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58877ce3-5d28-4361-983f-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877ce3-5d28-4361-983f-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877ce3-5d28-4361-983f-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fedex-notification.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -692,14 +692,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877ce3-acd4-4365-ac46-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877ce3-acd4-4365-ac46-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: docs-mails.servehttp.com (MISP Attribute #15680)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: docs-mails.servehttp.com (MISP Attribute #15680)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877ce3-acd4-4365-ac46-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58877ce3-acd4-4365-ac46-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877ce3-acd4-4365-ac46-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877ce3-acd4-4365-ac46-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">docs-mails.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -713,14 +713,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877ce3-5b10-49d8-b03d-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877ce3-5b10-49d8-b03d-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: restricted-videos.servehttp.com (MISP Attribute #15681)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: restricted-videos.servehttp.com (MISP Attribute #15681)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877ce3-5b10-49d8-b03d-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58877ce3-5b10-49d8-b03d-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877ce3-5b10-49d8-b03d-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877ce3-5b10-49d8-b03d-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">restricted-videos.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -734,14 +734,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58877ce3-f668-4eb1-828a-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58877ce3-f668-4eb1-828a-07298e96ca05" timestamp="2017-01-24T11:12:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dropboxnotification.servehttp.com (MISP Attribute #15682)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dropboxnotification.servehttp.com (MISP Attribute #15682)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58877ce3-f668-4eb1-828a-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58877ce3-f668-4eb1-828a-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58877ce3-f668-4eb1-828a-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58877ce3-f668-4eb1-828a-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dropboxnotification.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -755,14 +755,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5887a880-559c-4680-a403-0bbb8e96ca05" timestamp="2017-01-24T14:18:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5887a880-559c-4680-a403-0bbb8e96ca05" timestamp="2017-01-24T14:18:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: moi-gov.serveftp.com (MISP Attribute #15683)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: moi-gov.serveftp.com (MISP Attribute #15683)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5887a880-559c-4680-a403-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-5887a880-559c-4680-a403-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5887a880-559c-4680-a403-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5887a880-559c-4680-a403-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">moi-gov.serveftp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -776,14 +776,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5890c466-51f8-425d-850f-07298e96ca05" timestamp="2017-01-31T12:07:50+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5890c466-51f8-425d-850f-07298e96ca05" timestamp="2017-01-31T12:07:50+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: activate-google.servehttp.com (MISP Attribute #15685)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: activate-google.servehttp.com (MISP Attribute #15685)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5890c466-51f8-425d-850f-07298e96ca05">
-                                        <cybox:Object id=":DomainName-5890c466-51f8-425d-850f-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5890c466-51f8-425d-850f-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5890c466-51f8-425d-850f-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">activate-google.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -797,14 +797,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5890c521-f8f4-4df3-ab2c-07298e96ca05" timestamp="2017-01-31T12:10:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5890c521-f8f4-4df3-ab2c-07298e96ca05" timestamp="2017-01-31T12:10:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: googlemaps.servehttp.com (MISP Attribute #15686)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: googlemaps.servehttp.com (MISP Attribute #15686)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5890c521-f8f4-4df3-ab2c-07298e96ca05">
-                                        <cybox:Object id=":DomainName-5890c521-f8f4-4df3-ab2c-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5890c521-f8f4-4df3-ab2c-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5890c521-f8f4-4df3-ab2c-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">googlemaps.servehttp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -818,14 +818,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cfa0f-0b54-44f1-9f4c-0bbb8e96ca05" timestamp="2017-01-16T11:51:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cfa0f-0b54-44f1-9f4c-0bbb8e96ca05" timestamp="2017-01-16T11:51:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 108.61.176.96 (MISP Attribute #15399)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 108.61.176.96 (MISP Attribute #15399)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cfa0f-0b54-44f1-9f4c-0bbb8e96ca05">
-                                        <cybox:Object id=":Address-587cfa0f-0b54-44f1-9f4c-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cfa0f-0b54-44f1-9f4c-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-587cfa0f-0b54-44f1-9f4c-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">108.61.176.96</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -839,14 +839,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cfa22-d240-4c6a-ba53-0bbb8e96ca05" timestamp="2017-01-16T11:51:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cfa22-d240-4c6a-ba53-0bbb8e96ca05" timestamp="2017-01-16T11:51:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 104.238.191.204 (MISP Attribute #15400)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 104.238.191.204 (MISP Attribute #15400)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cfa22-d240-4c6a-ba53-0bbb8e96ca05">
-                                        <cybox:Object id=":Address-587cfa22-d240-4c6a-ba53-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cfa22-d240-4c6a-ba53-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-587cfa22-d240-4c6a-ba53-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">104.238.191.204</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -860,14 +860,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf53e-ee64-4e85-a4f5-0bbb8e96ca05" timestamp="2017-01-16T11:30:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf53e-ee64-4e85-a4f5-0bbb8e96ca05" timestamp="2017-01-16T11:30:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 176.123.26.42 (MISP Attribute #15358)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 176.123.26.42 (MISP Attribute #15358)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf53e-ee64-4e85-a4f5-0bbb8e96ca05">
-                                        <cybox:Object id=":Address-587cf53e-ee64-4e85-a4f5-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf53e-ee64-4e85-a4f5-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-587cf53e-ee64-4e85-a4f5-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">176.123.26.42</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -881,14 +881,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-c440-4d76-886f-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-c440-4d76-886f-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: secure.policy.check@gmail.com (MISP Attribute #15374)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: secure.policy.check@gmail.com (MISP Attribute #15374)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-c440-4d76-886f-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-c440-4d76-886f-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-c440-4d76-886f-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-c440-4d76-886f-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -906,14 +906,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-e780-49b3-8a72-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-e780-49b3-8a72-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: aramex.shipment@gmail.com (MISP Attribute #15375)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: aramex.shipment@gmail.com (MISP Attribute #15375)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-e780-49b3-8a72-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-e780-49b3-8a72-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-e780-49b3-8a72-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-e780-49b3-8a72-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -931,14 +931,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-1c68-4978-ad06-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-1c68-4978-ad06-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: fedex_tracking@outlook.sa (MISP Attribute #15376)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: fedex_tracking@outlook.sa (MISP Attribute #15376)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-1c68-4978-ad06-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-1c68-4978-ad06-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-1c68-4978-ad06-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-1c68-4978-ad06-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -956,14 +956,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-5760-44c5-9a0f-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-5760-44c5-9a0f-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: mails.acc.noreply@gmail.com (MISP Attribute #15377)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: mails.acc.noreply@gmail.com (MISP Attribute #15377)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-5760-44c5-9a0f-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-5760-44c5-9a0f-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-5760-44c5-9a0f-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-5760-44c5-9a0f-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -981,14 +981,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-e788-4294-bc78-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-e788-4294-bc78-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: fedex.noreply@gmail.com (MISP Attribute #15378)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: fedex.noreply@gmail.com (MISP Attribute #15378)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-e788-4294-bc78-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-e788-4294-bc78-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-e788-4294-bc78-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-e788-4294-bc78-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1006,14 +1006,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-b678-4509-828e-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-b678-4509-828e-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: customerserviceonlineteam@gmail.com (MISP Attribute #15379)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: customerserviceonlineteam@gmail.com (MISP Attribute #15379)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-b678-4509-828e-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-b678-4509-828e-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-b678-4509-828e-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-b678-4509-828e-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1031,14 +1031,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-cc54-41a3-81d7-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-cc54-41a3-81d7-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: fedexcustomers.service@gmail.com (MISP Attribute #15380)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: fedexcustomers.service@gmail.com (MISP Attribute #15380)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-cc54-41a3-81d7-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-cc54-41a3-81d7-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-cc54-41a3-81d7-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-cc54-41a3-81d7-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1056,14 +1056,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-3f30-4cd6-8821-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-3f30-4cd6-8821-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: elnadeem.org@gmail.com (MISP Attribute #15381)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: elnadeem.org@gmail.com (MISP Attribute #15381)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-3f30-4cd6-8821-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-3f30-4cd6-8821-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-3f30-4cd6-8821-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-3f30-4cd6-8821-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1081,14 +1081,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-8200-46ea-8b62-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-8200-46ea-8b62-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: dropbox.noreplay@gmail.com (MISP Attribute #15382)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: dropbox.noreplay@gmail.com (MISP Attribute #15382)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-8200-46ea-8b62-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-8200-46ea-8b62-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-8200-46ea-8b62-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-8200-46ea-8b62-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1106,14 +1106,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-814c-4b68-a2ed-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-814c-4b68-a2ed-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: mails.noreply.verify@gmail.com (MISP Attribute #15383)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: mails.noreply.verify@gmail.com (MISP Attribute #15383)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-814c-4b68-a2ed-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-814c-4b68-a2ed-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-814c-4b68-a2ed-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-814c-4b68-a2ed-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1131,14 +1131,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-991c-4110-bbcc-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-991c-4110-bbcc-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: fedex.mails.shipping@gmail.com (MISP Attribute #15384)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: fedex.mails.shipping@gmail.com (MISP Attribute #15384)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-991c-4110-bbcc-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-991c-4110-bbcc-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-991c-4110-bbcc-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-991c-4110-bbcc-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1156,14 +1156,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587cf8ac-07ac-4f31-b12a-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587cf8ac-07ac-4f31-b12a-0bbb8e96ca05" timestamp="2017-01-16T11:45:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: dropbox.notifications.mails@gmail.com (MISP Attribute #15385)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: dropbox.notifications.mails@gmail.com (MISP Attribute #15385)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587cf8ac-07ac-4f31-b12a-0bbb8e96ca05">
-                                        <cybox:Object id=":EmailMessage-587cf8ac-07ac-4f31-b12a-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587cf8ac-07ac-4f31-b12a-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-587cf8ac-07ac-4f31-b12a-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1181,14 +1181,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5887755a-551c-49ca-9e41-07288e96ca05" timestamp="2017-01-24T10:40:10+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5887755a-551c-49ca-9e41-07288e96ca05" timestamp="2017-01-24T10:40:10+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: dropbox.notfication@gmail.com (MISP Attribute #15649)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: dropbox.notfication@gmail.com (MISP Attribute #15649)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5887755a-551c-49ca-9e41-07288e96ca05">
-                                        <cybox:Object id=":EmailMessage-5887755a-551c-49ca-9e41-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5887755a-551c-49ca-9e41-07288e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-5887755a-551c-49ca-9e41-07288e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1206,14 +1206,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5887755a-4b1c-4e2a-96ac-07288e96ca05" timestamp="2017-01-24T10:40:10+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5887755a-4b1c-4e2a-96ac-07288e96ca05" timestamp="2017-01-24T10:40:10+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: drive.noreply.mail@gmail.com (MISP Attribute #15650)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: drive.noreply.mail@gmail.com (MISP Attribute #15650)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5887755a-4b1c-4e2a-96ac-07288e96ca05">
-                                        <cybox:Object id=":EmailMessage-5887755a-4b1c-4e2a-96ac-07288e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5887755a-4b1c-4e2a-96ac-07288e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-5887755a-4b1c-4e2a-96ac-07288e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">

--- a/201705_TaintedLeaks/stix.xml
+++ b/201705_TaintedLeaks/stix.xml
@@ -58,20 +58,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-b84be256-86f6-4616-905c-063f6f7bc5b7" version="1.1.1" timestamp="2017-05-25T15:20:50.437054+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-b84be256-86f6-4616-905c-063f6f7bc5b7" version="1.1.1" timestamp="2017-05-25T15:20:50.437054+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-5926f385-8a58-4fc0-a075-5d828e96ca05" version="1.1.1" timestamp="2017-05-25T11:15:16+00:00">
+            <stix:Package id="citizenlab:STIXPackage-5926f385-8a58-4fc0-a075-5d828e96ca05" version="1.1.1" timestamp="2017-05-25T11:15:16+00:00">
                 <stix:STIX_Header>
                     <stix:Title>TAINTED LEAKS: Disinformation and Phishing With a Russian Nexus (MISP Event #100)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-5926f385-8a58-4fc0-a075-5d828e96ca05" timestamp="2017-05-25T11:15:50+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-5926f385-8a58-4fc0-a075-5d828e96ca05" timestamp="2017-05-25T11:15:50+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>TAINTED LEAKS: Disinformation and Phishing With a Russian Nexus</incident:Title>
                         <incident:External_ID source="MISP Event">100</incident:External_ID>
                         <incident:Time>
@@ -82,14 +82,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f463-dc78-4a45-ba38-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f463-dc78-4a45-ba38-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: id833.ga (MISP Attribute #16046)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: id833.ga (MISP Attribute #16046)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f463-dc78-4a45-ba38-53928e96ca05">
-                                        <cybox:Object id=":DomainName-5926f463-dc78-4a45-ba38-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f463-dc78-4a45-ba38-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5926f463-dc78-4a45-ba38-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">id833.ga</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -103,14 +103,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f463-9b30-4133-9f8a-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f463-9b30-4133-9f8a-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: id834.ga (MISP Attribute #16047)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: id834.ga (MISP Attribute #16047)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f463-9b30-4133-9f8a-53928e96ca05">
-                                        <cybox:Object id=":DomainName-5926f463-9b30-4133-9f8a-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f463-9b30-4133-9f8a-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5926f463-9b30-4133-9f8a-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">id834.ga</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -124,14 +124,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f463-8944-4fcc-b570-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f463-8944-4fcc-b570-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: id9954.gq (MISP Attribute #16048)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: id9954.gq (MISP Attribute #16048)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f463-8944-4fcc-b570-53928e96ca05">
-                                        <cybox:Object id=":DomainName-5926f463-8944-4fcc-b570-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f463-8944-4fcc-b570-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5926f463-8944-4fcc-b570-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">id9954.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -145,14 +145,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f463-a1dc-4042-a982-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f463-a1dc-4042-a982-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: id4242.ga (MISP Attribute #16049)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: id4242.ga (MISP Attribute #16049)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f463-a1dc-4042-a982-53928e96ca05">
-                                        <cybox:Object id=":DomainName-5926f463-a1dc-4042-a982-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f463-a1dc-4042-a982-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5926f463-a1dc-4042-a982-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">id4242.ga</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -166,14 +166,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f463-45f0-45c6-bf0a-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f463-45f0-45c6-bf0a-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-google-login.blogspot.com (MISP Attribute #16050)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-google-login.blogspot.com (MISP Attribute #16050)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f463-45f0-45c6-bf0a-53928e96ca05">
-                                        <cybox:Object id=":DomainName-5926f463-45f0-45c6-bf0a-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f463-45f0-45c6-bf0a-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5926f463-45f0-45c6-bf0a-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-google-login.blogspot.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -187,14 +187,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f463-f7d4-432d-b56a-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f463-f7d4-432d-b56a-53928e96ca05" timestamp="2017-05-25T11:12:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-securitysettingpage.tk (MISP Attribute #16051)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-securitysettingpage.tk (MISP Attribute #16051)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f463-f7d4-432d-b56a-53928e96ca05">
-                                        <cybox:Object id=":DomainName-5926f463-f7d4-432d-b56a-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f463-f7d4-432d-b56a-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5926f463-f7d4-432d-b56a-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-securitysettingpage.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -208,14 +208,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f4a8-cf18-4416-b85d-5d828e96ca05" timestamp="2017-05-25T11:13:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f4a8-cf18-4416-b85d-5d828e96ca05" timestamp="2017-05-25T11:13:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 89.40.181.119 (MISP Attribute #16055)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 89.40.181.119 (MISP Attribute #16055)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f4a8-cf18-4416-b85d-5d828e96ca05">
-                                        <cybox:Object id=":Address-5926f4a8-cf18-4416-b85d-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f4a8-cf18-4416-b85d-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5926f4a8-cf18-4416-b85d-5d828e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">89.40.181.119</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -229,14 +229,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f4a8-e18c-4b39-b0ac-5d828e96ca05" timestamp="2017-05-25T11:13:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f4a8-e18c-4b39-b0ac-5d828e96ca05" timestamp="2017-05-25T11:13:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 89.32.40.238 (MISP Attribute #16056)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 89.32.40.238 (MISP Attribute #16056)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f4a8-e18c-4b39-b0ac-5d828e96ca05">
-                                        <cybox:Object id=":Address-5926f4a8-e18c-4b39-b0ac-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f4a8-e18c-4b39-b0ac-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5926f4a8-e18c-4b39-b0ac-5d828e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">89.32.40.238</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -250,14 +250,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f4a8-cb10-4528-89f8-5d828e96ca05" timestamp="2017-05-25T11:13:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f4a8-cb10-4528-89f8-5d828e96ca05" timestamp="2017-05-25T11:13:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 80.255.12.237 (MISP Attribute #16057)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 80.255.12.237 (MISP Attribute #16057)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f4a8-cb10-4528-89f8-5d828e96ca05">
-                                        <cybox:Object id=":Address-5926f4a8-cb10-4528-89f8-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f4a8-cb10-4528-89f8-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5926f4a8-cb10-4528-89f8-5d828e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">80.255.12.237</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -271,14 +271,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f504-4e00-4343-9488-5d828e96ca05" timestamp="2017-05-25T11:15:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f504-4e00-4343-9488-5d828e96ca05" timestamp="2017-05-25T11:15:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: g.mail2017@yandex.com (MISP Attribute #16058)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: g.mail2017@yandex.com (MISP Attribute #16058)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f504-4e00-4343-9488-5d828e96ca05">
-                                        <cybox:Object id=":EmailMessage-5926f504-4e00-4343-9488-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f504-4e00-4343-9488-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-5926f504-4e00-4343-9488-5d828e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -296,14 +296,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f504-53f4-4700-8a2b-5d828e96ca05" timestamp="2017-05-25T11:15:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f504-53f4-4700-8a2b-5d828e96ca05" timestamp="2017-05-25T11:15:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: annaablony@mail.com (MISP Attribute #16059)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: annaablony@mail.com (MISP Attribute #16059)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f504-53f4-4700-8a2b-5d828e96ca05">
-                                        <cybox:Object id=":EmailMessage-5926f504-53f4-4700-8a2b-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f504-53f4-4700-8a2b-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-5926f504-53f4-4700-8a2b-5d828e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -321,14 +321,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5926f504-a840-4d0e-8d26-5d828e96ca05" timestamp="2017-05-25T11:15:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5926f504-a840-4d0e-8d26-5d828e96ca05" timestamp="2017-05-25T11:15:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: myprimaryreger@gmail.com (MISP Attribute #16060)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: myprimaryreger@gmail.com (MISP Attribute #16060)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5926f504-a840-4d0e-8d26-5d828e96ca05">
-                                        <cybox:Object id=":EmailMessage-5926f504-a840-4d0e-8d26-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5926f504-a840-4d0e-8d26-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-5926f504-a840-4d0e-8d26-5d828e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">

--- a/201706_RecklessExploit/stix.xml
+++ b/201706_RecklessExploit/stix.xml
@@ -58,20 +58,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-1107ab14-42a8-4bff-b35b-c8444bb86797" version="1.1.1" timestamp="2017-06-26T17:32:11.167418+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-1107ab14-42a8-4bff-b35b-c8444bb86797" version="1.1.1" timestamp="2017-06-26T17:32:11.167418+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-59513ebe-4144-4e2d-8670-06b38e96ca05" version="1.1.1" timestamp="2017-06-26T13:23:58+00:00">
+            <stix:Package id="citizenlab:STIXPackage-59513ebe-4144-4e2d-8670-06b38e96ca05" version="1.1.1" timestamp="2017-06-26T13:23:58+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Reckless Exploit: Mexican Journalists, Lawyers, and a Child Targeted with NSO Spyware (MISP Event #104)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-59513ebe-4144-4e2d-8670-06b38e96ca05" timestamp="2017-06-26T13:30:22+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-59513ebe-4144-4e2d-8670-06b38e96ca05" timestamp="2017-06-26T13:30:22+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Reckless Exploit: Mexican Journalists, Lawyers, and a Child Targeted with NSO Spyware</incident:Title>
                         <incident:External_ID source="MISP Event">104</incident:External_ID>
                         <incident:Time>
@@ -82,14 +82,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>External analysis</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5951432e-a3f8-4510-b5ba-06b28e96ca05" timestamp="2017-06-26T13:23:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5951432e-a3f8-4510-b5ba-06b28e96ca05" timestamp="2017-06-26T13:23:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>External analysis: https://citizenlab.org/2017/06/reckless-exploit-mexico-nso/ (MISP Attribute #16322)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>External analysis: https://citizenlab.org/2017/06/reckless-exploit-mexico-nso/ (MISP Attribute #16322)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5951432e-a3f8-4510-b5ba-06b28e96ca05">
-                                        <cybox:Object id=":URI-5951432e-a3f8-4510-b5ba-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5951432e-a3f8-4510-b5ba-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-5951432e-a3f8-4510-b5ba-06b28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://citizenlab.org/2017/06/reckless-exploit-mexico-nso/</URIObj:Value>
                                             </cybox:Properties>
@@ -103,14 +103,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595140b9-a2cc-4642-be72-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595140b9-a2cc-4642-be72-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ideas-telcel.com.mx (MISP Attribute #16155)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ideas-telcel.com.mx (MISP Attribute #16155)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595140b9-a2cc-4642-be72-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-595140b9-a2cc-4642-be72-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595140b9-a2cc-4642-be72-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595140b9-a2cc-4642-be72-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ideas-telcel.com.mx</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -124,14 +124,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595140b9-6d24-4529-b5cb-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595140b9-6d24-4529-b5cb-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: iusacell-movil.com.mx (MISP Attribute #16156)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: iusacell-movil.com.mx (MISP Attribute #16156)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595140b9-6d24-4529-b5cb-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-595140b9-6d24-4529-b5cb-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595140b9-6d24-4529-b5cb-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595140b9-6d24-4529-b5cb-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">iusacell-movil.com.mx</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -145,14 +145,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595140b9-ea38-4167-af75-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595140b9-ea38-4167-af75-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mymensaje-sms.com (MISP Attribute #16157)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mymensaje-sms.com (MISP Attribute #16157)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595140b9-ea38-4167-af75-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-595140b9-ea38-4167-af75-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595140b9-ea38-4167-af75-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595140b9-ea38-4167-af75-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mymensaje-sms.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -166,14 +166,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595140b9-fee0-42c2-abc9-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595140b9-fee0-42c2-abc9-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: network190.com (MISP Attribute #16158)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: network190.com (MISP Attribute #16158)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595140b9-fee0-42c2-abc9-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-595140b9-fee0-42c2-abc9-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595140b9-fee0-42c2-abc9-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595140b9-fee0-42c2-abc9-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">network190.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -187,14 +187,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595140b9-8bf0-466f-a633-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595140b9-8bf0-466f-a633-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: secure-access10.mx (MISP Attribute #16159)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: secure-access10.mx (MISP Attribute #16159)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595140b9-8bf0-466f-a633-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-595140b9-8bf0-466f-a633-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595140b9-8bf0-466f-a633-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595140b9-8bf0-466f-a633-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">secure-access10.mx</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -208,14 +208,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595140b9-7ac8-4ae1-84ac-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595140b9-7ac8-4ae1-84ac-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: smscentro.com (MISP Attribute #16160)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: smscentro.com (MISP Attribute #16160)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595140b9-7ac8-4ae1-84ac-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-595140b9-7ac8-4ae1-84ac-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595140b9-7ac8-4ae1-84ac-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595140b9-7ac8-4ae1-84ac-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">smscentro.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -229,14 +229,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595140b9-bf04-4011-a222-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595140b9-bf04-4011-a222-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: smsmensaje.mx (MISP Attribute #16161)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: smsmensaje.mx (MISP Attribute #16161)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595140b9-bf04-4011-a222-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-595140b9-bf04-4011-a222-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595140b9-bf04-4011-a222-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595140b9-bf04-4011-a222-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">smsmensaje.mx</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -250,14 +250,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595140b9-7ed4-48c2-ad5b-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595140b9-7ed4-48c2-ad5b-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: twiitter.com.mx (MISP Attribute #16162)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: twiitter.com.mx (MISP Attribute #16162)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595140b9-7ed4-48c2-ad5b-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-595140b9-7ed4-48c2-ad5b-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595140b9-7ed4-48c2-ad5b-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595140b9-7ed4-48c2-ad5b-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">twiitter.com.mx</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -271,14 +271,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595140b9-d344-4943-8ee8-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595140b9-d344-4943-8ee8-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: unonoticias.net (MISP Attribute #16163)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: unonoticias.net (MISP Attribute #16163)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595140b9-d344-4943-8ee8-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-595140b9-d344-4943-8ee8-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595140b9-d344-4943-8ee8-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595140b9-d344-4943-8ee8-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">unonoticias.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -292,14 +292,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595140b9-fdf8-4877-ae89-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595140b9-fdf8-4877-ae89-06b28e96ca05" timestamp="2017-06-26T13:13:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fb-accounts.com (MISP Attribute #16164)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fb-accounts.com (MISP Attribute #16164)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595140b9-fdf8-4877-ae89-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-595140b9-fdf8-4877-ae89-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595140b9-fdf8-4877-ae89-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595140b9-fdf8-4877-ae89-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fb-accounts.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -313,14 +313,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-1a9c-4657-9043-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-1a9c-4657-9043-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1EQYOkG (MISP Attribute #16207)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1EQYOkG (MISP Attribute #16207)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-1a9c-4657-9043-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-1a9c-4657-9043-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-1a9c-4657-9043-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-1a9c-4657-9043-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1EQYOkG</URIObj:Value>
                                             </cybox:Properties>
@@ -334,14 +334,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-2608-4458-8a3a-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-2608-4458-8a3a-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1hMG15k (MISP Attribute #16208)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1hMG15k (MISP Attribute #16208)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-2608-4458-8a3a-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-2608-4458-8a3a-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-2608-4458-8a3a-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-2608-4458-8a3a-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1hMG15k</URIObj:Value>
                                             </cybox:Properties>
@@ -355,14 +355,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-77b0-4fc8-9cb0-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-77b0-4fc8-9cb0-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1JDkjuX (MISP Attribute #16209)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1JDkjuX (MISP Attribute #16209)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-77b0-4fc8-9cb0-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-77b0-4fc8-9cb0-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-77b0-4fc8-9cb0-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-77b0-4fc8-9cb0-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1JDkjuX</URIObj:Value>
                                             </cybox:Properties>
@@ -376,14 +376,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-10ec-4896-8197-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-10ec-4896-8197-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1JW0JFQ (MISP Attribute #16210)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1JW0JFQ (MISP Attribute #16210)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-10ec-4896-8197-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-10ec-4896-8197-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-10ec-4896-8197-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-10ec-4896-8197-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1JW0JFQ</URIObj:Value>
                                             </cybox:Properties>
@@ -397,14 +397,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-d470-4103-b354-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-d470-4103-b354-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1JzfmW1 (MISP Attribute #16211)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1JzfmW1 (MISP Attribute #16211)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-d470-4103-b354-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-d470-4103-b354-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-d470-4103-b354-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-d470-4103-b354-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1JzfmW1</URIObj:Value>
                                             </cybox:Properties>
@@ -418,14 +418,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-fca8-4841-b6e5-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-fca8-4841-b6e5-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1KDekJ9 (MISP Attribute #16212)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1KDekJ9 (MISP Attribute #16212)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-fca8-4841-b6e5-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-fca8-4841-b6e5-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-fca8-4841-b6e5-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-fca8-4841-b6e5-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1KDekJ9</URIObj:Value>
                                             </cybox:Properties>
@@ -439,14 +439,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-1ce8-4723-a8a7-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-1ce8-4723-a8a7-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1KufGUy (MISP Attribute #16213)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1KufGUy (MISP Attribute #16213)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-1ce8-4723-a8a7-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-1ce8-4723-a8a7-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-1ce8-4723-a8a7-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-1ce8-4723-a8a7-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1KufGUy</URIObj:Value>
                                             </cybox:Properties>
@@ -460,14 +460,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-5dac-47dc-81f3-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-5dac-47dc-81f3-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1LLY8oK (MISP Attribute #16214)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1LLY8oK (MISP Attribute #16214)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-5dac-47dc-81f3-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-5dac-47dc-81f3-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-5dac-47dc-81f3-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-5dac-47dc-81f3-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1LLY8oK</URIObj:Value>
                                             </cybox:Properties>
@@ -481,14 +481,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-e484-4c67-bb23-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-e484-4c67-bb23-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1LLYT15 (MISP Attribute #16215)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1LLYT15 (MISP Attribute #16215)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-e484-4c67-bb23-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-e484-4c67-bb23-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-e484-4c67-bb23-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-e484-4c67-bb23-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1LLYT15</URIObj:Value>
                                             </cybox:Properties>
@@ -502,14 +502,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-0754-4b53-a851-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-0754-4b53-a851-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1MAAWrO (MISP Attribute #16216)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1MAAWrO (MISP Attribute #16216)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-0754-4b53-a851-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-0754-4b53-a851-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-0754-4b53-a851-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-0754-4b53-a851-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1MAAWrO</URIObj:Value>
                                             </cybox:Properties>
@@ -523,14 +523,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-752c-4355-a7ca-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-752c-4355-a7ca-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1MAzTZ7 (MISP Attribute #16217)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1MAzTZ7 (MISP Attribute #16217)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-752c-4355-a7ca-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-752c-4355-a7ca-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-752c-4355-a7ca-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-752c-4355-a7ca-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1MAzTZ7</URIObj:Value>
                                             </cybox:Properties>
@@ -544,14 +544,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-7858-4579-a385-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-7858-4579-a385-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1NlM0ME (MISP Attribute #16218)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1NlM0ME (MISP Attribute #16218)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-7858-4579-a385-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-7858-4579-a385-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-7858-4579-a385-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-7858-4579-a385-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1NlM0ME</URIObj:Value>
                                             </cybox:Properties>
@@ -565,14 +565,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-2514-421a-86f7-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-2514-421a-86f7-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1Nr0Vpb (MISP Attribute #16219)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1Nr0Vpb (MISP Attribute #16219)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-2514-421a-86f7-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-2514-421a-86f7-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-2514-421a-86f7-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-2514-421a-86f7-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1Nr0Vpb</URIObj:Value>
                                             </cybox:Properties>
@@ -586,14 +586,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-1198-4ef7-89ab-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-1198-4ef7-89ab-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1Nz2RZe (MISP Attribute #16220)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1Nz2RZe (MISP Attribute #16220)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-1198-4ef7-89ab-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-1198-4ef7-89ab-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-1198-4ef7-89ab-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-1198-4ef7-89ab-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1Nz2RZe</URIObj:Value>
                                             </cybox:Properties>
@@ -607,14 +607,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-93c0-4169-828c-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-93c0-4169-828c-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1NzkyeZ (MISP Attribute #16221)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1NzkyeZ (MISP Attribute #16221)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-93c0-4169-828c-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-93c0-4169-828c-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-93c0-4169-828c-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-93c0-4169-828c-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1NzkyeZ</URIObj:Value>
                                             </cybox:Properties>
@@ -628,14 +628,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-9750-4b3f-822b-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-9750-4b3f-822b-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1O77vPb (MISP Attribute #16222)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1O77vPb (MISP Attribute #16222)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-9750-4b3f-822b-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-9750-4b3f-822b-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-9750-4b3f-822b-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-9750-4b3f-822b-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1O77vPb</URIObj:Value>
                                             </cybox:Properties>
@@ -649,14 +649,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-48bc-4d2b-a43d-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-48bc-4d2b-a43d-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1QbgONr (MISP Attribute #16223)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1QbgONr (MISP Attribute #16223)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-48bc-4d2b-a43d-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-48bc-4d2b-a43d-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-48bc-4d2b-a43d-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-48bc-4d2b-a43d-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1QbgONr</URIObj:Value>
                                             </cybox:Properties>
@@ -670,14 +670,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-4c4c-484b-b316-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-4c4c-484b-b316-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1QYVJU9 (MISP Attribute #16224)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1QYVJU9 (MISP Attribute #16224)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-4c4c-484b-b316-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-4c4c-484b-b316-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-4c4c-484b-b316-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-4c4c-484b-b316-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1QYVJU9</URIObj:Value>
                                             </cybox:Properties>
@@ -691,14 +691,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-fe1c-4872-a3fd-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-fe1c-4872-a3fd-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1s2eguc (MISP Attribute #16225)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1s2eguc (MISP Attribute #16225)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-fe1c-4872-a3fd-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-fe1c-4872-a3fd-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-fe1c-4872-a3fd-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-fe1c-4872-a3fd-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1s2eguc</URIObj:Value>
                                             </cybox:Properties>
@@ -712,14 +712,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-e780-479f-af9e-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-e780-479f-af9e-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1SU5N7q (MISP Attribute #16226)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1SU5N7q (MISP Attribute #16226)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-e780-479f-af9e-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-e780-479f-af9e-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-e780-479f-af9e-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-e780-479f-af9e-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1SU5N7q</URIObj:Value>
                                             </cybox:Properties>
@@ -733,14 +733,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-3fc4-49a7-a84a-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-3fc4-49a7-a84a-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1TTjm6D (MISP Attribute #16227)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1TTjm6D (MISP Attribute #16227)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-3fc4-49a7-a84a-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-3fc4-49a7-a84a-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-3fc4-49a7-a84a-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-3fc4-49a7-a84a-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1TTjm6D</URIObj:Value>
                                             </cybox:Properties>
@@ -754,14 +754,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-17e0-4953-ae3e-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-17e0-4953-ae3e-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1twXSDl (MISP Attribute #16228)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1twXSDl (MISP Attribute #16228)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-17e0-4953-ae3e-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-17e0-4953-ae3e-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-17e0-4953-ae3e-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-17e0-4953-ae3e-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1twXSDl</URIObj:Value>
                                             </cybox:Properties>
@@ -775,14 +775,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-136c-40a3-bf90-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-136c-40a3-bf90-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1U0yzVG (MISP Attribute #16229)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1U0yzVG (MISP Attribute #16229)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-136c-40a3-bf90-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-136c-40a3-bf90-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-136c-40a3-bf90-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-136c-40a3-bf90-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1U0yzVG</URIObj:Value>
                                             </cybox:Properties>
@@ -796,14 +796,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-e0e8-4d3d-a2f5-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-e0e8-4d3d-a2f5-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1Wzryvp (MISP Attribute #16230)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1Wzryvp (MISP Attribute #16230)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-e0e8-4d3d-a2f5-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-e0e8-4d3d-a2f5-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-e0e8-4d3d-a2f5-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-e0e8-4d3d-a2f5-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1Wzryvp</URIObj:Value>
                                             </cybox:Properties>
@@ -817,14 +817,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-4d6c-4191-96dd-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-4d6c-4191-96dd-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1WzrZ8T (MISP Attribute #16231)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1WzrZ8T (MISP Attribute #16231)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-4d6c-4191-96dd-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-4d6c-4191-96dd-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-4d6c-4191-96dd-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-4d6c-4191-96dd-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1WzrZ8T</URIObj:Value>
                                             </cybox:Properties>
@@ -838,14 +838,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ad-5060-4c84-b0e5-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ad-5060-4c84-b0e5-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1X9kJRJ (MISP Attribute #16232)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1X9kJRJ (MISP Attribute #16232)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ad-5060-4c84-b0e5-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ad-5060-4c84-b0e5-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ad-5060-4c84-b0e5-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ad-5060-4c84-b0e5-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1X9kJRJ</URIObj:Value>
                                             </cybox:Properties>
@@ -859,14 +859,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-c9ec-4d6b-aeb1-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-c9ec-4d6b-aeb1-06b38e96ca05" timestamp="2017-06-26T13:17:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1XFaS4F (MISP Attribute #16233)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1XFaS4F (MISP Attribute #16233)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-c9ec-4d6b-aeb1-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-c9ec-4d6b-aeb1-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-c9ec-4d6b-aeb1-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-c9ec-4d6b-aeb1-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1XFaS4F</URIObj:Value>
                                             </cybox:Properties>
@@ -880,14 +880,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-8e00-41c6-825e-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-8e00-41c6-825e-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1Xxf32k (MISP Attribute #16234)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1Xxf32k (MISP Attribute #16234)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-8e00-41c6-825e-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-8e00-41c6-825e-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-8e00-41c6-825e-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-8e00-41c6-825e-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1Xxf32k</URIObj:Value>
                                             </cybox:Properties>
@@ -901,14 +901,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-8354-4c49-b7a1-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-8354-4c49-b7a1-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/1z2NQdh (MISP Attribute #16235)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/1z2NQdh (MISP Attribute #16235)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-8354-4c49-b7a1-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-8354-4c49-b7a1-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-8354-4c49-b7a1-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-8354-4c49-b7a1-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1z2NQdh</URIObj:Value>
                                             </cybox:Properties>
@@ -922,14 +922,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-c494-4b9b-9676-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-c494-4b9b-9676-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/20Y9r10 (MISP Attribute #16236)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/20Y9r10 (MISP Attribute #16236)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-c494-4b9b-9676-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-c494-4b9b-9676-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-c494-4b9b-9676-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-c494-4b9b-9676-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/20Y9r10</URIObj:Value>
                                             </cybox:Properties>
@@ -943,14 +943,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-215c-4101-bdc5-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-215c-4101-bdc5-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/235giae (MISP Attribute #16237)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/235giae (MISP Attribute #16237)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-215c-4101-bdc5-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-215c-4101-bdc5-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-215c-4101-bdc5-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-215c-4101-bdc5-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/235giae</URIObj:Value>
                                             </cybox:Properties>
@@ -964,14 +964,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-7874-44b6-8638-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-7874-44b6-8638-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/246dkRy (MISP Attribute #16238)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/246dkRy (MISP Attribute #16238)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-7874-44b6-8638-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-7874-44b6-8638-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-7874-44b6-8638-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-7874-44b6-8638-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/246dkRy</URIObj:Value>
                                             </cybox:Properties>
@@ -985,14 +985,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-7660-4301-91cd-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-7660-4301-91cd-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/246doke (MISP Attribute #16239)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/246doke (MISP Attribute #16239)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-7660-4301-91cd-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-7660-4301-91cd-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-7660-4301-91cd-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-7660-4301-91cd-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/246doke</URIObj:Value>
                                             </cybox:Properties>
@@ -1006,14 +1006,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-f278-41ad-9e79-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-f278-41ad-9e79-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/25nmH1O (MISP Attribute #16240)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/25nmH1O (MISP Attribute #16240)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-f278-41ad-9e79-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-f278-41ad-9e79-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-f278-41ad-9e79-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-f278-41ad-9e79-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/25nmH1O</URIObj:Value>
                                             </cybox:Properties>
@@ -1027,14 +1027,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-2e38-4e91-a008-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-2e38-4e91-a008-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/292heXd (MISP Attribute #16241)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/292heXd (MISP Attribute #16241)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-2e38-4e91-a008-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-2e38-4e91-a008-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-2e38-4e91-a008-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-2e38-4e91-a008-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/292heXd</URIObj:Value>
                                             </cybox:Properties>
@@ -1048,14 +1048,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-e8f4-4c6b-9571-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-e8f4-4c6b-9571-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/295RmfH (MISP Attribute #16242)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/295RmfH (MISP Attribute #16242)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-e8f4-4c6b-9571-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-e8f4-4c6b-9571-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-e8f4-4c6b-9571-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-e8f4-4c6b-9571-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/295RmfH</URIObj:Value>
                                             </cybox:Properties>
@@ -1069,14 +1069,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-f250-4615-b9cd-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-f250-4615-b9cd-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/295RNq7 (MISP Attribute #16243)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/295RNq7 (MISP Attribute #16243)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-f250-4615-b9cd-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-f250-4615-b9cd-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-f250-4615-b9cd-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-f250-4615-b9cd-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/295RNq7</URIObj:Value>
                                             </cybox:Properties>
@@ -1090,14 +1090,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-83d4-45e0-960e-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-83d4-45e0-960e-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/29eWFqz (MISP Attribute #16244)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/29eWFqz (MISP Attribute #16244)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-83d4-45e0-960e-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-83d4-45e0-960e-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-83d4-45e0-960e-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-83d4-45e0-960e-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/29eWFqz</URIObj:Value>
                                             </cybox:Properties>
@@ -1111,14 +1111,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-4be8-45c9-b2dc-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-4be8-45c9-b2dc-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/29eWzzv (MISP Attribute #16245)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/29eWzzv (MISP Attribute #16245)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-4be8-45c9-b2dc-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-4be8-45c9-b2dc-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-4be8-45c9-b2dc-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-4be8-45c9-b2dc-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/29eWzzv</URIObj:Value>
                                             </cybox:Properties>
@@ -1132,14 +1132,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-d118-4cfe-a0a4-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-d118-4cfe-a0a4-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/29LfZfD (MISP Attribute #16246)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/29LfZfD (MISP Attribute #16246)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-d118-4cfe-a0a4-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-d118-4cfe-a0a4-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-d118-4cfe-a0a4-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-d118-4cfe-a0a4-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/29LfZfD</URIObj:Value>
                                             </cybox:Properties>
@@ -1153,14 +1153,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-b058-4eb5-bb7b-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-b058-4eb5-bb7b-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/29lQvyh (MISP Attribute #16247)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/29lQvyh (MISP Attribute #16247)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-b058-4eb5-bb7b-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-b058-4eb5-bb7b-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-b058-4eb5-bb7b-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-b058-4eb5-bb7b-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/29lQvyh</URIObj:Value>
                                             </cybox:Properties>
@@ -1174,14 +1174,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-8ca4-46f9-8c33-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-8ca4-46f9-8c33-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://bit.ly/2a0hZ2l (MISP Attribute #16248)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://bit.ly/2a0hZ2l (MISP Attribute #16248)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-8ca4-46f9-8c33-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-8ca4-46f9-8c33-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-8ca4-46f9-8c33-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-8ca4-46f9-8c33-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2a0hZ2l</URIObj:Value>
                                             </cybox:Properties>
@@ -1195,14 +1195,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-efbc-487e-ae1a-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-efbc-487e-ae1a-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://fb-accounts.com/1074139s/ (MISP Attribute #16249)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://fb-accounts.com/1074139s/ (MISP Attribute #16249)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-efbc-487e-ae1a-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-efbc-487e-ae1a-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-efbc-487e-ae1a-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-efbc-487e-ae1a-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://fb-accounts.com/1074139s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1216,14 +1216,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-a384-43c4-ae80-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-a384-43c4-ae80-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://fb-accounts.com/2069487s/ (MISP Attribute #16250)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://fb-accounts.com/2069487s/ (MISP Attribute #16250)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-a384-43c4-ae80-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-a384-43c4-ae80-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-a384-43c4-ae80-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-a384-43c4-ae80-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://fb-accounts.com/2069487s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1237,14 +1237,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-b48c-4a93-9163-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-b48c-4a93-9163-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://ideas-telcel.com.mx/1930327s (MISP Attribute #16251)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://ideas-telcel.com.mx/1930327s (MISP Attribute #16251)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-b48c-4a93-9163-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-b48c-4a93-9163-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-b48c-4a93-9163-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-b48c-4a93-9163-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://ideas-telcel.com.mx/1930327s</URIObj:Value>
                                             </cybox:Properties>
@@ -1258,14 +1258,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-d21c-4e4e-94b8-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-d21c-4e4e-94b8-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://ideas-telcel.com.mx/2110126s/ (MISP Attribute #16252)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://ideas-telcel.com.mx/2110126s/ (MISP Attribute #16252)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-d21c-4e4e-94b8-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-d21c-4e4e-94b8-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-d21c-4e4e-94b8-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-d21c-4e4e-94b8-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://ideas-telcel.com.mx/2110126s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1279,14 +1279,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-4944-4ad9-a7af-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-4944-4ad9-a7af-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://ideas-telcel.com.mx/7757294s (MISP Attribute #16253)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://ideas-telcel.com.mx/7757294s (MISP Attribute #16253)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-4944-4ad9-a7af-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-4944-4ad9-a7af-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-4944-4ad9-a7af-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-4944-4ad9-a7af-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://ideas-telcel.com.mx/7757294s</URIObj:Value>
                                             </cybox:Properties>
@@ -1300,14 +1300,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-ea14-4684-adb1-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-ea14-4684-adb1-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://iusacell-movil.com.mx/7918310s/ (MISP Attribute #16254)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://iusacell-movil.com.mx/7918310s/ (MISP Attribute #16254)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-ea14-4684-adb1-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-ea14-4684-adb1-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-ea14-4684-adb1-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-ea14-4684-adb1-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://iusacell-movil.com.mx/7918310s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1321,14 +1321,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-f220-4bee-9df4-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-f220-4bee-9df4-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://iusacell-movil.com.mx/8595070s/ (MISP Attribute #16255)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://iusacell-movil.com.mx/8595070s/ (MISP Attribute #16255)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-f220-4bee-9df4-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-f220-4bee-9df4-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-f220-4bee-9df4-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-f220-4bee-9df4-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://iusacell-movil.com.mx/8595070s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1342,14 +1342,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-3e2c-443b-ad7b-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-3e2c-443b-ad7b-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://mymensaje-sms.com/6649365s/ (MISP Attribute #16256)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://mymensaje-sms.com/6649365s/ (MISP Attribute #16256)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-3e2c-443b-ad7b-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-3e2c-443b-ad7b-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-3e2c-443b-ad7b-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-3e2c-443b-ad7b-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://mymensaje-sms.com/6649365s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1363,14 +1363,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-909c-4d8d-948a-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-909c-4d8d-948a-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://fb-accounts.com/2408931s (MISP Attribute #16257)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://fb-accounts.com/2408931s (MISP Attribute #16257)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-909c-4d8d-948a-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-909c-4d8d-948a-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-909c-4d8d-948a-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-909c-4d8d-948a-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://fb-accounts.com/2408931s</URIObj:Value>
                                             </cybox:Properties>
@@ -1384,14 +1384,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-fba4-4030-9c61-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-fba4-4030-9c61-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://ideas-telcel.com.mx/3975827s (MISP Attribute #16258)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://ideas-telcel.com.mx/3975827s (MISP Attribute #16258)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-fba4-4030-9c61-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-fba4-4030-9c61-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-fba4-4030-9c61-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-fba4-4030-9c61-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://ideas-telcel.com.mx/3975827s</URIObj:Value>
                                             </cybox:Properties>
@@ -1405,14 +1405,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-738c-4135-aa6c-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-738c-4135-aa6c-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://ideas-telcel.com.mx/5706662s (MISP Attribute #16259)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://ideas-telcel.com.mx/5706662s (MISP Attribute #16259)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-738c-4135-aa6c-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-738c-4135-aa6c-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-738c-4135-aa6c-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-738c-4135-aa6c-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://ideas-telcel.com.mx/5706662s</URIObj:Value>
                                             </cybox:Properties>
@@ -1426,14 +1426,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-b9e0-4327-aa26-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-b9e0-4327-aa26-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smscentro.com/9480260s/ (MISP Attribute #16260)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smscentro.com/9480260s/ (MISP Attribute #16260)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-b9e0-4327-aa26-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-b9e0-4327-aa26-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-b9e0-4327-aa26-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-b9e0-4327-aa26-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smscentro.com/9480260s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1447,14 +1447,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-24ec-488e-b0e8-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-24ec-488e-b0e8-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/1239663s/ (MISP Attribute #16261)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/1239663s/ (MISP Attribute #16261)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-24ec-488e-b0e8-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-24ec-488e-b0e8-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-24ec-488e-b0e8-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-24ec-488e-b0e8-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/1239663s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1468,14 +1468,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-593c-49e2-b5e2-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-593c-49e2-b5e2-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/1331744s/ (MISP Attribute #16262)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/1331744s/ (MISP Attribute #16262)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-593c-49e2-b5e2-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-593c-49e2-b5e2-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-593c-49e2-b5e2-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-593c-49e2-b5e2-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/1331744s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1489,14 +1489,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-e034-48d6-83cf-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-e034-48d6-83cf-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/1493024s/ (MISP Attribute #16263)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/1493024s/ (MISP Attribute #16263)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-e034-48d6-83cf-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-e034-48d6-83cf-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-e034-48d6-83cf-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-e034-48d6-83cf-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/1493024s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1510,14 +1510,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-0cb8-4da3-9788-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-0cb8-4da3-9788-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/1656017s/ (MISP Attribute #16264)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/1656017s/ (MISP Attribute #16264)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-0cb8-4da3-9788-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-0cb8-4da3-9788-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-0cb8-4da3-9788-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-0cb8-4da3-9788-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/1656017s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1531,14 +1531,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-e150-4ab5-93d5-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-e150-4ab5-93d5-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/1911343s/ (MISP Attribute #16265)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/1911343s/ (MISP Attribute #16265)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-e150-4ab5-93d5-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-e150-4ab5-93d5-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-e150-4ab5-93d5-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-e150-4ab5-93d5-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/1911343s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1552,14 +1552,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-4dc4-4d20-9726-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-4dc4-4d20-9726-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/3376811s/ (MISP Attribute #16266)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/3376811s/ (MISP Attribute #16266)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-4dc4-4d20-9726-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-4dc4-4d20-9726-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-4dc4-4d20-9726-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-4dc4-4d20-9726-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/3376811s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1573,14 +1573,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-b384-4fc8-9951-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-b384-4fc8-9951-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/3990495s/ (MISP Attribute #16267)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/3990495s/ (MISP Attribute #16267)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-b384-4fc8-9951-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-b384-4fc8-9951-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-b384-4fc8-9951-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-b384-4fc8-9951-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/3990495s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1594,14 +1594,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-0dbc-485c-9516-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-0dbc-485c-9516-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/5957475s/ (MISP Attribute #16268)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/5957475s/ (MISP Attribute #16268)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-0dbc-485c-9516-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-0dbc-485c-9516-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-0dbc-485c-9516-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-0dbc-485c-9516-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/5957475s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1615,14 +1615,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-f4f4-4f6d-9dbe-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-f4f4-4f6d-9dbe-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/6056487s/ (MISP Attribute #16269)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/6056487s/ (MISP Attribute #16269)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-f4f4-4f6d-9dbe-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-f4f4-4f6d-9dbe-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-f4f4-4f6d-9dbe-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-f4f4-4f6d-9dbe-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/6056487s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1636,14 +1636,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-e008-472d-9d03-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-e008-472d-9d03-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/6445761s/ (MISP Attribute #16270)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/6445761s/ (MISP Attribute #16270)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-e008-472d-9d03-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-e008-472d-9d03-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-e008-472d-9d03-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-e008-472d-9d03-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/6445761s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1657,14 +1657,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-b69c-4aaf-a217-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-b69c-4aaf-a217-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/6881768s/ (MISP Attribute #16271)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/6881768s/ (MISP Attribute #16271)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-b69c-4aaf-a217-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-b69c-4aaf-a217-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-b69c-4aaf-a217-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-b69c-4aaf-a217-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/6881768s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1678,14 +1678,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-7040-450e-97c7-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-7040-450e-97c7-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/9093723s/ (MISP Attribute #16272)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/9093723s/ (MISP Attribute #16272)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-7040-450e-97c7-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-7040-450e-97c7-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-7040-450e-97c7-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-7040-450e-97c7-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/9093723s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1699,14 +1699,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-1af0-4d3a-be93-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-1af0-4d3a-be93-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/9371877s/ (MISP Attribute #16273)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/9371877s/ (MISP Attribute #16273)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-1af0-4d3a-be93-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-1af0-4d3a-be93-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-1af0-4d3a-be93-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-1af0-4d3a-be93-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/9371877s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1720,14 +1720,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-6aa4-4e7f-a9b3-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-6aa4-4e7f-a9b3-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/9439115s/ (MISP Attribute #16274)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/9439115s/ (MISP Attribute #16274)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-6aa4-4e7f-a9b3-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-6aa4-4e7f-a9b3-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-6aa4-4e7f-a9b3-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-6aa4-4e7f-a9b3-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/9439115s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1741,14 +1741,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-929c-4c73-b5ae-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-929c-4c73-b5ae-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/9936510s/ (MISP Attribute #16275)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/9936510s/ (MISP Attribute #16275)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-929c-4c73-b5ae-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-929c-4c73-b5ae-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-929c-4c73-b5ae-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-929c-4c73-b5ae-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/9936510s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1762,14 +1762,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-4aa8-4962-986c-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-4aa8-4962-986c-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://smsmensaje.mx/[unavailable] (MISP Attribute #16276)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://smsmensaje.mx/[unavailable] (MISP Attribute #16276)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-4aa8-4962-986c-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-4aa8-4962-986c-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-4aa8-4962-986c-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-4aa8-4962-986c-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://smsmensaje.mx/[unavailable]</URIObj:Value>
                                             </cybox:Properties>
@@ -1783,14 +1783,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-74b0-4be5-be10-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-74b0-4be5-be10-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://network190.com/2066781s/ (MISP Attribute #16277)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://network190.com/2066781s/ (MISP Attribute #16277)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-74b0-4be5-be10-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-74b0-4be5-be10-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-74b0-4be5-be10-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-74b0-4be5-be10-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://network190.com/2066781s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1804,14 +1804,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-82a0-4fed-acdc-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-82a0-4fed-acdc-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://network190.com/6214010s/ (MISP Attribute #16278)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://network190.com/6214010s/ (MISP Attribute #16278)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-82a0-4fed-acdc-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-82a0-4fed-acdc-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-82a0-4fed-acdc-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-82a0-4fed-acdc-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://network190.com/6214010s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1825,14 +1825,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-191c-4dad-a8df-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-191c-4dad-a8df-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://network190.com/8361397s/ (MISP Attribute #16279)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://network190.com/8361397s/ (MISP Attribute #16279)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-191c-4dad-a8df-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-191c-4dad-a8df-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-191c-4dad-a8df-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-191c-4dad-a8df-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://network190.com/8361397s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1846,14 +1846,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-eba4-4d12-bc80-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-eba4-4d12-bc80-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://secure-access10.mx/2618844s/ (MISP Attribute #16280)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://secure-access10.mx/2618844s/ (MISP Attribute #16280)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-eba4-4d12-bc80-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-eba4-4d12-bc80-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-eba4-4d12-bc80-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-eba4-4d12-bc80-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://secure-access10.mx/2618844s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1867,14 +1867,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-cbe0-4757-a1a6-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-cbe0-4757-a1a6-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://secure-access10.mx/4257391s/ (MISP Attribute #16281)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://secure-access10.mx/4257391s/ (MISP Attribute #16281)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-cbe0-4757-a1a6-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-cbe0-4757-a1a6-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-cbe0-4757-a1a6-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-cbe0-4757-a1a6-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://secure-access10.mx/4257391s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1888,14 +1888,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-b0cc-46ad-8fda-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-b0cc-46ad-8fda-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://secure-access10.mx/7161504s/ (MISP Attribute #16282)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://secure-access10.mx/7161504s/ (MISP Attribute #16282)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-b0cc-46ad-8fda-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-b0cc-46ad-8fda-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-b0cc-46ad-8fda-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-b0cc-46ad-8fda-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://secure-access10.mx/7161504s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1909,14 +1909,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-21ac-41b9-956c-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-21ac-41b9-956c-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/2683786s/ (MISP Attribute #16283)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/2683786s/ (MISP Attribute #16283)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-21ac-41b9-956c-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-21ac-41b9-956c-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-21ac-41b9-956c-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-21ac-41b9-956c-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/2683786s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1930,14 +1930,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-6b6c-4675-b743-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-6b6c-4675-b743-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/4494681s/ (MISP Attribute #16284)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/4494681s/ (MISP Attribute #16284)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-6b6c-4675-b743-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-6b6c-4675-b743-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-6b6c-4675-b743-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-6b6c-4675-b743-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/4494681s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1951,14 +1951,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-2bf8-4f1d-8ed0-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-2bf8-4f1d-8ed0-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/4667624s/ (MISP Attribute #16285)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/4667624s/ (MISP Attribute #16285)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-2bf8-4f1d-8ed0-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-2bf8-4f1d-8ed0-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-2bf8-4f1d-8ed0-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-2bf8-4f1d-8ed0-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/4667624s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1972,14 +1972,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-4054-47ba-b479-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-4054-47ba-b479-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/4878494s/ (MISP Attribute #16286)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/4878494s/ (MISP Attribute #16286)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-4054-47ba-b479-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-4054-47ba-b479-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-4054-47ba-b479-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-4054-47ba-b479-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/4878494s/</URIObj:Value>
                                             </cybox:Properties>
@@ -1993,14 +1993,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-d08c-48ca-bd09-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-d08c-48ca-bd09-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/5478753s/ (MISP Attribute #16287)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/5478753s/ (MISP Attribute #16287)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-d08c-48ca-bd09-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-d08c-48ca-bd09-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-d08c-48ca-bd09-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-d08c-48ca-bd09-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/5478753s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2014,14 +2014,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-da5c-42a8-aea5-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-da5c-42a8-aea5-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/5732641s/ (MISP Attribute #16288)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/5732641s/ (MISP Attribute #16288)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-da5c-42a8-aea5-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-da5c-42a8-aea5-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-da5c-42a8-aea5-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-da5c-42a8-aea5-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/5732641s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2035,14 +2035,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-6cec-4bb8-b0ec-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-6cec-4bb8-b0ec-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/5840625s/ (MISP Attribute #16289)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/5840625s/ (MISP Attribute #16289)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-6cec-4bb8-b0ec-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-6cec-4bb8-b0ec-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-6cec-4bb8-b0ec-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-6cec-4bb8-b0ec-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/5840625s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2056,14 +2056,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-5650-454d-b04a-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-5650-454d-b04a-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/7831163s/ (MISP Attribute #16290)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/7831163s/ (MISP Attribute #16290)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-5650-454d-b04a-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-5650-454d-b04a-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-5650-454d-b04a-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-5650-454d-b04a-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/7831163s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2077,14 +2077,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-f498-4f27-bb20-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-f498-4f27-bb20-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/7893029s/ (MISP Attribute #16291)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/7893029s/ (MISP Attribute #16291)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-f498-4f27-bb20-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-f498-4f27-bb20-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-f498-4f27-bb20-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-f498-4f27-bb20-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/7893029s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2098,14 +2098,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-fa1c-4757-8946-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-fa1c-4757-8946-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/8435662s/ (MISP Attribute #16292)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/8435662s/ (MISP Attribute #16292)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-fa1c-4757-8946-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-fa1c-4757-8946-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-fa1c-4757-8946-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-fa1c-4757-8946-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/8435662s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2119,14 +2119,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-9418-41e9-aecc-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-9418-41e9-aecc-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://smsmensaje.mx/8643330s/ (MISP Attribute #16293)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://smsmensaje.mx/8643330s/ (MISP Attribute #16293)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-9418-41e9-aecc-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-9418-41e9-aecc-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-9418-41e9-aecc-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-9418-41e9-aecc-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/8643330s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2140,14 +2140,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-a298-4139-a48b-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-a298-4139-a48b-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/1214510s/ (MISP Attribute #16294)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/1214510s/ (MISP Attribute #16294)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-a298-4139-a48b-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-a298-4139-a48b-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-a298-4139-a48b-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-a298-4139-a48b-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/1214510s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2161,14 +2161,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141ae-420c-4615-b723-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141ae-420c-4615-b723-06b38e96ca05" timestamp="2017-06-26T13:17:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/1419678s/ (MISP Attribute #16295)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/1419678s/ (MISP Attribute #16295)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141ae-420c-4615-b723-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141ae-420c-4615-b723-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141ae-420c-4615-b723-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141ae-420c-4615-b723-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/1419678s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2182,14 +2182,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-75cc-4c7e-8e0a-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-75cc-4c7e-8e0a-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/1867745s/ (MISP Attribute #16296)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/1867745s/ (MISP Attribute #16296)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-75cc-4c7e-8e0a-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-75cc-4c7e-8e0a-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-75cc-4c7e-8e0a-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-75cc-4c7e-8e0a-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/1867745s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2203,14 +2203,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-dbd4-4aff-9733-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-dbd4-4aff-9733-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/2046803s/ (MISP Attribute #16297)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/2046803s/ (MISP Attribute #16297)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-dbd4-4aff-9733-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-dbd4-4aff-9733-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-dbd4-4aff-9733-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-dbd4-4aff-9733-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/2046803s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2224,14 +2224,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-109c-49c0-a621-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-109c-49c0-a621-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/3651023s/ (MISP Attribute #16298)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/3651023s/ (MISP Attribute #16298)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-109c-49c0-a621-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-109c-49c0-a621-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-109c-49c0-a621-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-109c-49c0-a621-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/3651023s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2245,14 +2245,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-a2c8-4f54-af98-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-a2c8-4f54-af98-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/4392216s/ (MISP Attribute #16299)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/4392216s/ (MISP Attribute #16299)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-a2c8-4f54-af98-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-a2c8-4f54-af98-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-a2c8-4f54-af98-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-a2c8-4f54-af98-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/4392216s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2266,14 +2266,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-8e20-4a46-bf32-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-8e20-4a46-bf32-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/4709973s/ (MISP Attribute #16300)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/4709973s/ (MISP Attribute #16300)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-8e20-4a46-bf32-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-8e20-4a46-bf32-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-8e20-4a46-bf32-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-8e20-4a46-bf32-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/4709973s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2287,14 +2287,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-3c6c-4adf-b195-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-3c6c-4adf-b195-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/5027740s/ (MISP Attribute #16301)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/5027740s/ (MISP Attribute #16301)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-3c6c-4adf-b195-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-3c6c-4adf-b195-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-3c6c-4adf-b195-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-3c6c-4adf-b195-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/5027740s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2308,14 +2308,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-1c0c-40a8-9059-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-1c0c-40a8-9059-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/5723329s/ (MISP Attribute #16302)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/5723329s/ (MISP Attribute #16302)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-1c0c-40a8-9059-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-1c0c-40a8-9059-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-1c0c-40a8-9059-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-1c0c-40a8-9059-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/5723329s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2329,14 +2329,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-ae9c-46b6-bd19-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-ae9c-46b6-bd19-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/5851721s/ (MISP Attribute #16303)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/5851721s/ (MISP Attribute #16303)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-ae9c-46b6-bd19-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-ae9c-46b6-bd19-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-ae9c-46b6-bd19-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-ae9c-46b6-bd19-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/5851721s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2350,14 +2350,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-e238-48f1-8fdf-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-e238-48f1-8fdf-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/6532946s/ (MISP Attribute #16304)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/6532946s/ (MISP Attribute #16304)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-e238-48f1-8fdf-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-e238-48f1-8fdf-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-e238-48f1-8fdf-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-e238-48f1-8fdf-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/6532946s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2371,14 +2371,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-545c-45eb-8055-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-545c-45eb-8055-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/6809853s/ (MISP Attribute #16305)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/6809853s/ (MISP Attribute #16305)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-545c-45eb-8055-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-545c-45eb-8055-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-545c-45eb-8055-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-545c-45eb-8055-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/6809853s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2392,14 +2392,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-4e28-43e0-abb7-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-4e28-43e0-abb7-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/6843502s/ (MISP Attribute #16306)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/6843502s/ (MISP Attribute #16306)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-4e28-43e0-abb7-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-4e28-43e0-abb7-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-4e28-43e0-abb7-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-4e28-43e0-abb7-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/6843502s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2413,14 +2413,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-af04-42cd-8891-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-af04-42cd-8891-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/7564969s/ (MISP Attribute #16307)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/7564969s/ (MISP Attribute #16307)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-af04-42cd-8891-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-af04-42cd-8891-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-af04-42cd-8891-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-af04-42cd-8891-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/7564969s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2434,14 +2434,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-b5e0-4b6e-a4ea-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-b5e0-4b6e-a4ea-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/7972736s/ (MISP Attribute #16308)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/7972736s/ (MISP Attribute #16308)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-b5e0-4b6e-a4ea-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-b5e0-4b6e-a4ea-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-b5e0-4b6e-a4ea-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-b5e0-4b6e-a4ea-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/7972736s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2455,14 +2455,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-fc1c-407c-a526-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-fc1c-407c-a526-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/8167459s/ (MISP Attribute #16309)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/8167459s/ (MISP Attribute #16309)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-fc1c-407c-a526-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-fc1c-407c-a526-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-fc1c-407c-a526-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-fc1c-407c-a526-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/8167459s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2476,14 +2476,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-64c8-4783-8cfc-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-64c8-4783-8cfc-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/8439927s/ (MISP Attribute #16310)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/8439927s/ (MISP Attribute #16310)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-64c8-4783-8cfc-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-64c8-4783-8cfc-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-64c8-4783-8cfc-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-64c8-4783-8cfc-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/8439927s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2497,14 +2497,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-2e50-4760-826b-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-2e50-4760-826b-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/8592764s/ (MISP Attribute #16311)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/8592764s/ (MISP Attribute #16311)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-2e50-4760-826b-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-2e50-4760-826b-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-2e50-4760-826b-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-2e50-4760-826b-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/8592764s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2518,14 +2518,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-d7c4-4ec4-b292-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-d7c4-4ec4-b292-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: https://unonoticias.net/9436744s/ (MISP Attribute #16312)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: https://unonoticias.net/9436744s/ (MISP Attribute #16312)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-d7c4-4ec4-b292-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-d7c4-4ec4-b292-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-d7c4-4ec4-b292-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-d7c4-4ec4-b292-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://unonoticias.net/9436744s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2539,14 +2539,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-e3dc-4232-b605-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-e3dc-4232-b605-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://tinyurl.com/j7luz86 (MISP Attribute #16313)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://tinyurl.com/j7luz86 (MISP Attribute #16313)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-e3dc-4232-b605-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-e3dc-4232-b605-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-e3dc-4232-b605-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-e3dc-4232-b605-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://tinyurl.com/j7luz86</URIObj:Value>
                                             </cybox:Properties>
@@ -2560,14 +2560,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-f744-4f14-825e-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-f744-4f14-825e-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://tinyurl.com/o2tq8rl (MISP Attribute #16314)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://tinyurl.com/o2tq8rl (MISP Attribute #16314)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-f744-4f14-825e-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-f744-4f14-825e-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-f744-4f14-825e-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-f744-4f14-825e-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://tinyurl.com/o2tq8rl</URIObj:Value>
                                             </cybox:Properties>
@@ -2581,14 +2581,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-73d4-45d1-aecd-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-73d4-45d1-aecd-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://twiitter.com.mx/2857663s/ (MISP Attribute #16315)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://twiitter.com.mx/2857663s/ (MISP Attribute #16315)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-73d4-45d1-aecd-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-73d4-45d1-aecd-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-73d4-45d1-aecd-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-73d4-45d1-aecd-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://twiitter.com.mx/2857663s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2602,14 +2602,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-8adc-48ba-b585-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-8adc-48ba-b585-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://unonoticias.net/1214510s/ (MISP Attribute #16316)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://unonoticias.net/1214510s/ (MISP Attribute #16316)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-8adc-48ba-b585-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-8adc-48ba-b585-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-8adc-48ba-b585-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-8adc-48ba-b585-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://unonoticias.net/1214510s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2623,14 +2623,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-6b7c-430b-ac54-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-6b7c-430b-ac54-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://unonoticias.net/3423768s/ (MISP Attribute #16317)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://unonoticias.net/3423768s/ (MISP Attribute #16317)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-6b7c-430b-ac54-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-6b7c-430b-ac54-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-6b7c-430b-ac54-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-6b7c-430b-ac54-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://unonoticias.net/3423768s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2644,14 +2644,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-4ed0-493c-abb8-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-4ed0-493c-abb8-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://unonoticias.net/5819525s/ (MISP Attribute #16318)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://unonoticias.net/5819525s/ (MISP Attribute #16318)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-4ed0-493c-abb8-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-4ed0-493c-abb8-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-4ed0-493c-abb8-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-4ed0-493c-abb8-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://unonoticias.net/5819525s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2665,14 +2665,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-8d70-4703-8aab-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-8d70-4703-8aab-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://unonoticias.net/6218095s/ (MISP Attribute #16319)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://unonoticias.net/6218095s/ (MISP Attribute #16319)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-8d70-4703-8aab-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-8d70-4703-8aab-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-8d70-4703-8aab-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-8d70-4703-8aab-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://unonoticias.net/6218095s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2686,14 +2686,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-1650-4b7a-a3f3-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-1650-4b7a-a3f3-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://unonoticias.net/9250302s/ (MISP Attribute #16320)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://unonoticias.net/9250302s/ (MISP Attribute #16320)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-1650-4b7a-a3f3-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-1650-4b7a-a3f3-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-1650-4b7a-a3f3-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-1650-4b7a-a3f3-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://unonoticias.net/9250302s/</URIObj:Value>
                                             </cybox:Properties>
@@ -2707,14 +2707,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595141af-2dac-4f74-9717-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595141af-2dac-4f74-9717-06b38e96ca05" timestamp="2017-06-26T13:17:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://unonoticias.net/9804185s/ (MISP Attribute #16321)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://unonoticias.net/9804185s/ (MISP Attribute #16321)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595141af-2dac-4f74-9717-06b38e96ca05">
-                                        <cybox:Object id=":URI-595141af-2dac-4f74-9717-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595141af-2dac-4f74-9717-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595141af-2dac-4f74-9717-06b38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://unonoticias.net/9804185s/</URIObj:Value>
                                             </cybox:Properties>

--- a/201706_RecklessRedux/stix.xml
+++ b/201706_RecklessRedux/stix.xml
@@ -58,20 +58,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-ef74f3fb-1f61-4d13-852d-918cfdea5669" version="1.1.1" timestamp="2017-06-29T14:41:32.031817+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-ef74f3fb-1f61-4d13-852d-918cfdea5669" version="1.1.1" timestamp="2017-06-29T14:41:32.031817+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-59550bab-3ce0-48c3-ba55-06b28e96ca05" version="1.1.1" timestamp="2017-06-29T10:18:35+00:00">
+            <stix:Package id="citizenlab:STIXPackage-59550bab-3ce0-48c3-ba55-06b28e96ca05" version="1.1.1" timestamp="2017-06-29T10:18:35+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Reckless Redux: Senior Mexican Legislators and Politicians Targeted with NSO Spyware (MISP Event #107)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-59550bab-3ce0-48c3-ba55-06b28e96ca05" timestamp="2017-06-29T10:18:44+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-59550bab-3ce0-48c3-ba55-06b28e96ca05" timestamp="2017-06-29T10:18:44+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Reckless Redux: Senior Mexican Legislators and Politicians Targeted with NSO Spyware</incident:Title>
                         <incident:External_ID source="MISP Event">107</incident:External_ID>
                         <incident:Time>
@@ -82,14 +82,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59550c3b-22ac-4348-add4-06b38e96ca05" timestamp="2017-06-29T10:18:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59550c3b-22ac-4348-add4-06b38e96ca05" timestamp="2017-06-29T10:18:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: smsmensaje.mx (MISP Attribute #16345)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: smsmensaje.mx (MISP Attribute #16345)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59550c3b-22ac-4348-add4-06b38e96ca05">
-                                        <cybox:Object id=":DomainName-59550c3b-22ac-4348-add4-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59550c3b-22ac-4348-add4-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-59550c3b-22ac-4348-add4-06b38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">smsmensaje.mx</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -103,14 +103,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59550c2c-d8dc-4c5c-a8e7-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59550c2c-d8dc-4c5c-a8e7-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/29F2psM (MISP Attribute #16337)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/29F2psM (MISP Attribute #16337)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59550c2c-d8dc-4c5c-a8e7-06b28e96ca05">
-                                        <cybox:Object id=":URI-59550c2c-d8dc-4c5c-a8e7-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59550c2c-d8dc-4c5c-a8e7-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-59550c2c-d8dc-4c5c-a8e7-06b28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/29F2psM</URIObj:Value>
                                             </cybox:Properties>
@@ -124,14 +124,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59550c2c-3820-4007-8f14-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59550c2c-3820-4007-8f14-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://smsmensaje.mx/8306090s/ (MISP Attribute #16338)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://smsmensaje.mx/8306090s/ (MISP Attribute #16338)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59550c2c-3820-4007-8f14-06b28e96ca05">
-                                        <cybox:Object id=":URI-59550c2c-3820-4007-8f14-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59550c2c-3820-4007-8f14-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-59550c2c-3820-4007-8f14-06b28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/8306090s/</URIObj:Value>
                                             </cybox:Properties>
@@ -145,14 +145,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59550c2c-7530-43d1-96c0-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59550c2c-7530-43d1-96c0-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/1WONumj (MISP Attribute #16339)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/1WONumj (MISP Attribute #16339)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59550c2c-7530-43d1-96c0-06b28e96ca05">
-                                        <cybox:Object id=":URI-59550c2c-7530-43d1-96c0-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59550c2c-7530-43d1-96c0-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-59550c2c-7530-43d1-96c0-06b28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1WONumj</URIObj:Value>
                                             </cybox:Properties>
@@ -166,14 +166,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59550c2c-aa30-4e89-831d-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59550c2c-aa30-4e89-831d-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://smsmensaje.mx/4995075s/ (MISP Attribute #16340)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://smsmensaje.mx/4995075s/ (MISP Attribute #16340)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59550c2c-aa30-4e89-831d-06b28e96ca05">
-                                        <cybox:Object id=":URI-59550c2c-aa30-4e89-831d-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59550c2c-aa30-4e89-831d-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-59550c2c-aa30-4e89-831d-06b28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/4995075s/</URIObj:Value>
                                             </cybox:Properties>
@@ -187,14 +187,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59550c2c-a2f8-4861-af47-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59550c2c-a2f8-4861-af47-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/1WRYHm8 (MISP Attribute #16341)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/1WRYHm8 (MISP Attribute #16341)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59550c2c-a2f8-4861-af47-06b28e96ca05">
-                                        <cybox:Object id=":URI-59550c2c-a2f8-4861-af47-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59550c2c-a2f8-4861-af47-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-59550c2c-a2f8-4861-af47-06b28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1WRYHm8</URIObj:Value>
                                             </cybox:Properties>
@@ -208,14 +208,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59550c2c-0184-45e7-935a-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59550c2c-0184-45e7-935a-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://smsmensaje.mx/1351276s/ (MISP Attribute #16342)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://smsmensaje.mx/1351276s/ (MISP Attribute #16342)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59550c2c-0184-45e7-935a-06b28e96ca05">
-                                        <cybox:Object id=":URI-59550c2c-0184-45e7-935a-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59550c2c-0184-45e7-935a-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-59550c2c-0184-45e7-935a-06b28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/1351276s/</URIObj:Value>
                                             </cybox:Properties>
@@ -229,14 +229,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59550c2c-ef48-4348-902f-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59550c2c-ef48-4348-902f-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/1UUsVi6 (MISP Attribute #16343)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/1UUsVi6 (MISP Attribute #16343)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59550c2c-ef48-4348-902f-06b28e96ca05">
-                                        <cybox:Object id=":URI-59550c2c-ef48-4348-902f-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59550c2c-ef48-4348-902f-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-59550c2c-ef48-4348-902f-06b28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/1UUsVi6</URIObj:Value>
                                             </cybox:Properties>
@@ -250,14 +250,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59550c2c-9e44-4b22-b65a-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59550c2c-9e44-4b22-b65a-06b28e96ca05" timestamp="2017-06-29T10:18:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://smsmensaje.mx/9993247s/ (MISP Attribute #16344)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://smsmensaje.mx/9993247s/ (MISP Attribute #16344)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59550c2c-9e44-4b22-b65a-06b28e96ca05">
-                                        <cybox:Object id=":URI-59550c2c-9e44-4b22-b65a-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59550c2c-9e44-4b22-b65a-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-59550c2c-9e44-4b22-b65a-06b28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://smsmensaje.mx/9993247s/</URIObj:Value>
                                             </cybox:Properties>

--- a/201707_InsiderInfo/stix.xml
+++ b/201707_InsiderInfo/stix.xml
@@ -58,20 +58,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-b50c3fdf-7ad2-4c13-8973-7e1d1a14dc92" version="1.1.1" timestamp="2017-07-04T15:38:19.891359+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-b50c3fdf-7ad2-4c13-8973-7e1d1a14dc92" version="1.1.1" timestamp="2017-07-04T15:38:19.891359+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-595baf14-d8e8-4e33-be25-06e38e96ca05" version="1.1.1" timestamp="2017-07-04T11:24:18+00:00">
+            <stix:Package id="citizenlab:STIXPackage-595baf14-d8e8-4e33-be25-06e38e96ca05" version="1.1.1" timestamp="2017-07-04T11:24:18+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Insider Information: An intrusion campaign targeting Chinese language news sites (MISP Event #108)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-595baf14-d8e8-4e33-be25-06e38e96ca05" timestamp="2017-07-04T11:25:53+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-595baf14-d8e8-4e33-be25-06e38e96ca05" timestamp="2017-07-04T11:25:53+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Insider Information: An intrusion campaign targeting Chinese language news sites</incident:Title>
                         <incident:External_ID source="MISP Event">108</incident:External_ID>
                         <incident:Time>
@@ -82,14 +82,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-2550-44cc-8747-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-2550-44cc-8747-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 19c5f8829444956ba30e023aaaec6408 (MISP Attribute #16407)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 19c5f8829444956ba30e023aaaec6408 (MISP Attribute #16407)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-2550-44cc-8747-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-2550-44cc-8747-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-2550-44cc-8747-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-2550-44cc-8747-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -108,14 +108,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-12c0-4c0c-8d64-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-12c0-4c0c-8d64-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: ac5763000ae435875f3b709a5f23ecc0 (MISP Attribute #16408)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: ac5763000ae435875f3b709a5f23ecc0 (MISP Attribute #16408)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-12c0-4c0c-8d64-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-12c0-4c0c-8d64-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-12c0-4c0c-8d64-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-12c0-4c0c-8d64-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -134,14 +134,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-0d44-4380-9208-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-0d44-4380-9208-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: d80fc6a4f175e3ab417b9f96c3b37c73 (MISP Attribute #16409)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: d80fc6a4f175e3ab417b9f96c3b37c73 (MISP Attribute #16409)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-0d44-4380-9208-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-0d44-4380-9208-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-0d44-4380-9208-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-0d44-4380-9208-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -160,14 +160,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-fa5c-4ee1-b354-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-fa5c-4ee1-b354-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 945de4d3a046a698aec222fc90a148ba (MISP Attribute #16410)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 945de4d3a046a698aec222fc90a148ba (MISP Attribute #16410)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-fa5c-4ee1-b354-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-fa5c-4ee1-b354-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-fa5c-4ee1-b354-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-fa5c-4ee1-b354-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -186,14 +186,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-7e84-47a6-a022-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-7e84-47a6-a022-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 95efa51b52f121cec239980127b7f96b (MISP Attribute #16411)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 95efa51b52f121cec239980127b7f96b (MISP Attribute #16411)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-7e84-47a6-a022-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-7e84-47a6-a022-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-7e84-47a6-a022-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-7e84-47a6-a022-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -212,14 +212,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-f1a0-4a70-a9ad-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-f1a0-4a70-a9ad-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 13b148aead5e844f7262da768873cec0 (MISP Attribute #16412)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 13b148aead5e844f7262da768873cec0 (MISP Attribute #16412)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-f1a0-4a70-a9ad-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-f1a0-4a70-a9ad-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-f1a0-4a70-a9ad-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-f1a0-4a70-a9ad-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -238,14 +238,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-dfec-480b-9ec1-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-dfec-480b-9ec1-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 029ba5f0f6997bc36a094e86848a5b82 (MISP Attribute #16413)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 029ba5f0f6997bc36a094e86848a5b82 (MISP Attribute #16413)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-dfec-480b-9ec1-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-dfec-480b-9ec1-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-dfec-480b-9ec1-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-dfec-480b-9ec1-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -264,14 +264,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-59ac-4310-aa50-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-59ac-4310-aa50-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: e841ecaa44b3589120b72e60b53f39c6 (MISP Attribute #16414)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: e841ecaa44b3589120b72e60b53f39c6 (MISP Attribute #16414)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-59ac-4310-aa50-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-59ac-4310-aa50-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-59ac-4310-aa50-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-59ac-4310-aa50-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -290,14 +290,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-4794-4b32-8ad7-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-4794-4b32-8ad7-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 88e027b1ef7b2da1766e6b6819bba0f0 (MISP Attribute #16415)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 88e027b1ef7b2da1766e6b6819bba0f0 (MISP Attribute #16415)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-4794-4b32-8ad7-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-4794-4b32-8ad7-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-4794-4b32-8ad7-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-4794-4b32-8ad7-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -316,14 +316,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-34b4-4c04-a93c-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-34b4-4c04-a93c-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: bb080489dbc98a59cac130475e019fb2 (MISP Attribute #16416)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: bb080489dbc98a59cac130475e019fb2 (MISP Attribute #16416)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-34b4-4c04-a93c-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-34b4-4c04-a93c-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-34b4-4c04-a93c-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-34b4-4c04-a93c-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -342,14 +342,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-a12c-4e3f-b0ee-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-a12c-4e3f-b0ee-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 88f43fe753e64d9c536fca16979984ef (MISP Attribute #16417)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 88f43fe753e64d9c536fca16979984ef (MISP Attribute #16417)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-a12c-4e3f-b0ee-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-a12c-4e3f-b0ee-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-a12c-4e3f-b0ee-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-a12c-4e3f-b0ee-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -368,14 +368,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-90a4-47f8-9056-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-90a4-47f8-9056-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: f282fd20d7eaebe848b5111ecdae82a6 (MISP Attribute #16418)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: f282fd20d7eaebe848b5111ecdae82a6 (MISP Attribute #16418)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-90a4-47f8-9056-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-90a4-47f8-9056-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-90a4-47f8-9056-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-90a4-47f8-9056-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -394,14 +394,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-0618-43dc-bd26-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-0618-43dc-bd26-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: e0338b1f010fdc4751de5f58e4acf2ad (MISP Attribute #16419)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: e0338b1f010fdc4751de5f58e4acf2ad (MISP Attribute #16419)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-0618-43dc-bd26-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-0618-43dc-bd26-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-0618-43dc-bd26-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-0618-43dc-bd26-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -420,14 +420,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-0b70-4d94-873f-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-0b70-4d94-873f-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: c1dabd54a672cbc2747c53a8041d5602 (MISP Attribute #16420)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: c1dabd54a672cbc2747c53a8041d5602 (MISP Attribute #16420)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-0b70-4d94-873f-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-0b70-4d94-873f-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-0b70-4d94-873f-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-0b70-4d94-873f-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -446,14 +446,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-897c-4d64-99b1-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-897c-4d64-99b1-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 2332aa40d15399179c068ab205a5303d (MISP Attribute #16421)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 2332aa40d15399179c068ab205a5303d (MISP Attribute #16421)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-897c-4d64-99b1-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-897c-4d64-99b1-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-897c-4d64-99b1-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-897c-4d64-99b1-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -472,14 +472,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb322-88f8-4934-93ca-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb322-88f8-4934-93ca-06e38e96ca05" timestamp="2017-07-04T11:24:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 4ddf012d8a42ad2666e06ad2f0a8410e (MISP Attribute #16422)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 4ddf012d8a42ad2666e06ad2f0a8410e (MISP Attribute #16422)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb322-88f8-4934-93ca-06e38e96ca05">
-                                        <cybox:Object id=":File-595bb322-88f8-4934-93ca-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb322-88f8-4934-93ca-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:File-595bb322-88f8-4934-93ca-06e38e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -498,7 +498,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb024-550c-4f0e-89b0-06e38e96ca05" timestamp="2017-07-04T11:11:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb024-550c-4f0e-89b0-06e38e96ca05" timestamp="2017-07-04T11:11:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: aobama_5@yahoo.com (MISP Attribute #16353)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: aobama_5@yahoo.com (MISP Attribute #16353)</indicator:Description>
@@ -511,14 +511,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb19a-2bec-4af4-bd28-06e28e96ca05" timestamp="2017-07-04T11:17:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb19a-2bec-4af4-bd28-06e28e96ca05" timestamp="2017-07-04T11:17:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: email23.secuerserver.com (MISP Attribute #16374)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: email23.secuerserver.com (MISP Attribute #16374)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb19a-2bec-4af4-bd28-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595bb19a-2bec-4af4-bd28-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb19a-2bec-4af4-bd28-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb19a-2bec-4af4-bd28-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">email23.secuerserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -532,14 +532,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb19a-3be4-4267-9c73-06e28e96ca05" timestamp="2017-07-04T11:17:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb19a-3be4-4267-9c73-06e28e96ca05" timestamp="2017-07-04T11:17:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hk.secuerserver.com (MISP Attribute #16375)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hk.secuerserver.com (MISP Attribute #16375)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb19a-3be4-4267-9c73-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595bb19a-3be4-4267-9c73-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb19a-3be4-4267-9c73-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb19a-3be4-4267-9c73-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hk.secuerserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -553,14 +553,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb19a-53fc-4c93-87b1-06e28e96ca05" timestamp="2017-07-04T11:17:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb19a-53fc-4c93-87b1-06e28e96ca05" timestamp="2017-07-04T11:17:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dns.bowenpress.org (MISP Attribute #16376)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dns.bowenpress.org (MISP Attribute #16376)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb19a-53fc-4c93-87b1-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595bb19a-53fc-4c93-87b1-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb19a-53fc-4c93-87b1-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb19a-53fc-4c93-87b1-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dns.bowenpress.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -574,14 +574,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb071-226c-4930-9b42-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb071-226c-4930-9b42-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: secuerserver.com (MISP Attribute #16354)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: secuerserver.com (MISP Attribute #16354)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb071-226c-4930-9b42-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595bb071-226c-4930-9b42-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb071-226c-4930-9b42-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb071-226c-4930-9b42-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">secuerserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -595,14 +595,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb071-d1e8-4cde-9c68-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb071-d1e8-4cde-9c68-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: bowenpres.com (MISP Attribute #16355)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: bowenpres.com (MISP Attribute #16355)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb071-d1e8-4cde-9c68-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595bb071-d1e8-4cde-9c68-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb071-d1e8-4cde-9c68-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb071-d1e8-4cde-9c68-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bowenpres.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -616,14 +616,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb071-3318-40b2-945f-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb071-3318-40b2-945f-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: bowenpress.net (MISP Attribute #16356)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: bowenpress.net (MISP Attribute #16356)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb071-3318-40b2-945f-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595bb071-3318-40b2-945f-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb071-3318-40b2-945f-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb071-3318-40b2-945f-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bowenpress.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -637,14 +637,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb071-3d20-4589-9055-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb071-3d20-4589-9055-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: bowenpress.org (MISP Attribute #16357)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: bowenpress.org (MISP Attribute #16357)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb071-3d20-4589-9055-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595bb071-3d20-4589-9055-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb071-3d20-4589-9055-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb071-3d20-4589-9055-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bowenpress.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -658,14 +658,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb071-c44c-45ce-b8b4-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb071-c44c-45ce-b8b4-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: bowenpross.com (MISP Attribute #16358)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: bowenpross.com (MISP Attribute #16358)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb071-c44c-45ce-b8b4-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595bb071-c44c-45ce-b8b4-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb071-c44c-45ce-b8b4-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb071-c44c-45ce-b8b4-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bowenpross.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -679,14 +679,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb071-b9e0-4f44-a56e-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb071-b9e0-4f44-a56e-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: datalink.one (MISP Attribute #16359)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: datalink.one (MISP Attribute #16359)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb071-b9e0-4f44-a56e-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595bb071-b9e0-4f44-a56e-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb071-b9e0-4f44-a56e-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb071-b9e0-4f44-a56e-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">datalink.one</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -700,14 +700,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb071-dcec-4872-ad35-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb071-dcec-4872-ad35-06e28e96ca05" timestamp="2017-07-04T11:12:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: epochatimes.com (MISP Attribute #16360)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: epochatimes.com (MISP Attribute #16360)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb071-dcec-4872-ad35-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595bb071-dcec-4872-ad35-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb071-dcec-4872-ad35-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb071-dcec-4872-ad35-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">epochatimes.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -721,14 +721,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb0af-5a40-459c-a05d-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb0af-5a40-459c-a05d-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: get.adobe.com.bowenpress.org (MISP Attribute #16361)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: get.adobe.com.bowenpress.org (MISP Attribute #16361)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb0af-5a40-459c-a05d-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595bb0af-5a40-459c-a05d-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb0af-5a40-459c-a05d-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb0af-5a40-459c-a05d-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">get.adobe.com.bowenpress.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -742,14 +742,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb0af-9bd4-4f6e-b2fa-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb0af-9bd4-4f6e-b2fa-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: hk.secuerserver.com (MISP Attribute #16362)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: hk.secuerserver.com (MISP Attribute #16362)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb0af-9bd4-4f6e-b2fa-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595bb0af-9bd4-4f6e-b2fa-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb0af-9bd4-4f6e-b2fa-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb0af-9bd4-4f6e-b2fa-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hk.secuerserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -763,14 +763,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb0af-c4b8-4124-a2b5-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb0af-c4b8-4124-a2b5-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: pop.secuerserver.com (MISP Attribute #16363)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: pop.secuerserver.com (MISP Attribute #16363)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb0af-c4b8-4124-a2b5-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595bb0af-c4b8-4124-a2b5-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb0af-c4b8-4124-a2b5-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb0af-c4b8-4124-a2b5-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">pop.secuerserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -784,14 +784,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb0af-3930-4285-9fdd-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb0af-3930-4285-9fdd-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: smtpout.secuerserver.com (MISP Attribute #16364)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: smtpout.secuerserver.com (MISP Attribute #16364)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb0af-3930-4285-9fdd-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595bb0af-3930-4285-9fdd-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb0af-3930-4285-9fdd-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb0af-3930-4285-9fdd-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">smtpout.secuerserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -805,14 +805,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb0af-e108-4480-aa27-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb0af-e108-4480-aa27-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: www.bowenpress.org (MISP Attribute #16365)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: www.bowenpress.org (MISP Attribute #16365)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb0af-e108-4480-aa27-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595bb0af-e108-4480-aa27-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb0af-e108-4480-aa27-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb0af-e108-4480-aa27-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.bowenpress.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -826,14 +826,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb0af-9c98-4021-9af7-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb0af-9c98-4021-9af7-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: www.mail.secuerserver.com (MISP Attribute #16366)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: www.mail.secuerserver.com (MISP Attribute #16366)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb0af-9c98-4021-9af7-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595bb0af-9c98-4021-9af7-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb0af-9c98-4021-9af7-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb0af-9c98-4021-9af7-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.mail.secuerserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -847,14 +847,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb0af-a424-469a-9a7f-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb0af-a424-469a-9a7f-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: www.secuerserver.com (MISP Attribute #16367)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: www.secuerserver.com (MISP Attribute #16367)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb0af-a424-469a-9a7f-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595bb0af-a424-469a-9a7f-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb0af-a424-469a-9a7f-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb0af-a424-469a-9a7f-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.secuerserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -868,14 +868,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb0af-4794-4d7f-ba4c-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb0af-4794-4d7f-ba4c-06e38e96ca05" timestamp="2017-07-04T11:13:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: www.vnews.hk (MISP Attribute #16368)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: www.vnews.hk (MISP Attribute #16368)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb0af-4794-4d7f-ba4c-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595bb0af-4794-4d7f-ba4c-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb0af-4794-4d7f-ba4c-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595bb0af-4794-4d7f-ba4c-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.vnews.hk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -889,14 +889,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595baf52-7340-4840-bda0-06e38e96ca05" timestamp="2017-07-04T11:08:02+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595baf52-7340-4840-bda0-06e38e96ca05" timestamp="2017-07-04T11:08:02+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: hellomice@mail.com (MISP Attribute #16348)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: hellomice@mail.com (MISP Attribute #16348)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595baf52-7340-4840-bda0-06e38e96ca05">
-                                        <cybox:Object id=":EmailMessage-595baf52-7340-4840-bda0-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595baf52-7340-4840-bda0-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-595baf52-7340-4840-bda0-06e38e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -914,14 +914,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595baf52-2a08-4576-9f76-06e38e96ca05" timestamp="2017-07-04T11:08:02+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595baf52-2a08-4576-9f76-06e38e96ca05" timestamp="2017-07-04T11:08:02+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: aisia.anminda8@mail.com (MISP Attribute #16349)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: aisia.anminda8@mail.com (MISP Attribute #16349)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595baf52-2a08-4576-9f76-06e38e96ca05">
-                                        <cybox:Object id=":EmailMessage-595baf52-2a08-4576-9f76-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595baf52-2a08-4576-9f76-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:EmailMessage-595baf52-2a08-4576-9f76-06e38e96ca05">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -939,14 +939,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb286-ee4c-4c91-91b9-06e38e96ca05" timestamp="2017-07-04T11:21:42+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb286-ee4c-4c91-91b9-06e38e96ca05" timestamp="2017-07-04T11:21:42+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 45.124.24.39 (MISP Attribute #16405)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 45.124.24.39 (MISP Attribute #16405)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb286-ee4c-4c91-91b9-06e38e96ca05">
-                                        <cybox:Object id=":Address-595bb286-ee4c-4c91-91b9-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb286-ee4c-4c91-91b9-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:Address-595bb286-ee4c-4c91-91b9-06e38e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="true">
                                                 <AddressObj:Address_Value condition="Equals">45.124.24.39</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -960,14 +960,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb2d6-70e0-4d6d-bdc7-06e28e96ca05" timestamp="2017-07-04T11:23:02+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb2d6-70e0-4d6d-bdc7-06e28e96ca05" timestamp="2017-07-04T11:23:02+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 23.239.106.119 (MISP Attribute #16406)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 23.239.106.119 (MISP Attribute #16406)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb2d6-70e0-4d6d-bdc7-06e28e96ca05">
-                                        <cybox:Object id=":Address-595bb2d6-70e0-4d6d-bdc7-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb2d6-70e0-4d6d-bdc7-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:Address-595bb2d6-70e0-4d6d-bdc7-06e28e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="true">
                                                 <AddressObj:Address_Value condition="Equals">23.239.106.119</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -981,14 +981,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bafe1-e518-4bfb-9701-06e28e96ca05" timestamp="2017-07-04T11:10:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bafe1-e518-4bfb-9701-06e28e96ca05" timestamp="2017-07-04T11:10:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 43.240.14.37 (MISP Attribute #16352)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 43.240.14.37 (MISP Attribute #16352)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bafe1-e518-4bfb-9701-06e28e96ca05">
-                                        <cybox:Object id=":Address-595bafe1-e518-4bfb-9701-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bafe1-e518-4bfb-9701-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:Address-595bafe1-e518-4bfb-9701-06e28e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="true">
                                                 <AddressObj:Address_Value condition="Equals">43.240.14.37</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -1002,14 +1002,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595baf7a-6598-4ecc-ba74-06e28e96ca05" timestamp="2017-07-04T11:08:42+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595baf7a-6598-4ecc-ba74-06e28e96ca05" timestamp="2017-07-04T11:08:42+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://43.240.14.37/asdasdasadqddd12222111.php/article.asp (MISP Attribute #16350)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://43.240.14.37/asdasdasadqddd12222111.php/article.asp (MISP Attribute #16350)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595baf7a-6598-4ecc-ba74-06e28e96ca05">
-                                        <cybox:Object id=":URI-595baf7a-6598-4ecc-ba74-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595baf7a-6598-4ecc-ba74-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595baf7a-6598-4ecc-ba74-06e28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://43.240.14.37/asdasdasadqddd12222111.php/article.asp</URIObj:Value>
                                             </cybox:Properties>
@@ -1023,14 +1023,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bafa7-2d34-43d7-87a1-06e38e96ca05" timestamp="2017-07-04T11:09:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bafa7-2d34-43d7-87a1-06e38e96ca05" timestamp="2017-07-04T11:09:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://chinadagitaltimes.net/2016/07/chinese-hackers-blamed-multiple-breaches-fdic (MISP Attribute #16351)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://chinadagitaltimes.net/2016/07/chinese-hackers-blamed-multiple-breaches-fdic (MISP Attribute #16351)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bafa7-2d34-43d7-87a1-06e38e96ca05">
-                                        <cybox:Object id=":URI-595bafa7-2d34-43d7-87a1-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bafa7-2d34-43d7-87a1-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595bafa7-2d34-43d7-87a1-06e38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://chinadagitaltimes.net/2016/07/chinese-hackers-blamed-multiple-breaches-fdic</URIObj:Value>
                                             </cybox:Properties>
@@ -1044,14 +1044,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb0cc-f258-491f-afcd-06e28e96ca05" timestamp="2017-07-04T11:14:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb0cc-f258-491f-afcd-06e28e96ca05" timestamp="2017-07-04T11:14:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://get.adobe.com.bowenpress.org/Adobe/update/20161201/AdobeUpdate.html (MISP Attribute #16369)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://get.adobe.com.bowenpress.org/Adobe/update/20161201/AdobeUpdate.html (MISP Attribute #16369)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb0cc-f258-491f-afcd-06e28e96ca05">
-                                        <cybox:Object id=":URI-595bb0cc-f258-491f-afcd-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb0cc-f258-491f-afcd-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595bb0cc-f258-491f-afcd-06e28e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://get.adobe.com.bowenpress.org/Adobe/update/20161201/AdobeUpdate.html</URIObj:Value>
                                             </cybox:Properties>
@@ -1065,14 +1065,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb15f-dc68-4468-9572-06e38e96ca05" timestamp="2017-07-04T11:16:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb15f-dc68-4468-9572-06e38e96ca05" timestamp="2017-07-04T11:16:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://get.adobe.com.bowenpress.org/Adobe/update/20160703/AdobeUpdate20160703.exe (MISP Attribute #16370)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://get.adobe.com.bowenpress.org/Adobe/update/20160703/AdobeUpdate20160703.exe (MISP Attribute #16370)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb15f-dc68-4468-9572-06e38e96ca05">
-                                        <cybox:Object id=":URI-595bb15f-dc68-4468-9572-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb15f-dc68-4468-9572-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595bb15f-dc68-4468-9572-06e38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://get.adobe.com.bowenpress.org/Adobe/update/20160703/AdobeUpdate20160703.exe</URIObj:Value>
                                             </cybox:Properties>
@@ -1086,14 +1086,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb15f-d000-400a-b7a9-06e38e96ca05" timestamp="2017-07-04T11:16:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb15f-d000-400a-b7a9-06e38e96ca05" timestamp="2017-07-04T11:16:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://get.adobe.com.bowenpress.org/Adobe/update/20160812/AdobeUpdate20160812.exe (MISP Attribute #16371)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://get.adobe.com.bowenpress.org/Adobe/update/20160812/AdobeUpdate20160812.exe (MISP Attribute #16371)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb15f-d000-400a-b7a9-06e38e96ca05">
-                                        <cybox:Object id=":URI-595bb15f-d000-400a-b7a9-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb15f-d000-400a-b7a9-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595bb15f-d000-400a-b7a9-06e38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://get.adobe.com.bowenpress.org/Adobe/update/20160812/AdobeUpdate20160812.exe</URIObj:Value>
                                             </cybox:Properties>
@@ -1107,14 +1107,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb15f-4a08-4a4a-9ff5-06e38e96ca05" timestamp="2017-07-04T11:16:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb15f-4a08-4a4a-9ff5-06e38e96ca05" timestamp="2017-07-04T11:16:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://get.adobe.com.bowenpress.org/Adobe/update/20161201/AdobeUpdate20161201.exe (MISP Attribute #16372)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://get.adobe.com.bowenpress.org/Adobe/update/20161201/AdobeUpdate20161201.exe (MISP Attribute #16372)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb15f-4a08-4a4a-9ff5-06e38e96ca05">
-                                        <cybox:Object id=":URI-595bb15f-4a08-4a4a-9ff5-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb15f-4a08-4a4a-9ff5-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595bb15f-4a08-4a4a-9ff5-06e38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://get.adobe.com.bowenpress.org/Adobe/update/20161201/AdobeUpdate20161201.exe</URIObj:Value>
                                             </cybox:Properties>
@@ -1128,14 +1128,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595bb15f-8488-4a3b-abea-06e38e96ca05" timestamp="2017-07-04T11:16:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595bb15f-8488-4a3b-abea-06e38e96ca05" timestamp="2017-07-04T11:16:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: http://get.adobe.com.bowenpress.org/Adobe/update/20170312/AdobeUpdate20170312.exe (MISP Attribute #16373)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: http://get.adobe.com.bowenpress.org/Adobe/update/20170312/AdobeUpdate20170312.exe (MISP Attribute #16373)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595bb15f-8488-4a3b-abea-06e38e96ca05">
-                                        <cybox:Object id=":URI-595bb15f-8488-4a3b-abea-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595bb15f-8488-4a3b-abea-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:URI-595bb15f-8488-4a3b-abea-06e38e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://get.adobe.com.bowenpress.org/Adobe/update/20170312/AdobeUpdate20170312.exe</URIObj:Value>
                                             </cybox:Properties>

--- a/201712_Cyberbit/stix.xml
+++ b/201712_Cyberbit/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,20 +59,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-4fc9013b-312e-4062-a2f4-9ff6621eb98c" version="1.1.1" timestamp="2017-12-06T16:16:33.380179+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-4fc9013b-312e-4062-a2f4-9ff6621eb98c" version="1.1.1" timestamp="2017-12-06T16:16:33.380179+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-5a27f994-d7c0-4ef0-9b8f-40758e96ca05" version="1.1.1" timestamp="2017-12-06T11:04:20+00:00">
+            <stix:Package id="citizenlab:STIXPackage-5a27f994-d7c0-4ef0-9b8f-40758e96ca05" version="1.1.1" timestamp="2017-12-06T11:04:20+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Champing at the Cyberbit: Ethiopian Dissidents Targeted with New Commercial Spyware (MISP Event #125)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-5a27f994-d7c0-4ef0-9b8f-40758e96ca05" timestamp="2017-12-06T11:04:35+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-5a27f994-d7c0-4ef0-9b8f-40758e96ca05" timestamp="2017-12-06T11:04:35+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Champing at the Cyberbit: Ethiopian Dissidents Targeted with New Commercial Spyware</incident:Title>
                         <incident:External_ID source="MISP Event">125</incident:External_ID>
                         <incident:Time>
@@ -83,14 +83,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-15cc-44d6-8153-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-15cc-44d6-8153-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 568d8c43815fa9608974071c49d68232 (MISP Attribute #17544)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 568d8c43815fa9608974071c49d68232 (MISP Attribute #17544)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-15cc-44d6-8153-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-15cc-44d6-8153-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-15cc-44d6-8153-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-15cc-44d6-8153-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -109,14 +109,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-4ac4-49c5-9c46-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-4ac4-49c5-9c46-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 80b7121c4ecac1c321ca2e3f507104c2 (MISP Attribute #17545)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 80b7121c4ecac1c321ca2e3f507104c2 (MISP Attribute #17545)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-4ac4-49c5-9c46-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-4ac4-49c5-9c46-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-4ac4-49c5-9c46-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-4ac4-49c5-9c46-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -135,14 +135,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-b378-4812-adc5-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-b378-4812-adc5-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 8d6ce1a256acf608d82db6539bf73ae7 (MISP Attribute #17546)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 8d6ce1a256acf608d82db6539bf73ae7 (MISP Attribute #17546)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-b378-4812-adc5-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-b378-4812-adc5-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-b378-4812-adc5-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-b378-4812-adc5-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -161,14 +161,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-e53c-422a-81bf-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-e53c-422a-81bf-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 840c4299f9cd5d4df46ee708c2c8247c (MISP Attribute #17547)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 840c4299f9cd5d4df46ee708c2c8247c (MISP Attribute #17547)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-e53c-422a-81bf-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-e53c-422a-81bf-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-e53c-422a-81bf-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-e53c-422a-81bf-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -187,14 +187,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-de5c-4a30-8d45-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-de5c-4a30-8d45-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 961730964fd76c93603fb8f0d445c6f2 (MISP Attribute #17548)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 961730964fd76c93603fb8f0d445c6f2 (MISP Attribute #17548)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-de5c-4a30-8d45-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-de5c-4a30-8d45-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-de5c-4a30-8d45-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-de5c-4a30-8d45-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -213,14 +213,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-bc88-4421-a137-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-bc88-4421-a137-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 376f28fb0aa650d6220a9d722cdb108d (MISP Attribute #17549)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 376f28fb0aa650d6220a9d722cdb108d (MISP Attribute #17549)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-bc88-4421-a137-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-bc88-4421-a137-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-bc88-4421-a137-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-bc88-4421-a137-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -239,14 +239,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-88bc-43fe-8b35-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-88bc-43fe-8b35-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: ca782d91daea6d67dfc49d6e7baf39b0 (MISP Attribute #17550)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: ca782d91daea6d67dfc49d6e7baf39b0 (MISP Attribute #17550)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-88bc-43fe-8b35-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-88bc-43fe-8b35-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-88bc-43fe-8b35-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-88bc-43fe-8b35-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -265,14 +265,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-84fc-42ff-b5b6-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-84fc-42ff-b5b6-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 0488cf9c58f895076311bf8e2d93bf63 (MISP Attribute #17551)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 0488cf9c58f895076311bf8e2d93bf63 (MISP Attribute #17551)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-84fc-42ff-b5b6-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-84fc-42ff-b5b6-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-84fc-42ff-b5b6-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-84fc-42ff-b5b6-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -291,14 +291,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-80d8-4fdb-a65b-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-80d8-4fdb-a65b-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: f483fe294b4c3af1e3c8163200d60aae (MISP Attribute #17552)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: f483fe294b4c3af1e3c8163200d60aae (MISP Attribute #17552)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-80d8-4fdb-a65b-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-80d8-4fdb-a65b-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-80d8-4fdb-a65b-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-80d8-4fdb-a65b-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -317,14 +317,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-6a58-470b-a448-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-6a58-470b-a448-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 1dcff300018c37a888fbe36f270f43a7 (MISP Attribute #17553)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 1dcff300018c37a888fbe36f270f43a7 (MISP Attribute #17553)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-6a58-470b-a448-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-6a58-470b-a448-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-6a58-470b-a448-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-6a58-470b-a448-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -343,14 +343,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-737c-4b9b-a821-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-737c-4b9b-a821-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: ed42fcd0ae2e1baf3d0eead4fcf9c9da (MISP Attribute #17554)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: ed42fcd0ae2e1baf3d0eead4fcf9c9da (MISP Attribute #17554)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-737c-4b9b-a821-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-737c-4b9b-a821-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-737c-4b9b-a821-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-737c-4b9b-a821-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -369,14 +369,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-5cfc-4111-b71a-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-5cfc-4111-b71a-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 4b6d030664668224a88ca260354e5b4e (MISP Attribute #17555)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 4b6d030664668224a88ca260354e5b4e (MISP Attribute #17555)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-5cfc-4111-b71a-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-5cfc-4111-b71a-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-5cfc-4111-b71a-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-5cfc-4111-b71a-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -395,14 +395,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-561c-42c6-8c04-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-561c-42c6-8c04-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 94d49232f1d77611544371826be16a99 (MISP Attribute #17556)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 94d49232f1d77611544371826be16a99 (MISP Attribute #17556)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-561c-42c6-8c04-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-561c-42c6-8c04-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-561c-42c6-8c04-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-561c-42c6-8c04-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -421,14 +421,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-4b54-448c-9154-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-4b54-448c-9154-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: fd903f9471e7b3f60739b8f29fec041d (MISP Attribute #17557)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: fd903f9471e7b3f60739b8f29fec041d (MISP Attribute #17557)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-4b54-448c-9154-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-4b54-448c-9154-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-4b54-448c-9154-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-4b54-448c-9154-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -447,14 +447,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-5284-4795-9ec0-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-5284-4795-9ec0-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: d3ebb760c9de3486379abc3672dbee8b (MISP Attribute #17558)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: d3ebb760c9de3486379abc3672dbee8b (MISP Attribute #17558)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-5284-4795-9ec0-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-5284-4795-9ec0-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-5284-4795-9ec0-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-5284-4795-9ec0-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -473,14 +473,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-50b8-472a-a1f2-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-50b8-472a-a1f2-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 37c9e979a36b31355e779f10ecaba886 (MISP Attribute #17559)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 37c9e979a36b31355e779f10ecaba886 (MISP Attribute #17559)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-50b8-472a-a1f2-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-50b8-472a-a1f2-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-50b8-472a-a1f2-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-50b8-472a-a1f2-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -499,14 +499,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-36b4-4d66-841e-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-36b4-4d66-841e-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: bb0143290d7c9cb1d186e209e4aa8d87 (MISP Attribute #17560)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: bb0143290d7c9cb1d186e209e4aa8d87 (MISP Attribute #17560)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-36b4-4d66-841e-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-36b4-4d66-841e-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-36b4-4d66-841e-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-36b4-4d66-841e-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -525,14 +525,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-32f4-4344-a582-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-32f4-4344-a582-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: e0804de1f0b4a22dbeddc90fb2854bfe (MISP Attribute #17561)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: e0804de1f0b4a22dbeddc90fb2854bfe (MISP Attribute #17561)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-32f4-4344-a582-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-32f4-4344-a582-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-32f4-4344-a582-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-32f4-4344-a582-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -551,14 +551,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-43e8-46ee-941b-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-43e8-46ee-941b-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 4feae73c2ef347692be0068793fc2c73 (MISP Attribute #17562)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 4feae73c2ef347692be0068793fc2c73 (MISP Attribute #17562)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-43e8-46ee-941b-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-43e8-46ee-941b-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-43e8-46ee-941b-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-43e8-46ee-941b-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -577,14 +577,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-46cc-473a-aaaa-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-46cc-473a-aaaa-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 46cab66af42f40c9f65fa20bf071601f (MISP Attribute #17563)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 46cab66af42f40c9f65fa20bf071601f (MISP Attribute #17563)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-46cc-473a-aaaa-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-46cc-473a-aaaa-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-46cc-473a-aaaa-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-46cc-473a-aaaa-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -603,14 +603,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-2ebc-4c0e-b1c2-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-2ebc-4c0e-b1c2-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 8a20147b5df86ea6bdd39b9ea84dfc2d (MISP Attribute #17564)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 8a20147b5df86ea6bdd39b9ea84dfc2d (MISP Attribute #17564)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-2ebc-4c0e-b1c2-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-2ebc-4c0e-b1c2-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-2ebc-4c0e-b1c2-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-2ebc-4c0e-b1c2-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -629,14 +629,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-2778-4784-b22c-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-2778-4784-b22c-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: c616f271a456eb2c54bdbee67fb88eda (MISP Attribute #17565)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: c616f271a456eb2c54bdbee67fb88eda (MISP Attribute #17565)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-2778-4784-b22c-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-2778-4784-b22c-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-2778-4784-b22c-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-2778-4784-b22c-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -655,14 +655,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-3b28-4b81-9e4b-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-3b28-4b81-9e4b-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 19dfff93ad650c02fbffa73faea48a96 (MISP Attribute #17566)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 19dfff93ad650c02fbffa73faea48a96 (MISP Attribute #17566)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-3b28-4b81-9e4b-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-3b28-4b81-9e4b-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-3b28-4b81-9e4b-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-3b28-4b81-9e4b-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -681,14 +681,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-57d4-4f8b-acc0-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-57d4-4f8b-acc0-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: eaf569c0d8866df41f6c419b6683946b (MISP Attribute #17567)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: eaf569c0d8866df41f6c419b6683946b (MISP Attribute #17567)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-57d4-4f8b-acc0-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-57d4-4f8b-acc0-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-57d4-4f8b-acc0-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-57d4-4f8b-acc0-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -707,14 +707,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-6864-4d94-b9e1-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-6864-4d94-b9e1-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 2f9911e69ee7eeb2db050f82da85688e (MISP Attribute #17568)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 2f9911e69ee7eeb2db050f82da85688e (MISP Attribute #17568)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-6864-4d94-b9e1-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-6864-4d94-b9e1-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-6864-4d94-b9e1-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-6864-4d94-b9e1-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -733,14 +733,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-7764-435a-bc52-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-7764-435a-bc52-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 1b6ef8b512ab768d76999d81387eeca6 (MISP Attribute #17569)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 1b6ef8b512ab768d76999d81387eeca6 (MISP Attribute #17569)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-7764-435a-bc52-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-7764-435a-bc52-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-7764-435a-bc52-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-7764-435a-bc52-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -759,14 +759,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-7a48-4aef-8735-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-7a48-4aef-8735-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 370db91c6eca64f63083d577049bba5b (MISP Attribute #17570)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 370db91c6eca64f63083d577049bba5b (MISP Attribute #17570)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-7a48-4aef-8735-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-7a48-4aef-8735-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-7a48-4aef-8735-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-7a48-4aef-8735-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -785,14 +785,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-64f4-4a1a-8a35-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-64f4-4a1a-8a35-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: dd9826b9dc747f625015d24ccd22acd6 (MISP Attribute #17571)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: dd9826b9dc747f625015d24ccd22acd6 (MISP Attribute #17571)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-64f4-4a1a-8a35-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-64f4-4a1a-8a35-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-64f4-4a1a-8a35-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-64f4-4a1a-8a35-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -811,14 +811,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-c1b0-4ee1-a1b4-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-c1b0-4ee1-a1b4-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 14465588c4b201fcb03366292b1112d8 (MISP Attribute #17572)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 14465588c4b201fcb03366292b1112d8 (MISP Attribute #17572)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-c1b0-4ee1-a1b4-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-c1b0-4ee1-a1b4-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-c1b0-4ee1-a1b4-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-c1b0-4ee1-a1b4-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -837,14 +837,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-f11c-4695-a426-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-f11c-4695-a426-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: a3125fdc709ff73ecf75447095fe4aa5 (MISP Attribute #17573)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: a3125fdc709ff73ecf75447095fe4aa5 (MISP Attribute #17573)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-f11c-4695-a426-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-f11c-4695-a426-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-f11c-4695-a426-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-f11c-4695-a426-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -863,14 +863,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-ee88-42ff-a6c6-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-ee88-42ff-a6c6-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 9cecb0bd8ccf9be70a1a24c729514bda (MISP Attribute #17574)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 9cecb0bd8ccf9be70a1a24c729514bda (MISP Attribute #17574)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-ee88-42ff-a6c6-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-ee88-42ff-a6c6-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-ee88-42ff-a6c6-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-ee88-42ff-a6c6-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -889,14 +889,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-c4e4-41c1-8e91-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-c4e4-41c1-8e91-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: eb45d72b786904fe7e5e2376b845061d (MISP Attribute #17575)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: eb45d72b786904fe7e5e2376b845061d (MISP Attribute #17575)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-c4e4-41c1-8e91-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-c4e4-41c1-8e91-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-c4e4-41c1-8e91-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-c4e4-41c1-8e91-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -915,14 +915,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-b8f0-4e75-95f4-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-b8f0-4e75-95f4-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: e220361db365f017583705ec341bd15b (MISP Attribute #17576)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: e220361db365f017583705ec341bd15b (MISP Attribute #17576)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-b8f0-4e75-95f4-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-b8f0-4e75-95f4-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-b8f0-4e75-95f4-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-b8f0-4e75-95f4-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -941,14 +941,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-cfc0-480c-8223-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-cfc0-480c-8223-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 3c124dfd026c71b6035beb5c2499ae26 (MISP Attribute #17577)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 3c124dfd026c71b6035beb5c2499ae26 (MISP Attribute #17577)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-cfc0-480c-8223-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-cfc0-480c-8223-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-cfc0-480c-8223-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-cfc0-480c-8223-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -967,14 +967,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-cfe8-4f1e-8e8a-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-cfe8-4f1e-8e8a-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 74d5c71cc073ccedafefcb10fde91e04 (MISP Attribute #17578)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 74d5c71cc073ccedafefcb10fde91e04 (MISP Attribute #17578)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-cfe8-4f1e-8e8a-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-cfe8-4f1e-8e8a-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-cfe8-4f1e-8e8a-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-cfe8-4f1e-8e8a-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -993,14 +993,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9c5-d0d8-4264-92c7-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9c5-d0d8-4264-92c7-11098e96ca05" timestamp="2017-12-06T09:08:05+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: ae2161510ef99f71afaa7cf69a8f814c (MISP Attribute #17579)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: ae2161510ef99f71afaa7cf69a8f814c (MISP Attribute #17579)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9c5-d0d8-4264-92c7-11098e96ca05">
-                                        <cybox:Object id=":File-5a27f9c5-d0d8-4264-92c7-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9c5-d0d8-4264-92c7-11098e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a27f9c5-d0d8-4264-92c7-11098e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1019,14 +1019,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27fa44-40d8-4732-94b1-11098e96ca05" timestamp="2017-12-06T09:10:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27fa44-40d8-4732-94b1-11098e96ca05" timestamp="2017-12-06T09:10:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: PerfIPC (MISP Attribute #17590)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Host Characteristics</indicator:Type>
                                     <indicator:Description>Artifacts dropped: PerfIPC (MISP Attribute #17590)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27fa44-40d8-4732-94b1-11098e96ca05">
-                                        <cybox:Object id=":Mutex-5a27fa44-40d8-4732-94b1-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27fa44-40d8-4732-94b1-11098e96ca05">
+                                        <cybox:Object id="citizenlab:Mutex-5a27fa44-40d8-4732-94b1-11098e96ca05">
                                             <cybox:Properties xsi:type="MutexObj:MutexObjectType">
                                                 <MutexObj:Name condition="Equals">PerfIPC</MutexObj:Name>
                                             </cybox:Properties>
@@ -1040,14 +1040,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27fa44-0978-4448-9bf1-11098e96ca05" timestamp="2017-12-06T09:10:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27fa44-0978-4448-9bf1-11098e96ca05" timestamp="2017-12-06T09:10:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: STORAGE_MUTEX (MISP Attribute #17591)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Host Characteristics</indicator:Type>
                                     <indicator:Description>Artifacts dropped: STORAGE_MUTEX (MISP Attribute #17591)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27fa44-0978-4448-9bf1-11098e96ca05">
-                                        <cybox:Object id=":Mutex-5a27fa44-0978-4448-9bf1-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27fa44-0978-4448-9bf1-11098e96ca05">
+                                        <cybox:Object id="citizenlab:Mutex-5a27fa44-0978-4448-9bf1-11098e96ca05">
                                             <cybox:Properties xsi:type="MutexObj:MutexObjectType">
                                                 <MutexObj:Name condition="Equals">STORAGE_MUTEX</MutexObj:Name>
                                             </cybox:Properties>
@@ -1061,14 +1061,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27fa44-438c-497a-b355-11098e96ca05" timestamp="2017-12-06T09:10:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27fa44-438c-497a-b355-11098e96ca05" timestamp="2017-12-06T09:10:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: Global\76467a526e3f430f870f2d48876b77b7 (MISP Attribute #17592)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Host Characteristics</indicator:Type>
                                     <indicator:Description>Artifacts dropped: Global\76467a526e3f430f870f2d48876b77b7 (MISP Attribute #17592)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27fa44-438c-497a-b355-11098e96ca05">
-                                        <cybox:Object id=":Mutex-5a27fa44-438c-497a-b355-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27fa44-438c-497a-b355-11098e96ca05">
+                                        <cybox:Object id="citizenlab:Mutex-5a27fa44-438c-497a-b355-11098e96ca05">
                                             <cybox:Properties xsi:type="MutexObj:MutexObjectType">
                                                 <MutexObj:Name condition="Equals">Global\76467a526e3f430f870f2d48876b77b7</MutexObj:Name>
                                             </cybox:Properties>
@@ -1082,14 +1082,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27fa44-c94c-405b-b213-11098e96ca05" timestamp="2017-12-06T09:10:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27fa44-c94c-405b-b213-11098e96ca05" timestamp="2017-12-06T09:10:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: Global\6efa80dda7d8489f931cc9b2eac58777 (MISP Attribute #17593)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Host Characteristics</indicator:Type>
                                     <indicator:Description>Artifacts dropped: Global\6efa80dda7d8489f931cc9b2eac58777 (MISP Attribute #17593)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27fa44-c94c-405b-b213-11098e96ca05">
-                                        <cybox:Object id=":Mutex-5a27fa44-c94c-405b-b213-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27fa44-c94c-405b-b213-11098e96ca05">
+                                        <cybox:Object id="citizenlab:Mutex-5a27fa44-c94c-405b-b213-11098e96ca05">
                                             <cybox:Properties xsi:type="MutexObj:MutexObjectType">
                                                 <MutexObj:Name condition="Equals">Global\6efa80dda7d8489f931cc9b2eac58777</MutexObj:Name>
                                             </cybox:Properties>
@@ -1103,14 +1103,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27fa36-8c68-4682-ab5c-11098e96ca05" timestamp="2017-12-06T09:09:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27fa36-8c68-4682-ab5c-11098e96ca05" timestamp="2017-12-06T09:09:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: \\.\pipe\BrowseIPC (MISP Attribute #17588)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Host Characteristics</indicator:Type>
                                     <indicator:Description>Artifacts dropped: \\.\pipe\BrowseIPC (MISP Attribute #17588)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27fa36-8c68-4682-ab5c-11098e96ca05">
-                                        <cybox:Object id=":Pipe-5a27fa36-8c68-4682-ab5c-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27fa36-8c68-4682-ab5c-11098e96ca05">
+                                        <cybox:Object id="citizenlab:Pipe-5a27fa36-8c68-4682-ab5c-11098e96ca05">
                                             <cybox:Properties xsi:type="PipeObj:PipeObjectType">
                                                 <PipeObj:Name condition="Equals">\\.\pipe\BrowseIPC</PipeObj:Name>
                                             </cybox:Properties>
@@ -1124,14 +1124,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27fa36-4e00-4a43-9aa1-11098e96ca05" timestamp="2017-12-06T09:09:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27fa36-4e00-4a43-9aa1-11098e96ca05" timestamp="2017-12-06T09:09:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: \\.\pipe\{82221195-6222-4854-8874-016aa4e9dd41} (MISP Attribute #17589)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Host Characteristics</indicator:Type>
                                     <indicator:Description>Artifacts dropped: \\.\pipe\{82221195-6222-4854-8874-016aa4e9dd41} (MISP Attribute #17589)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27fa36-4e00-4a43-9aa1-11098e96ca05">
-                                        <cybox:Object id=":Pipe-5a27fa36-4e00-4a43-9aa1-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27fa36-4e00-4a43-9aa1-11098e96ca05">
+                                        <cybox:Object id="citizenlab:Pipe-5a27fa36-4e00-4a43-9aa1-11098e96ca05">
                                             <cybox:Properties xsi:type="PipeObj:PipeObjectType">
                                                 <PipeObj:Name condition="Equals">\\.\pipe\{82221195-6222-4854-8874-016aa4e9dd41}</PipeObj:Name>
                                             </cybox:Properties>
@@ -1145,14 +1145,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27fa29-2f2c-428e-971b-11098e96ca05" timestamp="2017-12-06T09:09:45+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27fa29-2f2c-428e-971b-11098e96ca05" timestamp="2017-12-06T09:09:45+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: pssts1.nozonenet.com (MISP Attribute #17585)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: pssts1.nozonenet.com (MISP Attribute #17585)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27fa29-2f2c-428e-971b-11098e96ca05">
-                                        <cybox:Object id=":DomainName-5a27fa29-2f2c-428e-971b-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27fa29-2f2c-428e-971b-11098e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a27fa29-2f2c-428e-971b-11098e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">pssts1.nozonenet.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1166,14 +1166,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27fa29-c180-4131-8e5d-11098e96ca05" timestamp="2017-12-06T09:09:45+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27fa29-c180-4131-8e5d-11098e96ca05" timestamp="2017-12-06T09:09:45+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: time-local.com (MISP Attribute #17586)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: time-local.com (MISP Attribute #17586)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27fa29-c180-4131-8e5d-11098e96ca05">
-                                        <cybox:Object id=":DomainName-5a27fa29-c180-4131-8e5d-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27fa29-c180-4131-8e5d-11098e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a27fa29-c180-4131-8e5d-11098e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">time-local.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1187,14 +1187,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27fa29-36d8-4b5e-bef3-11098e96ca05" timestamp="2017-12-06T09:09:45+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27fa29-36d8-4b5e-bef3-11098e96ca05" timestamp="2017-12-06T09:09:45+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: time-local.net (MISP Attribute #17587)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: time-local.net (MISP Attribute #17587)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27fa29-36d8-4b5e-bef3-11098e96ca05">
-                                        <cybox:Object id=":DomainName-5a27fa29-36d8-4b5e-bef3-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27fa29-36d8-4b5e-bef3-11098e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a27fa29-36d8-4b5e-bef3-11098e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">time-local.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1208,14 +1208,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27fac9-1f90-405a-8145-11098e96ca05" timestamp="2017-12-06T09:12:25+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27fac9-1f90-405a-8145-11098e96ca05" timestamp="2017-12-06T09:12:25+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: pupki.co (MISP Attribute #17594)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: pupki.co (MISP Attribute #17594)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27fac9-1f90-405a-8145-11098e96ca05">
-                                        <cybox:Object id=":DomainName-5a27fac9-1f90-405a-8145-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27fac9-1f90-405a-8145-11098e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a27fac9-1f90-405a-8145-11098e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">pupki.co</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1229,14 +1229,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a281504-1720-4c8f-90c1-11098e96ca05" timestamp="2017-12-06T11:04:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a281504-1720-4c8f-90c1-11098e96ca05" timestamp="2017-12-06T11:04:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: eastafro.net (MISP Attribute #17595)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: eastafro.net (MISP Attribute #17595)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a281504-1720-4c8f-90c1-11098e96ca05">
-                                        <cybox:Object id=":DomainName-5a281504-1720-4c8f-90c1-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a281504-1720-4c8f-90c1-11098e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a281504-1720-4c8f-90c1-11098e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">eastafro.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1250,14 +1250,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a281504-7ee0-446f-bd09-11098e96ca05" timestamp="2017-12-06T11:04:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a281504-7ee0-446f-bd09-11098e96ca05" timestamp="2017-12-06T11:04:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: getadobeplayer.com (MISP Attribute #17596)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: getadobeplayer.com (MISP Attribute #17596)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a281504-7ee0-446f-bd09-11098e96ca05">
-                                        <cybox:Object id=":DomainName-5a281504-7ee0-446f-bd09-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a281504-7ee0-446f-bd09-11098e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a281504-7ee0-446f-bd09-11098e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">getadobeplayer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1271,14 +1271,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a281504-f94c-4e52-8866-11098e96ca05" timestamp="2017-12-06T11:04:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a281504-f94c-4e52-8866-11098e96ca05" timestamp="2017-12-06T11:04:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: diretube.co.uk (MISP Attribute #17597)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: diretube.co.uk (MISP Attribute #17597)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a281504-f94c-4e52-8866-11098e96ca05">
-                                        <cybox:Object id=":DomainName-5a281504-f94c-4e52-8866-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a281504-f94c-4e52-8866-11098e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a281504-f94c-4e52-8866-11098e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">diretube.co.uk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1292,14 +1292,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a281504-6d78-458c-834f-11098e96ca05" timestamp="2017-12-06T11:04:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a281504-6d78-458c-834f-11098e96ca05" timestamp="2017-12-06T11:04:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: meskereme.net (MISP Attribute #17598)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: meskereme.net (MISP Attribute #17598)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a281504-6d78-458c-834f-11098e96ca05">
-                                        <cybox:Object id=":DomainName-5a281504-6d78-458c-834f-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a281504-6d78-458c-834f-11098e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a281504-6d78-458c-834f-11098e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">meskereme.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1313,14 +1313,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9f0-b9fc-4809-bbdb-11098e96ca05" timestamp="2017-12-06T09:08:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9f0-b9fc-4809-bbdb-11098e96ca05" timestamp="2017-12-06T09:08:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://pssts1.nozonenet.com/ts8/ts8.php (MISP Attribute #17580)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://pssts1.nozonenet.com/ts8/ts8.php (MISP Attribute #17580)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9f0-b9fc-4809-bbdb-11098e96ca05">
-                                        <cybox:Object id=":URI-5a27f9f0-b9fc-4809-bbdb-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9f0-b9fc-4809-bbdb-11098e96ca05">
+                                        <cybox:Object id="citizenlab:URI-5a27f9f0-b9fc-4809-bbdb-11098e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://pssts1.nozonenet.com/ts8/ts8.php</URIObj:Value>
                                             </cybox:Properties>
@@ -1334,14 +1334,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9f0-8b98-4c33-bfce-11098e96ca05" timestamp="2017-12-06T09:08:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9f0-8b98-4c33-bfce-11098e96ca05" timestamp="2017-12-06T09:08:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://time-local.com/ (MISP Attribute #17581)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://time-local.com/ (MISP Attribute #17581)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9f0-8b98-4c33-bfce-11098e96ca05">
-                                        <cybox:Object id=":URI-5a27f9f0-8b98-4c33-bfce-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9f0-8b98-4c33-bfce-11098e96ca05">
+                                        <cybox:Object id="citizenlab:URI-5a27f9f0-8b98-4c33-bfce-11098e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://time-local.com/</URIObj:Value>
                                             </cybox:Properties>
@@ -1355,14 +1355,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9f0-de2c-4a55-91a9-11098e96ca05" timestamp="2017-12-06T09:08:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9f0-de2c-4a55-91a9-11098e96ca05" timestamp="2017-12-06T09:08:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://time-local.net/ (MISP Attribute #17582)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://time-local.net/ (MISP Attribute #17582)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9f0-de2c-4a55-91a9-11098e96ca05">
-                                        <cybox:Object id=":URI-5a27f9f0-de2c-4a55-91a9-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9f0-de2c-4a55-91a9-11098e96ca05">
+                                        <cybox:Object id="citizenlab:URI-5a27f9f0-de2c-4a55-91a9-11098e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://time-local.net/</URIObj:Value>
                                             </cybox:Properties>
@@ -1376,14 +1376,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9f0-ff88-4631-90ae-11098e96ca05" timestamp="2017-12-06T09:08:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9f0-ff88-4631-90ae-11098e96ca05" timestamp="2017-12-06T09:08:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://time-local.com/ts.php (MISP Attribute #17583)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://time-local.com/ts.php (MISP Attribute #17583)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9f0-ff88-4631-90ae-11098e96ca05">
-                                        <cybox:Object id=":URI-5a27f9f0-ff88-4631-90ae-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9f0-ff88-4631-90ae-11098e96ca05">
+                                        <cybox:Object id="citizenlab:URI-5a27f9f0-ff88-4631-90ae-11098e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://time-local.com/ts.php</URIObj:Value>
                                             </cybox:Properties>
@@ -1397,14 +1397,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a27f9f0-0654-4388-adcc-11098e96ca05" timestamp="2017-12-06T09:08:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a27f9f0-0654-4388-adcc-11098e96ca05" timestamp="2017-12-06T09:08:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://time-local.net/ts.php (MISP Attribute #17584)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://time-local.net/ts.php (MISP Attribute #17584)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a27f9f0-0654-4388-adcc-11098e96ca05">
-                                        <cybox:Object id=":URI-5a27f9f0-0654-4388-adcc-11098e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a27f9f0-0654-4388-adcc-11098e96ca05">
+                                        <cybox:Object id="citizenlab:URI-5a27f9f0-0654-4388-adcc-11098e96ca05">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://time-local.net/ts.php</URIObj:Value>
                                             </cybox:Properties>

--- a/201801_SpyingOnABudget/stix.xml
+++ b/201801_SpyingOnABudget/stix.xml
@@ -26,7 +26,7 @@
 	xmlns:snortTM="http://stix.mitre.org/extensions/TestMechanism#Snort-1"
 	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:="https://rufus.citlab.utoronto.ca"
+	xmlns:citizenlab="https://rufus.citlab.utoronto.ca"
 	xmlns:xal="urn:oasis:names:tc:ciq:xal:3"
 	xmlns:xnl="urn:oasis:names:tc:ciq:xnl:3"
 	xmlns:xpil="urn:oasis:names:tc:ciq:xpil:3"
@@ -59,20 +59,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-40b66a4e-c1fc-4384-9166-cee0d655e858" version="1.1.1" timestamp="2018-01-16T21:37:25.459683+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-40b66a4e-c1fc-4384-9166-cee0d655e858" version="1.1.1" timestamp="2018-01-16T21:37:25.459683+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-584942e2-93e0-4626-ad82-0bbb8e96ca05" version="1.1.1" timestamp="2018-01-16T16:34:15+00:00">
+            <stix:Package id="citizenlab:STIXPackage-584942e2-93e0-4626-ad82-0bbb8e96ca05" version="1.1.1" timestamp="2018-01-16T16:34:15+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Spying on a Budget: Inside a Phishing Operation Targeting the Tibetan Community</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-584942e2-93e0-4626-ad82-0bbb8e96ca05" timestamp="2018-01-16T16:34:45+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-584942e2-93e0-4626-ad82-0bbb8e96ca05" timestamp="2018-01-16T16:34:45+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Spying on a Budget: Inside a Phishing Operation Targeting the Tibetan Community</incident:Title>
                         <incident:External_ID source="MISP Event">57</incident:External_ID>
                         <incident:Time>
@@ -83,14 +83,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5a1c-a8c4-46ff-a05d-06df8e96ca05" timestamp="2018-01-16T15:01:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5a1c-a8c4-46ff-a05d-06df8e96ca05" timestamp="2018-01-16T15:01:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 0963bee29e797ea7481be5f18f354029 (MISP Attribute #17923)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 0963bee29e797ea7481be5f18f354029 (MISP Attribute #17923)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e5a1c-a8c4-46ff-a05d-06df8e96ca05">
-                                        <cybox:Object id=":File-5a5e5a1c-a8c4-46ff-a05d-06df8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e5a1c-a8c4-46ff-a05d-06df8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a5e5a1c-a8c4-46ff-a05d-06df8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -109,14 +109,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5a2e-56e4-470b-81ab-06df8e96ca05" timestamp="2018-01-16T15:01:50+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5a2e-56e4-470b-81ab-06df8e96ca05" timestamp="2018-01-16T15:01:50+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 2ab43fc90a1928684b8590375643da52285b8625 (MISP Attribute #17924)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 2ab43fc90a1928684b8590375643da52285b8625 (MISP Attribute #17924)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e5a2e-56e4-470b-81ab-06df8e96ca05">
-                                        <cybox:Object id=":File-5a5e5a2e-56e4-470b-81ab-06df8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e5a2e-56e4-470b-81ab-06df8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a5e5a2e-56e4-470b-81ab-06df8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -135,14 +135,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5a36-8794-40c1-8259-06df8e96ca05" timestamp="2018-01-16T15:01:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5a36-8794-40c1-8259-06df8e96ca05" timestamp="2018-01-16T15:01:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: f5967a8f3db4f4f33e89976e39914fceff46401bd2243b29162e1ddeb61f8dd3 (MISP Attribute #17925)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: f5967a8f3db4f4f33e89976e39914fceff46401bd2243b29162e1ddeb61f8dd3 (MISP Attribute #17925)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e5a36-8794-40c1-8259-06df8e96ca05">
-                                        <cybox:Object id=":File-5a5e5a36-8794-40c1-8259-06df8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e5a36-8794-40c1-8259-06df8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a5e5a36-8794-40c1-8259-06df8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -161,7 +161,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5b10-e044-472f-8835-06df8e96ca05" timestamp="2018-01-16T15:05:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5b10-e044-472f-8835-06df8e96ca05" timestamp="2018-01-16T15:05:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: deepcliff@sina.com (MISP Attribute #17926)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: deepcliff@sina.com (MISP Attribute #17926)</indicator:Description>
@@ -174,7 +174,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5b26-6a78-436a-94a7-06df8e96ca05" timestamp="2018-01-16T15:05:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5b26-6a78-436a-94a7-06df8e96ca05" timestamp="2018-01-16T15:05:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: liang007@outlook.com (MISP Attribute #17927)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: liang007@outlook.com (MISP Attribute #17927)</indicator:Description>
@@ -187,7 +187,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5b53-0674-48b2-832d-06df8e96ca05" timestamp="2018-01-16T15:06:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5b53-0674-48b2-832d-06df8e96ca05" timestamp="2018-01-16T15:06:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: directoriaffairs@outlook.com (MISP Attribute #17928)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: directoriaffairs@outlook.com (MISP Attribute #17928)</indicator:Description>
@@ -200,7 +200,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5b62-f8a0-4b4c-b538-06df8e96ca05" timestamp="2018-01-16T15:06:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5b62-f8a0-4b4c-b538-06df8e96ca05" timestamp="2018-01-16T15:06:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: leungguodong@outlook.com (MISP Attribute #17929)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: leungguodong@outlook.com (MISP Attribute #17929)</indicator:Description>
@@ -213,7 +213,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5b7c-3644-4d50-8705-06df8e96ca05" timestamp="2018-01-16T15:07:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5b7c-3644-4d50-8705-06df8e96ca05" timestamp="2018-01-16T15:07:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: zhuchangzi@outlook.com (MISP Attribute #17930)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: zhuchangzi@outlook.com (MISP Attribute #17930)</indicator:Description>
@@ -226,7 +226,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5bdd-90b0-487e-9c6f-06df8e96ca05" timestamp="2018-01-16T15:09:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5bdd-90b0-487e-9c6f-06df8e96ca05" timestamp="2018-01-16T15:09:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: uglybeeking@hotmail.com (MISP Attribute #17931)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: uglybeeking@hotmail.com (MISP Attribute #17931)</indicator:Description>
@@ -239,7 +239,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5bdd-9c1c-442e-8380-06df8e96ca05" timestamp="2018-01-16T15:09:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5bdd-9c1c-442e-8380-06df8e96ca05" timestamp="2018-01-16T15:09:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: styloveyou@163.com (MISP Attribute #17932)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: styloveyou@163.com (MISP Attribute #17932)</indicator:Description>
@@ -252,7 +252,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5bdd-dd78-44b0-9462-06df8e96ca05" timestamp="2018-01-16T15:09:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5bdd-dd78-44b0-9462-06df8e96ca05" timestamp="2018-01-16T15:09:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: evalliang@163.com (MISP Attribute #17933)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: evalliang@163.com (MISP Attribute #17933)</indicator:Description>
@@ -265,7 +265,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5bdd-9d24-45f0-9bf5-06df8e96ca05" timestamp="2018-01-16T15:09:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5bdd-9d24-45f0-9bf5-06df8e96ca05" timestamp="2018-01-16T15:09:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: pangchokpa@gmail.com (MISP Attribute #17934)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: pangchokpa@gmail.com (MISP Attribute #17934)</indicator:Description>
@@ -278,7 +278,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5bdd-0a64-4079-b69d-06df8e96ca05" timestamp="2018-01-16T15:09:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5bdd-0a64-4079-b69d-06df8e96ca05" timestamp="2018-01-16T15:09:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: 6060841@qq.com (MISP Attribute #17935)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: 6060841@qq.com (MISP Attribute #17935)</indicator:Description>
@@ -291,14 +291,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-3004-4276-9bde-07298e96ca05" timestamp="2018-01-16T16:31:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-3004-4276-9bde-07298e96ca05" timestamp="2018-01-16T16:31:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https-drive-google.cf (MISP Attribute #15616)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https-drive-google.cf (MISP Attribute #15616)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-3004-4276-9bde-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-3004-4276-9bde-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-3004-4276-9bde-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-3004-4276-9bde-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https-drive-google.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -312,14 +312,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-323c-4ba6-8fd6-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-323c-4ba6-8fd6-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mydrive-accounts-google.ml (MISP Attribute #15617)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mydrive-accounts-google.ml (MISP Attribute #15617)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-323c-4ba6-8fd6-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-323c-4ba6-8fd6-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-323c-4ba6-8fd6-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-323c-4ba6-8fd6-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mydrive-accounts-google.ml</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -333,14 +333,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-fb10-4ec5-8f06-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-fb10-4ec5-8f06-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https-drive-accounts-goog1e.cf (MISP Attribute #15618)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https-drive-accounts-goog1e.cf (MISP Attribute #15618)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-fb10-4ec5-8f06-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-fb10-4ec5-8f06-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-fb10-4ec5-8f06-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-fb10-4ec5-8f06-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https-drive-accounts-goog1e.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -354,14 +354,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-d7c0-431d-935e-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-d7c0-431d-935e-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google-drive.gq (MISP Attribute #15619)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google-drive.gq (MISP Attribute #15619)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-d7c0-431d-935e-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-d7c0-431d-935e-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-d7c0-431d-935e-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-d7c0-431d-935e-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google-drive.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -375,14 +375,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-34fc-4f71-a8ba-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-34fc-4f71-a8ba-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https-drive-google.ml (MISP Attribute #15620)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https-drive-google.ml (MISP Attribute #15620)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-34fc-4f71-a8ba-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-34fc-4f71-a8ba-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-34fc-4f71-a8ba-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-34fc-4f71-a8ba-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https-drive-google.ml</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -396,14 +396,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-970c-4966-abc9-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-970c-4966-abc9-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-accounts-goog1e.cf (MISP Attribute #15621)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-accounts-goog1e.cf (MISP Attribute #15621)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-970c-4966-abc9-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-970c-4966-abc9-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-970c-4966-abc9-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-970c-4966-abc9-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-accounts-goog1e.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -417,14 +417,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-c2c8-4f33-89b8-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-c2c8-4f33-89b8-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsmydrive-accounts-goog1e.gq (MISP Attribute #15622)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsmydrive-accounts-goog1e.gq (MISP Attribute #15622)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-c2c8-4f33-89b8-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-c2c8-4f33-89b8-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-c2c8-4f33-89b8-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-c2c8-4f33-89b8-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsmydrive-accounts-goog1e.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -438,14 +438,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-e5d0-40eb-bbc4-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-e5d0-40eb-bbc4-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-accounts-google.ml (MISP Attribute #15623)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-accounts-google.ml (MISP Attribute #15623)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-e5d0-40eb-bbc4-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-e5d0-40eb-bbc4-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-e5d0-40eb-bbc4-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-e5d0-40eb-bbc4-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-accounts-google.ml</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -459,14 +459,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-2b9c-4091-89e8-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-2b9c-4091-89e8-07298e96ca05" timestamp="2018-01-16T16:34:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsgoogle-drive.gq (MISP Attribute #15624)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsgoogle-drive.gq (MISP Attribute #15624)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-2b9c-4091-89e8-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-2b9c-4091-89e8-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-2b9c-4091-89e8-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-2b9c-4091-89e8-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsgoogle-drive.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -480,14 +480,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-7ae4-4613-b3d5-07298e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-7ae4-4613-b3d5-07298e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsaccounts-google.ga (MISP Attribute #15625)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsaccounts-google.ga (MISP Attribute #15625)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-7ae4-4613-b3d5-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-7ae4-4613-b3d5-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-7ae4-4613-b3d5-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-7ae4-4613-b3d5-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsaccounts-google.ga</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -501,14 +501,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-b494-40f5-844b-07298e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-b494-40f5-844b-07298e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-goog1e.in (MISP Attribute #15626)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-goog1e.in (MISP Attribute #15626)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-b494-40f5-844b-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-b494-40f5-844b-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-b494-40f5-844b-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-b494-40f5-844b-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-goog1e.in</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -522,14 +522,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-d4e0-46cf-b549-07298e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-d4e0-46cf-b549-07298e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: microsoft-inc.us (MISP Attribute #15627)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: microsoft-inc.us (MISP Attribute #15627)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-d4e0-46cf-b549-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-d4e0-46cf-b549-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-d4e0-46cf-b549-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-d4e0-46cf-b549-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">microsoft-inc.us</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -543,14 +543,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-1618-4702-9a3e-07298e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-1618-4702-9a3e-07298e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: goog1e.space (MISP Attribute #15628)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: goog1e.space (MISP Attribute #15628)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-1618-4702-9a3e-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-1618-4702-9a3e-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-1618-4702-9a3e-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-1618-4702-9a3e-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">goog1e.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -564,14 +564,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-5e3c-415c-96c9-07298e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-5e3c-415c-96c9-07298e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-secret.com (MISP Attribute #15629)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-secret.com (MISP Attribute #15629)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-5e3c-415c-96c9-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-5e3c-415c-96c9-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-5e3c-415c-96c9-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-5e3c-415c-96c9-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-secret.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -585,14 +585,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828772-b108-4592-a9e2-0bbb8e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828772-b108-4592-a9e2-0bbb8e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: files-mail-google.ml (MISP Attribute #15630)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: files-mail-google.ml (MISP Attribute #15630)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828772-b108-4592-a9e2-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-58828772-b108-4592-a9e2-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828772-b108-4592-a9e2-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828772-b108-4592-a9e2-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">files-mail-google.ml</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -606,14 +606,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828772-603c-4ccc-ab02-0bbb8e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828772-603c-4ccc-ab02-0bbb8e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google-authorize.gq (MISP Attribute #15631)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google-authorize.gq (MISP Attribute #15631)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828772-603c-4ccc-ab02-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-58828772-603c-4ccc-ab02-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828772-603c-4ccc-ab02-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828772-603c-4ccc-ab02-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google-authorize.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -627,14 +627,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828772-0390-4cbb-a763-0bbb8e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828772-0390-4cbb-a763-0bbb8e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-google.gq (MISP Attribute #15632)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-google.gq (MISP Attribute #15632)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828772-0390-4cbb-a763-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-58828772-0390-4cbb-a763-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828772-0390-4cbb-a763-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828772-0390-4cbb-a763-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-google.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -648,14 +648,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-593ee83f-77c8-4e61-8dc0-53928e96ca05" timestamp="2017-06-12T15:15:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-593ee83f-77c8-4e61-8dc0-53928e96ca05" timestamp="2017-06-12T15:15:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myaccounts-gooog1e.com (MISP Attribute #16144)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myaccounts-gooog1e.com (MISP Attribute #16144)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-593ee83f-77c8-4e61-8dc0-53928e96ca05">
-                                        <cybox:Object id=":DomainName-593ee83f-77c8-4e61-8dc0-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-593ee83f-77c8-4e61-8dc0-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-593ee83f-77c8-4e61-8dc0-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myaccounts-gooog1e.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -669,14 +669,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6617-9f1c-4e58-add8-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6617-9f1c-4e58-add8-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.gmail-profile.com (MISP Attribute #17936)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.gmail-profile.com (MISP Attribute #17936)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6617-9f1c-4e58-add8-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6617-9f1c-4e58-add8-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6617-9f1c-4e58-add8-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6617-9f1c-4e58-add8-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.gmail-profile.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -690,14 +690,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828772-cac4-4aff-a5cc-0bbb8e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828772-cac4-4aff-a5cc-0bbb8e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google-settings.ml (MISP Attribute #15633)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google-settings.ml (MISP Attribute #15633)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828772-cac4-4aff-a5cc-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-58828772-cac4-4aff-a5cc-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828772-cac4-4aff-a5cc-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828772-cac4-4aff-a5cc-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google-settings.ml</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -711,14 +711,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6617-8fb0-45a7-b730-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6617-8fb0-45a7-b730-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.google-sign.tk (MISP Attribute #17937)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.google-sign.tk (MISP Attribute #17937)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6617-8fb0-45a7-b730-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6617-8fb0-45a7-b730-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6617-8fb0-45a7-b730-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6617-8fb0-45a7-b730-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.google-sign.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -732,14 +732,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6617-9444-4079-ad77-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6617-9444-4079-ad77-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive.postmailsecret.com (MISP Attribute #17938)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive.postmailsecret.com (MISP Attribute #17938)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6617-9444-4079-ad77-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6617-9444-4079-ad77-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6617-9444-4079-ad77-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6617-9444-4079-ad77-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive.postmailsecret.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -753,14 +753,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828772-5bd0-410b-87bf-0bbb8e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828772-5bd0-410b-87bf-0bbb8e96ca05" timestamp="2018-01-16T16:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-google-com.gq (MISP Attribute #15635)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-google-com.gq (MISP Attribute #15635)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828772-5bd0-410b-87bf-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-58828772-5bd0-410b-87bf-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828772-5bd0-410b-87bf-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828772-5bd0-410b-87bf-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-google-com.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -774,14 +774,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6617-cab0-4c5c-b2d3-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6617-cab0-4c5c-b2d3-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.drive-mail.online (MISP Attribute #17939)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.drive-mail.online (MISP Attribute #17939)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6617-cab0-4c5c-b2d3-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6617-cab0-4c5c-b2d3-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6617-cab0-4c5c-b2d3-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6617-cab0-4c5c-b2d3-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.drive-mail.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -795,14 +795,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6617-b918-45a8-a427-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6617-b918-45a8-a427-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webmail.postmailsecret.com (MISP Attribute #17940)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webmail.postmailsecret.com (MISP Attribute #17940)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6617-b918-45a8-a427-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6617-b918-45a8-a427-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6617-b918-45a8-a427-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6617-b918-45a8-a427-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webmail.postmailsecret.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -816,14 +816,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828772-d120-4619-b0a2-0bbb8e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828772-d120-4619-b0a2-0bbb8e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-mg16-yahoo.cf (MISP Attribute #15637)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-mg16-yahoo.cf (MISP Attribute #15637)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828772-d120-4619-b0a2-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-58828772-d120-4619-b0a2-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828772-d120-4619-b0a2-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828772-d120-4619-b0a2-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-mg16-yahoo.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -837,14 +837,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6617-c6e4-4925-b6ef-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6617-c6e4-4925-b6ef-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.yahoo-verification.us (MISP Attribute #17941)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.yahoo-verification.us (MISP Attribute #17941)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6617-c6e4-4925-b6ef-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6617-c6e4-4925-b6ef-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6617-c6e4-4925-b6ef-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6617-c6e4-4925-b6ef-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.yahoo-verification.us</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -858,14 +858,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6617-3c34-41c1-9a1d-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6617-3c34-41c1-9a1d-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.drive-mail.us (MISP Attribute #17942)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.drive-mail.us (MISP Attribute #17942)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6617-3c34-41c1-9a1d-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6617-3c34-41c1-9a1d-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6617-3c34-41c1-9a1d-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6617-3c34-41c1-9a1d-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.drive-mail.us</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -879,14 +879,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828772-5f6c-4ee7-adb7-0bbb8e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828772-5f6c-4ee7-adb7-0bbb8e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: yahoo-noreply.tk (MISP Attribute #15639)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: yahoo-noreply.tk (MISP Attribute #15639)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828772-5f6c-4ee7-adb7-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-58828772-5f6c-4ee7-adb7-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828772-5f6c-4ee7-adb7-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828772-5f6c-4ee7-adb7-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">yahoo-noreply.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -900,14 +900,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6617-ed6c-4dc4-9ef0-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6617-ed6c-4dc4-9ef0-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.login-live.us (MISP Attribute #17943)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.login-live.us (MISP Attribute #17943)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6617-ed6c-4dc4-9ef0-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6617-ed6c-4dc4-9ef0-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6617-ed6c-4dc4-9ef0-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6617-ed6c-4dc4-9ef0-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.login-live.us</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -921,14 +921,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828772-4ec0-4888-a537-0bbb8e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828772-4ec0-4888-a537-0bbb8e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: yahoo-secure.tk (MISP Attribute #15640)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: yahoo-secure.tk (MISP Attribute #15640)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828772-4ec0-4888-a537-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-58828772-4ec0-4888-a537-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828772-4ec0-4888-a537-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828772-4ec0-4888-a537-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">yahoo-secure.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -942,14 +942,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6617-de24-4be4-989c-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6617-de24-4be4-989c-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.drive-mail.info (MISP Attribute #17944)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.drive-mail.info (MISP Attribute #17944)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6617-de24-4be4-989c-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6617-de24-4be4-989c-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6617-de24-4be4-989c-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6617-de24-4be4-989c-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.drive-mail.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -963,14 +963,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59511af6-6c28-42aa-b561-06b28e96ca05" timestamp="2017-06-26T10:32:22+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59511af6-6c28-42aa-b561-06b28e96ca05" timestamp="2017-06-26T10:32:22+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-mailbox.space (MISP Attribute #16153)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-mailbox.space (MISP Attribute #16153)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59511af6-6c28-42aa-b561-06b28e96ca05">
-                                        <cybox:Object id=":DomainName-59511af6-6c28-42aa-b561-06b28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59511af6-6c28-42aa-b561-06b28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-59511af6-6c28-42aa-b561-06b28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-mailbox.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -984,14 +984,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6617-6b6c-4c4e-8981-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6617-6b6c-4c4e-8981-09238e96ca05" timestamp="2018-01-16T15:52:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts.gooog1e.com (MISP Attribute #17945)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts.gooog1e.com (MISP Attribute #17945)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6617-6b6c-4c4e-8981-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6617-6b6c-4c4e-8981-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6617-6b6c-4c4e-8981-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6617-6b6c-4c4e-8981-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts.gooog1e.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1005,14 +1005,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595120ce-76a0-4dc0-852e-06b38e96ca05" timestamp="2017-06-26T10:57:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595120ce-76a0-4dc0-852e-06b38e96ca05" timestamp="2017-06-26T10:57:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-defense.tk (MISP Attribute #16154)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-defense.tk (MISP Attribute #16154)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595120ce-76a0-4dc0-852e-06b38e96ca05">
-                                        <cybox:Object id=":DomainName-595120ce-76a0-4dc0-852e-06b38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595120ce-76a0-4dc0-852e-06b38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595120ce-76a0-4dc0-852e-06b38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-defense.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1026,14 +1026,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6618-7c7c-4624-8a90-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6618-7c7c-4624-8a90-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive.gooog1e.com (MISP Attribute #17946)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive.gooog1e.com (MISP Attribute #17946)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6618-7c7c-4624-8a90-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6618-7c7c-4624-8a90-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6618-7c7c-4624-8a90-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6618-7c7c-4624-8a90-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive.gooog1e.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1047,14 +1047,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6618-e678-425a-bb9f-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6618-e678-425a-bb9f-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive.mail-status.com (MISP Attribute #17947)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive.mail-status.com (MISP Attribute #17947)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6618-e678-425a-bb9f-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6618-e678-425a-bb9f-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6618-e678-425a-bb9f-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6618-e678-425a-bb9f-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive.mail-status.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1068,14 +1068,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6618-be5c-43ac-9491-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6618-be5c-43ac-9491-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive.myaccount-mail.com (MISP Attribute #17948)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive.myaccount-mail.com (MISP Attribute #17948)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6618-be5c-43ac-9491-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6618-be5c-43ac-9491-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6618-be5c-43ac-9491-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6618-be5c-43ac-9491-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive.myaccount-mail.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1089,14 +1089,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6618-8c7c-4664-9f5a-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6618-8c7c-4664-9f5a-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myaccount-mail.com (MISP Attribute #17949)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myaccount-mail.com (MISP Attribute #17949)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6618-8c7c-4664-9f5a-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6618-8c7c-4664-9f5a-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6618-8c7c-4664-9f5a-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6618-8c7c-4664-9f5a-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myaccount-mail.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1110,14 +1110,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828ebd-afe8-46f2-9782-07298e96ca05" timestamp="2017-01-20T17:27:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828ebd-afe8-46f2-9782-07298e96ca05" timestamp="2017-01-20T17:27:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: gmail-retry.tk (MISP Attribute #15646)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: gmail-retry.tk (MISP Attribute #15646)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828ebd-afe8-46f2-9782-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58828ebd-afe8-46f2-9782-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828ebd-afe8-46f2-9782-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828ebd-afe8-46f2-9782-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">gmail-retry.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1131,14 +1131,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6618-545c-4112-8d51-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6618-545c-4112-8d51-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https.drive-google.gq (MISP Attribute #17950)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https.drive-google.gq (MISP Attribute #17950)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6618-545c-4112-8d51-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6618-545c-4112-8d51-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6618-545c-4112-8d51-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6618-545c-4112-8d51-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https.drive-google.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1152,14 +1152,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828ebd-e824-48c2-888e-07298e96ca05" timestamp="2017-01-20T17:27:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828ebd-e824-48c2-888e-07298e96ca05" timestamp="2017-01-20T17:27:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-163.tk (MISP Attribute #15647)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-163.tk (MISP Attribute #15647)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828ebd-e824-48c2-888e-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58828ebd-e824-48c2-888e-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828ebd-e824-48c2-888e-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828ebd-e824-48c2-888e-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-163.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1173,14 +1173,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-5758-40af-b0d2-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-5758-40af-b0d2-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-google.co.in (MISP Attribute #17439)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-google.co.in (MISP Attribute #17439)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-5758-40af-b0d2-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-5758-40af-b0d2-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-5758-40af-b0d2-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-5758-40af-b0d2-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-google.co.in</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1194,14 +1194,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6618-37a8-4ec6-88ca-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6618-37a8-4ec6-88ca-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive.accounts-gooog1e.online (MISP Attribute #17951)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive.accounts-gooog1e.online (MISP Attribute #17951)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6618-37a8-4ec6-88ca-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6618-37a8-4ec6-88ca-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6618-37a8-4ec6-88ca-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6618-37a8-4ec6-88ca-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive.accounts-gooog1e.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1215,14 +1215,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58828ebd-ef30-4937-b5f0-07298e96ca05" timestamp="2017-01-20T17:27:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58828ebd-ef30-4937-b5f0-07298e96ca05" timestamp="2017-01-20T17:27:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: gmail-secure.tk (MISP Attribute #15648)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: gmail-secure.tk (MISP Attribute #15648)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58828ebd-ef30-4937-b5f0-07298e96ca05">
-                                        <cybox:Object id=":DomainName-58828ebd-ef30-4937-b5f0-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58828ebd-ef30-4937-b5f0-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58828ebd-ef30-4937-b5f0-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">gmail-secure.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1236,14 +1236,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-8b7c-47c4-9bca-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-8b7c-47c4-9bca-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dalailama.space (MISP Attribute #17440)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dalailama.space (MISP Attribute #17440)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-8b7c-47c4-9bca-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-8b7c-47c4-9bca-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-8b7c-47c4-9bca-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-8b7c-47c4-9bca-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dalailama.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1257,14 +1257,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6618-0500-41e5-b930-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6618-0500-41e5-b930-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webmail.dalailama.space (MISP Attribute #17952)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webmail.dalailama.space (MISP Attribute #17952)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6618-0500-41e5-b930-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6618-0500-41e5-b930-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6618-0500-41e5-b930-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6618-0500-41e5-b930-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webmail.dalailama.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1278,14 +1278,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-7720-47c6-8c44-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-7720-47c6-8c44-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: docs-mail.space (MISP Attribute #17441)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: docs-mail.space (MISP Attribute #17441)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-7720-47c6-8c44-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-7720-47c6-8c44-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-7720-47c6-8c44-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-7720-47c6-8c44-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">docs-mail.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1299,14 +1299,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6618-e1f8-4f65-b342-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6618-e1f8-4f65-b342-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.mail-protect.space (MISP Attribute #17953)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.mail-protect.space (MISP Attribute #17953)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6618-e1f8-4f65-b342-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6618-e1f8-4f65-b342-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6618-e1f8-4f65-b342-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6618-e1f8-4f65-b342-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.mail-protect.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1320,14 +1320,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-28c8-45b7-934a-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-28c8-45b7-934a-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-accounts-google.ga (MISP Attribute #17442)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-accounts-google.ga (MISP Attribute #17442)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-28c8-45b7-934a-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-28c8-45b7-934a-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-28c8-45b7-934a-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-28c8-45b7-934a-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-accounts-google.ga</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1341,14 +1341,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6618-baa4-404c-842e-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6618-baa4-404c-842e-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.mail-attachment-usercontent.space (MISP Attribute #17954)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.mail-attachment-usercontent.space (MISP Attribute #17954)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6618-baa4-404c-842e-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6618-baa4-404c-842e-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6618-baa4-404c-842e-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6618-baa4-404c-842e-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.mail-attachment-usercontent.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1362,14 +1362,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-82fc-4c1c-b200-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-82fc-4c1c-b200-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-google.cf (MISP Attribute #17443)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-google.cf (MISP Attribute #17443)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-82fc-4c1c-b200-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-82fc-4c1c-b200-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-82fc-4c1c-b200-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-82fc-4c1c-b200-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-google.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1383,14 +1383,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e6618-3184-4bb3-8947-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e6618-3184-4bb3-8947-09238e96ca05" timestamp="2018-01-16T15:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.drlve-gooog1e.com (MISP Attribute #17955)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.drlve-gooog1e.com (MISP Attribute #17955)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e6618-3184-4bb3-8947-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e6618-3184-4bb3-8947-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e6618-3184-4bb3-8947-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e6618-3184-4bb3-8947-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.drlve-gooog1e.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1404,14 +1404,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-ef74-4ea4-9173-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-ef74-4ea4-9173-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-google.gq (MISP Attribute #17444)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-google.gq (MISP Attribute #17444)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-ef74-4ea4-9173-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-ef74-4ea4-9173-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-ef74-4ea4-9173-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-ef74-4ea4-9173-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-google.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1425,14 +1425,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-a0ac-44d1-97d8-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-a0ac-44d1-97d8-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-google.me (MISP Attribute #17445)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-google.me (MISP Attribute #17445)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-a0ac-44d1-97d8-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-a0ac-44d1-97d8-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-a0ac-44d1-97d8-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-a0ac-44d1-97d8-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-google.me</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1446,14 +1446,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-336c-4698-bda5-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-336c-4698-bda5-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-google.ml (MISP Attribute #17446)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-google.ml (MISP Attribute #17446)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-336c-4698-bda5-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-336c-4698-bda5-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-336c-4698-bda5-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-336c-4698-bda5-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-google.ml</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1467,14 +1467,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595d4924-1ce8-45be-b051-06e38e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595d4924-1ce8-45be-b051-06e38e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myapp-gooog1e.com (MISP Attribute #16423)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myapp-gooog1e.com (MISP Attribute #16423)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595d4924-1ce8-45be-b051-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595d4924-1ce8-45be-b051-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595d4924-1ce8-45be-b051-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595d4924-1ce8-45be-b051-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myapp-gooog1e.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1488,14 +1488,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-d054-4b3d-8577-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-d054-4b3d-8577-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-google.space (MISP Attribute #17447)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-google.space (MISP Attribute #17447)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-d054-4b3d-8577-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-d054-4b3d-8577-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-d054-4b3d-8577-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-d054-4b3d-8577-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-google.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1509,14 +1509,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595d4924-e9ec-4caa-be6f-06e38e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595d4924-e9ec-4caa-be6f-06e38e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: email-netvigator.info (MISP Attribute #16424)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: email-netvigator.info (MISP Attribute #16424)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595d4924-e9ec-4caa-be6f-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595d4924-e9ec-4caa-be6f-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595d4924-e9ec-4caa-be6f-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595d4924-e9ec-4caa-be6f-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">email-netvigator.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1530,14 +1530,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-eb0c-48d0-a98d-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-eb0c-48d0-a98d-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: epochtimes.space (MISP Attribute #17448)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: epochtimes.space (MISP Attribute #17448)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-eb0c-48d0-a98d-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-eb0c-48d0-a98d-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-eb0c-48d0-a98d-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-eb0c-48d0-a98d-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">epochtimes.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1551,14 +1551,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595dc225-f7b0-4818-a102-06e38e96ca05" timestamp="2017-07-06T00:52:53+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595dc225-f7b0-4818-a102-06e38e96ca05" timestamp="2017-07-06T00:52:53+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-dsi-go.space (MISP Attribute #16425)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-dsi-go.space (MISP Attribute #16425)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595dc225-f7b0-4818-a102-06e38e96ca05">
-                                        <cybox:Object id=":DomainName-595dc225-f7b0-4818-a102-06e38e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595dc225-f7b0-4818-a102-06e38e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595dc225-f7b0-4818-a102-06e38e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-dsi-go.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1572,14 +1572,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb13-7070-44b6-a867-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb13-7070-44b6-a867-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: gmail-relation.tk (MISP Attribute #17449)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: gmail-relation.tk (MISP Attribute #17449)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb13-7070-44b6-a867-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb13-7070-44b6-a867-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb13-7070-44b6-a867-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb13-7070-44b6-a867-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">gmail-relation.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1593,14 +1593,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595dc260-a7f4-4875-b35b-06e28e96ca05" timestamp="2017-07-06T00:53:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595dc260-a7f4-4875-b35b-06e28e96ca05" timestamp="2017-07-06T00:53:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-continue.space (MISP Attribute #16426)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-continue.space (MISP Attribute #16426)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595dc260-a7f4-4875-b35b-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595dc260-a7f4-4875-b35b-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595dc260-a7f4-4875-b35b-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595dc260-a7f4-4875-b35b-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-continue.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1614,14 +1614,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-314c-4df1-a63c-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-314c-4df1-a63c-5f708e96ca05" timestamp="2017-11-22T16:24:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: gmail-ssl.tk (MISP Attribute #17450)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: gmail-ssl.tk (MISP Attribute #17450)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-314c-4df1-a63c-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-314c-4df1-a63c-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-314c-4df1-a63c-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-314c-4df1-a63c-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">gmail-ssl.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1635,14 +1635,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-595dc260-e70c-4de7-aac2-06e28e96ca05" timestamp="2017-07-06T00:53:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-595dc260-e70c-4de7-aac2-06e28e96ca05" timestamp="2017-07-06T00:53:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-package.space (MISP Attribute #16427)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-package.space (MISP Attribute #16427)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-595dc260-e70c-4de7-aac2-06e28e96ca05">
-                                        <cybox:Object id=":DomainName-595dc260-e70c-4de7-aac2-06e28e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-595dc260-e70c-4de7-aac2-06e28e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-595dc260-e70c-4de7-aac2-06e28e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-package.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1656,14 +1656,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-9ed0-4a34-ae55-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-9ed0-4a34-ae55-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google-issue.tk (MISP Attribute #17451)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google-issue.tk (MISP Attribute #17451)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-9ed0-4a34-ae55-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-9ed0-4a34-ae55-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-9ed0-4a34-ae55-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-9ed0-4a34-ae55-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google-issue.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1677,14 +1677,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-0558-4518-ac84-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-0558-4518-ac84-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google-sign.tk (MISP Attribute #17452)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google-sign.tk (MISP Attribute #17452)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-0558-4518-ac84-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-0558-4518-ac84-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-0558-4518-ac84-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-0558-4518-ac84-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google-sign.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1698,14 +1698,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-b3ec-4060-a321-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-b3ec-4060-a321-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsaccounts-google.cf (MISP Attribute #17453)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsaccounts-google.cf (MISP Attribute #17453)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-b3ec-4060-a321-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-b3ec-4060-a321-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-b3ec-4060-a321-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-b3ec-4060-a321-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsaccounts-google.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1719,14 +1719,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-853c-4a10-a97f-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-853c-4a10-a97f-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsdrive-google.gq (MISP Attribute #17454)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsdrive-google.gq (MISP Attribute #17454)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-853c-4a10-a97f-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-853c-4a10-a97f-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-853c-4a10-a97f-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-853c-4a10-a97f-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsdrive-google.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1740,14 +1740,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-595c-4990-a1e2-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-595c-4990-a1e2-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsdrive-myaccounts-google.cf (MISP Attribute #17455)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsdrive-myaccounts-google.cf (MISP Attribute #17455)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-595c-4990-a1e2-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-595c-4990-a1e2-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-595c-4990-a1e2-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-595c-4990-a1e2-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsdrive-myaccounts-google.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1761,14 +1761,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-1170-4c82-a6d3-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-1170-4c82-a6d3-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https-google-drive.ml (MISP Attribute #17456)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https-google-drive.ml (MISP Attribute #17456)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-1170-4c82-a6d3-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-1170-4c82-a6d3-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-1170-4c82-a6d3-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-1170-4c82-a6d3-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https-google-drive.ml</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1782,14 +1782,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-1884-4430-8e51-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-1884-4430-8e51-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https-my-accounts-google.gq (MISP Attribute #17457)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https-my-accounts-google.gq (MISP Attribute #17457)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-1884-4430-8e51-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-1884-4430-8e51-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-1884-4430-8e51-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-1884-4430-8e51-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https-my-accounts-google.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1803,14 +1803,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-c00c-4bab-83dc-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-c00c-4bab-83dc-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-guazi.com (MISP Attribute #17458)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-guazi.com (MISP Attribute #17458)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-c00c-4bab-83dc-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-c00c-4bab-83dc-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-c00c-4bab-83dc-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-c00c-4bab-83dc-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-guazi.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1824,14 +1824,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-b000-4b12-af5f-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-b000-4b12-af5f-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-secret.online (MISP Attribute #17459)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-secret.online (MISP Attribute #17459)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-b000-4b12-af5f-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-b000-4b12-af5f-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-b000-4b12-af5f-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-b000-4b12-af5f-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-secret.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1845,14 +1845,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-755c-4d9e-9a18-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-755c-4d9e-9a18-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-status.com (MISP Attribute #17460)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-status.com (MISP Attribute #17460)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-755c-4d9e-9a18-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-755c-4d9e-9a18-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-755c-4d9e-9a18-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-755c-4d9e-9a18-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-status.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1866,14 +1866,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-5bd8-4238-ae27-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-5bd8-4238-ae27-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myaccounts-google.space (MISP Attribute #17461)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myaccounts-google.space (MISP Attribute #17461)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-5bd8-4238-ae27-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-5bd8-4238-ae27-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-5bd8-4238-ae27-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-5bd8-4238-ae27-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myaccounts-google.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1887,14 +1887,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-a634-40f6-9cc0-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-a634-40f6-9cc0-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mydrive-google.space (MISP Attribute #17462)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mydrive-google.space (MISP Attribute #17462)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-a634-40f6-9cc0-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-a634-40f6-9cc0-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-a634-40f6-9cc0-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-a634-40f6-9cc0-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mydrive-google.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1908,14 +1908,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-9ebc-4d27-89de-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-9ebc-4d27-89de-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: my-office.cf (MISP Attribute #17463)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: my-office.cf (MISP Attribute #17463)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-9ebc-4d27-89de-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-9ebc-4d27-89de-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-9ebc-4d27-89de-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-9ebc-4d27-89de-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">my-office.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1929,14 +1929,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-7acc-436d-a895-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-7acc-436d-a895-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tibet-office.net (MISP Attribute #17464)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tibet-office.net (MISP Attribute #17464)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-7acc-436d-a895-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-7acc-436d-a895-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-7acc-436d-a895-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-7acc-436d-a895-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tibet-office.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1950,14 +1950,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a15eb14-9f00-4534-a69f-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a15eb14-9f00-4534-a69f-5f708e96ca05" timestamp="2017-11-22T16:24:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: yahoo-device.tk (MISP Attribute #17465)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: yahoo-device.tk (MISP Attribute #17465)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a15eb14-9f00-4534-a69f-5f708e96ca05">
-                                        <cybox:Object id=":DomainName-5a15eb14-9f00-4534-a69f-5f708e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a15eb14-9f00-4534-a69f-5f708e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a15eb14-9f00-4534-a69f-5f708e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">yahoo-device.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1971,14 +1971,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-588a5521-f080-4aad-93b1-0bbb8e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-588a5521-f080-4aad-93b1-0bbb8e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-google.cc (MISP Attribute #15684)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-google.cc (MISP Attribute #15684)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-588a5521-f080-4aad-93b1-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-588a5521-f080-4aad-93b1-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-588a5521-f080-4aad-93b1-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-588a5521-f080-4aad-93b1-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-google.cc</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1992,14 +1992,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5893a06c-4bd4-4112-97a8-0bbb8e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5893a06c-4bd4-4112-97a8-0bbb8e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsdocs-google.info (MISP Attribute #15689)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsdocs-google.info (MISP Attribute #15689)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5893a06c-4bd4-4112-97a8-0bbb8e96ca05">
-                                        <cybox:Object id=":DomainName-5893a06c-4bd4-4112-97a8-0bbb8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5893a06c-4bd4-4112-97a8-0bbb8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5893a06c-4bd4-4112-97a8-0bbb8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsdocs-google.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2013,14 +2013,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5907849c-97a4-4d52-aca1-5d828e96ca05" timestamp="2017-05-01T14:55:24+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5907849c-97a4-4d52-aca1-5d828e96ca05" timestamp="2017-05-01T14:55:24+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drlve-gooog1e.com (MISP Attribute #15961)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drlve-gooog1e.com (MISP Attribute #15961)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5907849c-97a4-4d52-aca1-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-5907849c-97a4-4d52-aca1-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5907849c-97a4-4d52-aca1-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5907849c-97a4-4d52-aca1-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drlve-gooog1e.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2034,14 +2034,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59078a5c-50a0-44b8-be71-53928e96ca05" timestamp="2017-05-01T15:19:56+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59078a5c-50a0-44b8-be71-53928e96ca05" timestamp="2017-05-01T15:19:56+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-youxinpai.com (MISP Attribute #15962)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-youxinpai.com (MISP Attribute #15962)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59078a5c-50a0-44b8-be71-53928e96ca05">
-                                        <cybox:Object id=":DomainName-59078a5c-50a0-44b8-be71-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59078a5c-50a0-44b8-be71-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-59078a5c-50a0-44b8-be71-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-youxinpai.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2055,14 +2055,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-590cd842-783c-4e0d-9d45-53928e96ca05" timestamp="2017-05-05T15:53:38+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-590cd842-783c-4e0d-9d45-53928e96ca05" timestamp="2017-05-05T15:53:38+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-gooog1e.asia (MISP Attribute #15963)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-gooog1e.asia (MISP Attribute #15963)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-590cd842-783c-4e0d-9d45-53928e96ca05">
-                                        <cybox:Object id=":DomainName-590cd842-783c-4e0d-9d45-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-590cd842-783c-4e0d-9d45-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-590cd842-783c-4e0d-9d45-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-gooog1e.asia</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2076,14 +2076,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-590cd918-792c-4c08-a3f7-53928e96ca05" timestamp="2017-05-05T15:57:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-590cd918-792c-4c08-a3f7-53928e96ca05" timestamp="2017-05-05T15:57:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-gooog1e.online (MISP Attribute #15964)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-gooog1e.online (MISP Attribute #15964)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-590cd918-792c-4c08-a3f7-53928e96ca05">
-                                        <cybox:Object id=":DomainName-590cd918-792c-4c08-a3f7-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-590cd918-792c-4c08-a3f7-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-590cd918-792c-4c08-a3f7-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-gooog1e.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2097,14 +2097,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-590cdccf-e228-4406-84c2-5d828e96ca05" timestamp="2017-05-05T16:13:03+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-590cdccf-e228-4406-84c2-5d828e96ca05" timestamp="2017-05-05T16:13:03+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-guazi.space (MISP Attribute #15965)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-guazi.space (MISP Attribute #15965)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-590cdccf-e228-4406-84c2-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-590cdccf-e228-4406-84c2-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-590cdccf-e228-4406-84c2-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-590cdccf-e228-4406-84c2-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-guazi.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2118,14 +2118,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-590cdff8-7884-467e-88d4-53938e96ca05" timestamp="2017-05-05T16:26:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-590cdff8-7884-467e-88d4-53938e96ca05" timestamp="2017-05-05T16:26:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-sina.space (MISP Attribute #15966)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-sina.space (MISP Attribute #15966)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-590cdff8-7884-467e-88d4-53938e96ca05">
-                                        <cybox:Object id=":DomainName-590cdff8-7884-467e-88d4-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-590cdff8-7884-467e-88d4-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-590cdff8-7884-467e-88d4-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-sina.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2139,14 +2139,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-590ce0f7-43d0-4e1e-9c10-53938e96ca05" timestamp="2017-05-05T16:30:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-590ce0f7-43d0-4e1e-9c10-53938e96ca05" timestamp="2017-05-05T16:30:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: winupdate.space (MISP Attribute #15967)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: winupdate.space (MISP Attribute #15967)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-590ce0f7-43d0-4e1e-9c10-53938e96ca05">
-                                        <cybox:Object id=":DomainName-590ce0f7-43d0-4e1e-9c10-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-590ce0f7-43d0-4e1e-9c10-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-590ce0f7-43d0-4e1e-9c10-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">winupdate.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2160,14 +2160,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-590ce20b-83b4-4cba-9dc7-53938e96ca05" timestamp="2017-05-05T16:35:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-590ce20b-83b4-4cba-9dc7-53938e96ca05" timestamp="2017-05-05T16:35:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ymail-settings.space (MISP Attribute #15968)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ymail-settings.space (MISP Attribute #15968)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-590ce20b-83b4-4cba-9dc7-53938e96ca05">
-                                        <cybox:Object id=":DomainName-590ce20b-83b4-4cba-9dc7-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-590ce20b-83b4-4cba-9dc7-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-590ce20b-83b4-4cba-9dc7-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ymail-settings.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2181,14 +2181,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59109412-5e18-4f66-be68-53928e96ca05" timestamp="2017-05-08T11:51:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59109412-5e18-4f66-be68-53928e96ca05" timestamp="2017-05-08T11:51:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-modular.space (MISP Attribute #15970)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-modular.space (MISP Attribute #15970)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59109412-5e18-4f66-be68-53928e96ca05">
-                                        <cybox:Object id=":DomainName-59109412-5e18-4f66-be68-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59109412-5e18-4f66-be68-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-59109412-5e18-4f66-be68-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-modular.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2202,14 +2202,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5910c536-b214-46e2-9385-5d828e96ca05" timestamp="2017-05-08T15:21:26+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5910c536-b214-46e2-9385-5d828e96ca05" timestamp="2017-05-08T15:21:26+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: login-live.space (MISP Attribute #15972)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: login-live.space (MISP Attribute #15972)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5910c536-b214-46e2-9385-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-5910c536-b214-46e2-9385-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5910c536-b214-46e2-9385-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5910c536-b214-46e2-9385-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">login-live.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2223,14 +2223,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5910c63a-bc38-4957-b1f0-5d828e96ca05" timestamp="2017-05-08T15:25:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5910c63a-bc38-4957-b1f0-5d828e96ca05" timestamp="2017-05-08T15:25:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: logln-yahoo.com (MISP Attribute #15973)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: logln-yahoo.com (MISP Attribute #15973)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5910c63a-bc38-4957-b1f0-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-5910c63a-bc38-4957-b1f0-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5910c63a-bc38-4957-b1f0-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5910c63a-bc38-4957-b1f0-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">logln-yahoo.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2244,14 +2244,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5910cb7b-bf90-463b-aba2-5d828e96ca05" timestamp="2017-05-08T15:48:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5910cb7b-bf90-463b-aba2-5d828e96ca05" timestamp="2017-05-08T15:48:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webmail-mpt.space (MISP Attribute #15974)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webmail-mpt.space (MISP Attribute #15974)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5910cb7b-bf90-463b-aba2-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-5910cb7b-bf90-463b-aba2-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5910cb7b-bf90-463b-aba2-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5910cb7b-bf90-463b-aba2-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webmail-mpt.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2265,14 +2265,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59123c8a-948c-4abd-b79b-5d828e96ca05" timestamp="2017-05-09T18:02:50+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59123c8a-948c-4abd-b79b-5d828e96ca05" timestamp="2017-05-09T18:02:50+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: wengiguowengui.space (MISP Attribute #15975)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: wengiguowengui.space (MISP Attribute #15975)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59123c8a-948c-4abd-b79b-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-59123c8a-948c-4abd-b79b-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59123c8a-948c-4abd-b79b-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-59123c8a-948c-4abd-b79b-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">wengiguowengui.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2286,14 +2286,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58b44b3a-c44c-4104-9ec1-53938e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58b44b3a-c44c-4104-9ec1-53938e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: yahoo-verification.us (MISP Attribute #15730)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: yahoo-verification.us (MISP Attribute #15730)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58b44b3a-c44c-4104-9ec1-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58b44b3a-c44c-4104-9ec1-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58b44b3a-c44c-4104-9ec1-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58b44b3a-c44c-4104-9ec1-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">yahoo-verification.us</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2307,14 +2307,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58b83e4a-9e80-4357-b4ef-53928e96ca05" timestamp="2017-03-02T10:46:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58b83e4a-9e80-4357-b4ef-53928e96ca05" timestamp="2017-03-02T10:46:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-mail.us (MISP Attribute #15736)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-mail.us (MISP Attribute #15736)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58b83e4a-9e80-4357-b4ef-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58b83e4a-9e80-4357-b4ef-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58b83e4a-9e80-4357-b4ef-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58b83e4a-9e80-4357-b4ef-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-mail.us</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2328,14 +2328,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58b84631-6960-41b3-b7a4-53938e96ca05" timestamp="2017-03-02T11:20:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58b84631-6960-41b3-b7a4-53938e96ca05" timestamp="2017-03-02T11:20:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: docs-mail-google.us (MISP Attribute #15738)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: docs-mail-google.us (MISP Attribute #15738)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58b84631-6960-41b3-b7a4-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58b84631-6960-41b3-b7a4-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58b84631-6960-41b3-b7a4-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58b84631-6960-41b3-b7a4-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">docs-mail-google.us</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2349,14 +2349,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58b98d25-6d24-4081-abae-53928e96ca05" timestamp="2017-03-03T10:35:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58b98d25-6d24-4081-abae-53928e96ca05" timestamp="2017-03-03T10:35:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: login-live.us (MISP Attribute #15739)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: login-live.us (MISP Attribute #15739)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58b98d25-6d24-4081-abae-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58b98d25-6d24-4081-abae-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58b98d25-6d24-4081-abae-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58b98d25-6d24-4081-abae-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">login-live.us</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2370,14 +2370,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58c2ce5b-4d04-488d-a6c5-53938e96ca05" timestamp="2017-03-10T11:03:39+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58c2ce5b-4d04-488d-a6c5-53938e96ca05" timestamp="2017-03-10T11:03:39+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-mail.info (MISP Attribute #15780)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-mail.info (MISP Attribute #15780)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58c2ce5b-4d04-488d-a6c5-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58c2ce5b-4d04-488d-a6c5-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58c2ce5b-4d04-488d-a6c5-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58c2ce5b-4d04-488d-a6c5-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-mail.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2391,14 +2391,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58c676e9-d594-4dcc-8daf-53928e96ca05" timestamp="2017-03-13T06:39:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58c676e9-d594-4dcc-8daf-53928e96ca05" timestamp="2017-03-13T06:39:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: gooog1e.com (MISP Attribute #15786)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: gooog1e.com (MISP Attribute #15786)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58c676e9-d594-4dcc-8daf-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58c676e9-d594-4dcc-8daf-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58c676e9-d594-4dcc-8daf-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58c676e9-d594-4dcc-8daf-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">gooog1e.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2412,14 +2412,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5919cd19-cb28-413f-9b83-53928e96ca05" timestamp="2017-05-15T11:45:29+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5919cd19-cb28-413f-9b83-53928e96ca05" timestamp="2017-05-15T11:45:29+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-defense.space (MISP Attribute #16043)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-defense.space (MISP Attribute #16043)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5919cd19-cb28-413f-9b83-53928e96ca05">
-                                        <cybox:Object id=":DomainName-5919cd19-cb28-413f-9b83-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5919cd19-cb28-413f-9b83-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5919cd19-cb28-413f-9b83-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-defense.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2433,14 +2433,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58c67caf-8e54-40a7-be8a-53928e96ca05" timestamp="2017-03-13T07:04:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58c67caf-8e54-40a7-be8a-53928e96ca05" timestamp="2017-03-13T07:04:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-goog1e.com (MISP Attribute #15788)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-goog1e.com (MISP Attribute #15788)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58c67caf-8e54-40a7-be8a-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58c67caf-8e54-40a7-be8a-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58c67caf-8e54-40a7-be8a-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58c67caf-8e54-40a7-be8a-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-goog1e.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2454,14 +2454,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-591e040b-ce60-45df-ba1e-5d828e96ca05" timestamp="2017-05-18T16:28:59+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-591e040b-ce60-45df-ba1e-5d828e96ca05" timestamp="2017-05-18T16:28:59+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: files-gooog1e.space (MISP Attribute #16044)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: files-gooog1e.space (MISP Attribute #16044)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-591e040b-ce60-45df-ba1e-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-591e040b-ce60-45df-ba1e-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-591e040b-ce60-45df-ba1e-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-591e040b-ce60-45df-ba1e-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">files-gooog1e.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2475,14 +2475,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58c91f4c-dfe8-4639-9ded-53938e96ca05" timestamp="2017-03-15T07:02:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58c91f4c-dfe8-4639-9ded-53938e96ca05" timestamp="2017-03-15T07:02:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mydrive-mail.asia (MISP Attribute #15789)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mydrive-mail.asia (MISP Attribute #15789)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58c91f4c-dfe8-4639-9ded-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58c91f4c-dfe8-4639-9ded-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58c91f4c-dfe8-4639-9ded-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58c91f4c-dfe8-4639-9ded-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mydrive-mail.asia</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2496,14 +2496,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-591e0d44-e8b8-4c0e-a959-5d828e96ca05" timestamp="2017-05-18T17:08:20+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-591e0d44-e8b8-4c0e-a959-5d828e96ca05" timestamp="2017-05-18T17:08:20+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-extend.space (MISP Attribute #16045)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-extend.space (MISP Attribute #16045)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-591e0d44-e8b8-4c0e-a959-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-591e0d44-e8b8-4c0e-a959-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-591e0d44-e8b8-4c0e-a959-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-591e0d44-e8b8-4c0e-a959-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-extend.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2517,14 +2517,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58dbfa91-0c20-4d50-83d8-53938e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58dbfa91-0c20-4d50-83d8-53938e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-gooog1e.info (MISP Attribute #15790)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-gooog1e.info (MISP Attribute #15790)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58dbfa91-0c20-4d50-83d8-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58dbfa91-0c20-4d50-83d8-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58dbfa91-0c20-4d50-83d8-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58dbfa91-0c20-4d50-83d8-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-gooog1e.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2538,14 +2538,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58dbfa91-d540-4a8b-a255-53938e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58dbfa91-d540-4a8b-a255-53938e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-secret.info (MISP Attribute #15792)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-secret.info (MISP Attribute #15792)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58dbfa91-d540-4a8b-a255-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58dbfa91-d540-4a8b-a255-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58dbfa91-d540-4a8b-a255-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58dbfa91-d540-4a8b-a255-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-secret.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2559,14 +2559,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58dbfabb-3344-4411-ba5c-53938e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58dbfabb-3344-4411-ba5c-53938e96ca05" timestamp="2018-01-16T16:34:13+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myaccounts-mail.com (MISP Attribute #15793)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myaccounts-mail.com (MISP Attribute #15793)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58dbfabb-3344-4411-ba5c-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58dbfabb-3344-4411-ba5c-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58dbfabb-3344-4411-ba5c-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58dbfabb-3344-4411-ba5c-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myaccounts-mail.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2580,14 +2580,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58dbfada-dd70-4742-8b09-53928e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58dbfada-dd70-4742-8b09-53928e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: yahoo-edit.us (MISP Attribute #15794)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: yahoo-edit.us (MISP Attribute #15794)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58dbfada-dd70-4742-8b09-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58dbfada-dd70-4742-8b09-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58dbfada-dd70-4742-8b09-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58dbfada-dd70-4742-8b09-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">yahoo-edit.us</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2601,14 +2601,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58dd97e8-ed28-4f49-811e-53938e96ca05" timestamp="2017-03-30T19:42:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58dd97e8-ed28-4f49-811e-53938e96ca05" timestamp="2017-03-30T19:42:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: account-gooogle.info (MISP Attribute #15796)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: account-gooogle.info (MISP Attribute #15796)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58dd97e8-ed28-4f49-811e-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58dd97e8-ed28-4f49-811e-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58dd97e8-ed28-4f49-811e-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58dd97e8-ed28-4f49-811e-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">account-gooogle.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2622,14 +2622,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58dd97e8-44dc-4bc3-ad48-53938e96ca05" timestamp="2017-03-30T19:42:32+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58dd97e8-44dc-4bc3-ad48-53938e96ca05" timestamp="2017-03-30T19:42:32+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: outlook-login.com (MISP Attribute #15797)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: outlook-login.com (MISP Attribute #15797)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58dd97e8-44dc-4bc3-ad48-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58dd97e8-44dc-4bc3-ad48-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58dd97e8-44dc-4bc3-ad48-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58dd97e8-44dc-4bc3-ad48-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">outlook-login.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2643,14 +2643,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58e2afc8-fb0c-40f7-9da1-53928e96ca05" timestamp="2017-04-03T16:25:44+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58e2afc8-fb0c-40f7-9da1-53928e96ca05" timestamp="2017-04-03T16:25:44+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-mail.space (MISP Attribute #15799)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-mail.space (MISP Attribute #15799)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58e2afc8-fb0c-40f7-9da1-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58e2afc8-fb0c-40f7-9da1-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58e2afc8-fb0c-40f7-9da1-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58e2afc8-fb0c-40f7-9da1-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-mail.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2664,14 +2664,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59272a06-6768-4f85-b5f9-5d828e96ca05" timestamp="2017-05-25T15:01:26+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59272a06-6768-4f85-b5f9-5d828e96ca05" timestamp="2017-05-25T15:01:26+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-platform.space (MISP Attribute #16064)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-platform.space (MISP Attribute #16064)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59272a06-6768-4f85-b5f9-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-59272a06-6768-4f85-b5f9-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59272a06-6768-4f85-b5f9-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-59272a06-6768-4f85-b5f9-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-platform.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2685,14 +2685,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-03c8-4bfd-9152-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-03c8-4bfd-9152-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google-protected.gq (MISP Attribute #15553)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google-protected.gq (MISP Attribute #15553)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-03c8-4bfd-9152-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-03c8-4bfd-9152-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-03c8-4bfd-9152-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-03c8-4bfd-9152-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google-protected.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2706,14 +2706,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-592c726a-2c78-4466-8ed6-53938e96ca05" timestamp="2017-05-29T15:11:38+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-592c726a-2c78-4466-8ed6-53938e96ca05" timestamp="2017-05-29T15:11:38+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-info.space (MISP Attribute #16065)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-info.space (MISP Attribute #16065)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-592c726a-2c78-4466-8ed6-53938e96ca05">
-                                        <cybox:Object id=":DomainName-592c726a-2c78-4466-8ed6-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-592c726a-2c78-4466-8ed6-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-592c726a-2c78-4466-8ed6-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-info.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2727,14 +2727,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-a574-41cd-932a-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-a574-41cd-932a-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https-mail-google.ml (MISP Attribute #15554)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https-mail-google.ml (MISP Attribute #15554)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-a574-41cd-932a-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-a574-41cd-932a-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-a574-41cd-932a-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-a574-41cd-932a-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https-mail-google.ml</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2748,14 +2748,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-592c7284-ab6c-4d44-9ff1-53938e96ca05" timestamp="2017-05-29T15:12:04+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-592c7284-ab6c-4d44-9ff1-53938e96ca05" timestamp="2017-05-29T15:12:04+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-goo.space (MISP Attribute #16066)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-goo.space (MISP Attribute #16066)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-592c7284-ab6c-4d44-9ff1-53938e96ca05">
-                                        <cybox:Object id=":DomainName-592c7284-ab6c-4d44-9ff1-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-592c7284-ab6c-4d44-9ff1-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-592c7284-ab6c-4d44-9ff1-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-goo.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2769,14 +2769,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-4ab0-4b27-9e1e-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-4ab0-4b27-9e1e-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsmail-google.cf (MISP Attribute #15555)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsmail-google.cf (MISP Attribute #15555)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-4ab0-4b27-9e1e-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-4ab0-4b27-9e1e-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-4ab0-4b27-9e1e-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-4ab0-4b27-9e1e-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsmail-google.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2790,14 +2790,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59304dd8-2f88-45ab-8a63-5d828e96ca05" timestamp="2017-06-01T13:24:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59304dd8-2f88-45ab-8a63-5d828e96ca05" timestamp="2017-06-01T13:24:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webmail-dalailama.space (MISP Attribute #16067)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webmail-dalailama.space (MISP Attribute #16067)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59304dd8-2f88-45ab-8a63-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-59304dd8-2f88-45ab-8a63-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59304dd8-2f88-45ab-8a63-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-59304dd8-2f88-45ab-8a63-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webmail-dalailama.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2811,14 +2811,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-8ac8-4e39-9241-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-8ac8-4e39-9241-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https-mail-google.gq (MISP Attribute #15556)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https-mail-google.gq (MISP Attribute #15556)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-8ac8-4e39-9241-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-8ac8-4e39-9241-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-8ac8-4e39-9241-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-8ac8-4e39-9241-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https-mail-google.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2832,14 +2832,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58e7b5c8-9a60-4396-b42c-53928e96ca05" timestamp="2017-04-07T11:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58e7b5c8-9a60-4396-b42c-53928e96ca05" timestamp="2017-04-07T11:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: cc-mail-secret.com (MISP Attribute #15812)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: cc-mail-secret.com (MISP Attribute #15812)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58e7b5c8-9a60-4396-b42c-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58e7b5c8-9a60-4396-b42c-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58e7b5c8-9a60-4396-b42c-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58e7b5c8-9a60-4396-b42c-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">cc-mail-secret.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2853,14 +2853,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5935b5e6-6838-4e13-8e4a-53928e96ca05" timestamp="2017-06-05T15:49:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5935b5e6-6838-4e13-8e4a-53928e96ca05" timestamp="2017-06-05T15:49:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: xin-corp.space (MISP Attribute #16068)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: xin-corp.space (MISP Attribute #16068)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5935b5e6-6838-4e13-8e4a-53928e96ca05">
-                                        <cybox:Object id=":DomainName-5935b5e6-6838-4e13-8e4a-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5935b5e6-6838-4e13-8e4a-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5935b5e6-6838-4e13-8e4a-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">xin-corp.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2874,14 +2874,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-7160-4d05-b9dd-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-7160-4d05-b9dd-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google-secure.gq (MISP Attribute #15557)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google-secure.gq (MISP Attribute #15557)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-7160-4d05-b9dd-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-7160-4d05-b9dd-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-7160-4d05-b9dd-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-7160-4d05-b9dd-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google-secure.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2895,14 +2895,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58e7b5c8-64c0-43cf-a8fd-53928e96ca05" timestamp="2017-04-07T11:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58e7b5c8-64c0-43cf-a8fd-53928e96ca05" timestamp="2017-04-07T11:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-goog1e.info (MISP Attribute #15813)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-goog1e.info (MISP Attribute #15813)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58e7b5c8-64c0-43cf-a8fd-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58e7b5c8-64c0-43cf-a8fd-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58e7b5c8-64c0-43cf-a8fd-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58e7b5c8-64c0-43cf-a8fd-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-goog1e.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2916,14 +2916,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5935b5e6-e930-41fe-9c27-53928e96ca05" timestamp="2017-06-05T15:49:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5935b5e6-e930-41fe-9c27-53928e96ca05" timestamp="2017-06-05T15:49:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-defend.space (MISP Attribute #16069)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-defend.space (MISP Attribute #16069)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5935b5e6-e930-41fe-9c27-53928e96ca05">
-                                        <cybox:Object id=":DomainName-5935b5e6-e930-41fe-9c27-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5935b5e6-e930-41fe-9c27-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5935b5e6-e930-41fe-9c27-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-defend.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2937,14 +2937,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58e7b5c8-f7f8-49f8-9246-53928e96ca05" timestamp="2017-04-07T11:52:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58e7b5c8-f7f8-49f8-9246-53928e96ca05" timestamp="2017-04-07T11:52:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-mail.online (MISP Attribute #15814)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-mail.online (MISP Attribute #15814)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58e7b5c8-f7f8-49f8-9246-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58e7b5c8-f7f8-49f8-9246-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58e7b5c8-f7f8-49f8-9246-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58e7b5c8-f7f8-49f8-9246-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-mail.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2958,14 +2958,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59396b77-c09c-4765-aac8-53938e96ca05" timestamp="2017-06-08T11:21:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59396b77-c09c-4765-aac8-53938e96ca05" timestamp="2017-06-08T11:21:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: appinstall-mail.space (MISP Attribute #16070)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: appinstall-mail.space (MISP Attribute #16070)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59396b77-c09c-4765-aac8-53938e96ca05">
-                                        <cybox:Object id=":DomainName-59396b77-c09c-4765-aac8-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59396b77-c09c-4765-aac8-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-59396b77-c09c-4765-aac8-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">appinstall-mail.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2979,14 +2979,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-3998-4684-961b-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-3998-4684-961b-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: gmail-profile.com (MISP Attribute #15559)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: gmail-profile.com (MISP Attribute #15559)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-3998-4684-961b-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-3998-4684-961b-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-3998-4684-961b-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-3998-4684-961b-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">gmail-profile.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3000,14 +3000,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58eba748-88cc-4103-b1f4-53938e96ca05" timestamp="2017-04-10T11:39:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58eba748-88cc-4103-b1f4-53938e96ca05" timestamp="2017-04-10T11:39:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-gooog1e.space (MISP Attribute #15815)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-gooog1e.space (MISP Attribute #15815)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58eba748-88cc-4103-b1f4-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58eba748-88cc-4103-b1f4-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58eba748-88cc-4103-b1f4-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58eba748-88cc-4103-b1f4-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-gooog1e.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3021,14 +3021,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-59396b77-2f9c-40dd-938c-53938e96ca05" timestamp="2017-06-08T11:21:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-59396b77-2f9c-40dd-938c-53938e96ca05" timestamp="2017-06-08T11:21:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: edit-ymail.space (MISP Attribute #16071)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: edit-ymail.space (MISP Attribute #16071)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-59396b77-2f9c-40dd-938c-53938e96ca05">
-                                        <cybox:Object id=":DomainName-59396b77-2f9c-40dd-938c-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-59396b77-2f9c-40dd-938c-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-59396b77-2f9c-40dd-938c-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">edit-ymail.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3042,14 +3042,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58eba748-1028-4648-a69f-53938e96ca05" timestamp="2017-04-10T11:39:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58eba748-1028-4648-a69f-53938e96ca05" timestamp="2017-04-10T11:39:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myaccounts-gooog1e.space (MISP Attribute #15816)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myaccounts-gooog1e.space (MISP Attribute #15816)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58eba748-1028-4648-a69f-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58eba748-1028-4648-a69f-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58eba748-1028-4648-a69f-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58eba748-1028-4648-a69f-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myaccounts-gooog1e.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3063,14 +3063,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-cd40-40b2-aeea-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-cd40-40b2-aeea-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hotmail-sign.com (MISP Attribute #15561)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hotmail-sign.com (MISP Attribute #15561)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-cd40-40b2-aeea-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-cd40-40b2-aeea-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-cd40-40b2-aeea-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-cd40-40b2-aeea-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hotmail-sign.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3084,14 +3084,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58eba748-0438-4514-bd1f-53938e96ca05" timestamp="2017-04-10T11:39:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58eba748-0438-4514-bd1f-53938e96ca05" timestamp="2017-04-10T11:39:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webmail-dalailama.com (MISP Attribute #15817)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webmail-dalailama.com (MISP Attribute #15817)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58eba748-0438-4514-bd1f-53938e96ca05">
-                                        <cybox:Object id=":DomainName-58eba748-0438-4514-bd1f-53938e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58eba748-0438-4514-bd1f-53938e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58eba748-0438-4514-bd1f-53938e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webmail-dalailama.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3105,14 +3105,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-e068-49d4-852b-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-e068-49d4-852b-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: yahoo-images.com (MISP Attribute #15562)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: yahoo-images.com (MISP Attribute #15562)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-e068-49d4-852b-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-e068-49d4-852b-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-e068-49d4-852b-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-e068-49d4-852b-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">yahoo-images.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3126,14 +3126,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-1a34-46ff-9a98-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-1a34-46ff-9a98-07298e96ca05" timestamp="2018-01-16T16:34:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: yahoo-safety.com (MISP Attribute #15563)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: yahoo-safety.com (MISP Attribute #15563)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-1a34-46ff-9a98-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-1a34-46ff-9a98-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-1a34-46ff-9a98-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-1a34-46ff-9a98-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">yahoo-safety.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3147,14 +3147,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-3c10-4fdc-98cb-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-3c10-4fdc-98cb-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google-post.com (MISP Attribute #15564)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google-post.com (MISP Attribute #15564)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-3c10-4fdc-98cb-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-3c10-4fdc-98cb-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-3c10-4fdc-98cb-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-3c10-4fdc-98cb-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google-post.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3168,14 +3168,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-8b3c-4300-a70b-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-8b3c-4300-a70b-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: yahoo-protect.com (MISP Attribute #15565)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: yahoo-protect.com (MISP Attribute #15565)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-8b3c-4300-a70b-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-8b3c-4300-a70b-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-8b3c-4300-a70b-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-8b3c-4300-a70b-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">yahoo-protect.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3189,14 +3189,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-ca80-495e-8d0c-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-ca80-495e-8d0c-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: gmail-safety.pw (MISP Attribute #15566)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: gmail-safety.pw (MISP Attribute #15566)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-ca80-495e-8d0c-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-ca80-495e-8d0c-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-ca80-495e-8d0c-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-ca80-495e-8d0c-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">gmail-safety.pw</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3210,14 +3210,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-b674-4ca5-9f07-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-b674-4ca5-9f07-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsdrive-google.pw (MISP Attribute #15567)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsdrive-google.pw (MISP Attribute #15567)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-b674-4ca5-9f07-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-b674-4ca5-9f07-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-b674-4ca5-9f07-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-b674-4ca5-9f07-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsdrive-google.pw</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3231,14 +3231,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-2abc-4a62-a220-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-2abc-4a62-a220-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-doubt.com (MISP Attribute #15568)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-doubt.com (MISP Attribute #15568)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-2abc-4a62-a220-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-2abc-4a62-a220-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-2abc-4a62-a220-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-2abc-4a62-a220-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-doubt.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3252,14 +3252,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-a0f0-4f2a-9149-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-a0f0-4f2a-9149-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: yahoomaintain.com (MISP Attribute #15569)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: yahoomaintain.com (MISP Attribute #15569)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-a0f0-4f2a-9149-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-a0f0-4f2a-9149-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-a0f0-4f2a-9149-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-a0f0-4f2a-9149-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">yahoomaintain.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3273,14 +3273,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-3dd8-4b9d-a1a9-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-3dd8-4b9d-a1a9-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: t1bet.net (MISP Attribute #15570)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: t1bet.net (MISP Attribute #15570)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-3dd8-4b9d-a1a9-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-3dd8-4b9d-a1a9-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-3dd8-4b9d-a1a9-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-3dd8-4b9d-a1a9-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">t1bet.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3294,14 +3294,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58ee49a7-7740-4766-9547-5d828e96ca05" timestamp="2017-04-12T11:37:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58ee49a7-7740-4766-9547-5d828e96ca05" timestamp="2017-04-12T11:37:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-aol.space (MISP Attribute #15826)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-aol.space (MISP Attribute #15826)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58ee49a7-7740-4766-9547-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-58ee49a7-7740-4766-9547-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58ee49a7-7740-4766-9547-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58ee49a7-7740-4766-9547-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-aol.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3315,14 +3315,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-be20-4fe3-92f4-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-be20-4fe3-92f4-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google-secret.com (MISP Attribute #15571)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google-secret.com (MISP Attribute #15571)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-be20-4fe3-92f4-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-be20-4fe3-92f4-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-be20-4fe3-92f4-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-be20-4fe3-92f4-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google-secret.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3336,14 +3336,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58ee4d32-1f88-411b-bbe5-5d828e96ca05" timestamp="2017-04-12T11:52:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58ee4d32-1f88-411b-bbe5-5d828e96ca05" timestamp="2017-04-12T11:52:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-epochtimes.space (MISP Attribute #15827)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-epochtimes.space (MISP Attribute #15827)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58ee4d32-1f88-411b-bbe5-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-58ee4d32-1f88-411b-bbe5-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58ee4d32-1f88-411b-bbe5-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58ee4d32-1f88-411b-bbe5-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-epochtimes.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3357,14 +3357,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-9df0-4ca1-948f-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-9df0-4ca1-948f-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accountsgoog1e.info (MISP Attribute #15572)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accountsgoog1e.info (MISP Attribute #15572)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-9df0-4ca1-948f-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-9df0-4ca1-948f-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-9df0-4ca1-948f-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-9df0-4ca1-948f-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accountsgoog1e.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3378,14 +3378,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58ee553c-4c6c-4fa6-8c2f-5d828e96ca05" timestamp="2017-04-12T12:26:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58ee553c-4c6c-4fa6-8c2f-5d828e96ca05" timestamp="2017-04-12T12:26:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-email.space (MISP Attribute #15828)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-email.space (MISP Attribute #15828)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58ee553c-4c6c-4fa6-8c2f-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-58ee553c-4c6c-4fa6-8c2f-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58ee553c-4c6c-4fa6-8c2f-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58ee553c-4c6c-4fa6-8c2f-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-email.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3399,14 +3399,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-8128-4bd5-9dbc-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-8128-4bd5-9dbc-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-google.info (MISP Attribute #15573)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-google.info (MISP Attribute #15573)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-8128-4bd5-9dbc-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-8128-4bd5-9dbc-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-8128-4bd5-9dbc-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-8128-4bd5-9dbc-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-google.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3420,14 +3420,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-7f20-46c1-9bd2-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-7f20-46c1-9bd2-07298e96ca05" timestamp="2018-01-16T16:34:15+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: accounts-goog1e.com (MISP Attribute #15574)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: accounts-goog1e.com (MISP Attribute #15574)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-7f20-46c1-9bd2-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-7f20-46c1-9bd2-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-7f20-46c1-9bd2-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-7f20-46c1-9bd2-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">accounts-goog1e.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3441,14 +3441,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58efbb0f-19b4-4a87-8f27-5d828e96ca05" timestamp="2017-04-13T13:53:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58efbb0f-19b4-4a87-8f27-5d828e96ca05" timestamp="2017-04-13T13:53:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: files-mail.space (MISP Attribute #15830)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: files-mail.space (MISP Attribute #15830)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58efbb0f-19b4-4a87-8f27-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-58efbb0f-19b4-4a87-8f27-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58efbb0f-19b4-4a87-8f27-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58efbb0f-19b4-4a87-8f27-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">files-mail.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3462,14 +3462,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-8644-420d-b070-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-8644-420d-b070-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: postmailsecret.com (MISP Attribute #15576)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: postmailsecret.com (MISP Attribute #15576)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-8644-420d-b070-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-8644-420d-b070-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-8644-420d-b070-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-8644-420d-b070-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">postmailsecret.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3483,14 +3483,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-5938-4cb4-9b4b-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-5938-4cb4-9b4b-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsaccounts-google.pw (MISP Attribute #15577)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsaccounts-google.pw (MISP Attribute #15577)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-5938-4cb4-9b4b-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-5938-4cb4-9b4b-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-5938-4cb4-9b4b-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-5938-4cb4-9b4b-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsaccounts-google.pw</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3504,14 +3504,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-d4ec-4a9f-a9cb-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-d4ec-4a9f-a9cb-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsaccounts-google.com (MISP Attribute #15578)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsaccounts-google.com (MISP Attribute #15578)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-d4ec-4a9f-a9cb-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-d4ec-4a9f-a9cb-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-d4ec-4a9f-a9cb-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-d4ec-4a9f-a9cb-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsaccounts-google.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3525,14 +3525,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-eb20-4b18-9740-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-eb20-4b18-9740-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsdrive-google.site (MISP Attribute #15580)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsdrive-google.site (MISP Attribute #15580)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-eb20-4b18-9740-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-eb20-4b18-9740-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-eb20-4b18-9740-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-eb20-4b18-9740-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsdrive-google.site</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3546,14 +3546,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-be78-4001-bb08-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-be78-4001-bb08-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https-drive-google.com (MISP Attribute #15581)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https-drive-google.com (MISP Attribute #15581)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-be78-4001-bb08-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-be78-4001-bb08-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-be78-4001-bb08-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-be78-4001-bb08-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https-drive-google.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3567,14 +3567,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-2c48-4b14-915e-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-2c48-4b14-915e-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsdrive-accounts-google.site (MISP Attribute #15582)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsdrive-accounts-google.site (MISP Attribute #15582)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-2c48-4b14-915e-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-2c48-4b14-915e-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-2c48-4b14-915e-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-2c48-4b14-915e-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsdrive-accounts-google.site</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3588,14 +3588,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-6b28-4688-9f8e-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-6b28-4688-9f8e-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsaccounts-google.site (MISP Attribute #15583)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsaccounts-google.site (MISP Attribute #15583)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-6b28-4688-9f8e-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-6b28-4688-9f8e-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-6b28-4688-9f8e-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-6b28-4688-9f8e-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsaccounts-google.site</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3609,14 +3609,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-cb00-4c50-9a6f-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-cb00-4c50-9a6f-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsmyaccounts-google.space (MISP Attribute #15585)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsmyaccounts-google.space (MISP Attribute #15585)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-cb00-4c50-9a6f-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-cb00-4c50-9a6f-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-cb00-4c50-9a6f-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-cb00-4c50-9a6f-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsmyaccounts-google.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3630,14 +3630,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-0aa8-4976-9e0b-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-0aa8-4976-9e0b-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsaccounts-google.info (MISP Attribute #15586)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsaccounts-google.info (MISP Attribute #15586)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-0aa8-4976-9e0b-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-0aa8-4976-9e0b-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-0aa8-4976-9e0b-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-0aa8-4976-9e0b-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsaccounts-google.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3651,14 +3651,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa321-4520-4b40-87c8-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa321-4520-4b40-87c8-07298e96ca05" timestamp="2018-01-16T16:34:16+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mydrive-google.com (MISP Attribute #15587)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mydrive-google.com (MISP Attribute #15587)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa321-4520-4b40-87c8-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa321-4520-4b40-87c8-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa321-4520-4b40-87c8-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa321-4520-4b40-87c8-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mydrive-google.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3672,14 +3672,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-7e2c-4594-aa21-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-7e2c-4594-aa21-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsmyaccount-google.info (MISP Attribute #15588)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsmyaccount-google.info (MISP Attribute #15588)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-7e2c-4594-aa21-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-7e2c-4594-aa21-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-7e2c-4594-aa21-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-7e2c-4594-aa21-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsmyaccount-google.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3693,14 +3693,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-ba50-47d9-82ba-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-ba50-47d9-82ba-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsdrive-google.net (MISP Attribute #15589)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsdrive-google.net (MISP Attribute #15589)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-ba50-47d9-82ba-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-ba50-47d9-82ba-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-ba50-47d9-82ba-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-ba50-47d9-82ba-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsdrive-google.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3714,14 +3714,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-0724-494e-bae1-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-0724-494e-bae1-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-accounts-google.com (MISP Attribute #15590)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-accounts-google.com (MISP Attribute #15590)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-0724-494e-bae1-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-0724-494e-bae1-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-0724-494e-bae1-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-0724-494e-bae1-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-accounts-google.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3735,14 +3735,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-a65c-4bd7-8c7d-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-a65c-4bd7-8c7d-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myaccountsgoogle.info (MISP Attribute #15591)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myaccountsgoogle.info (MISP Attribute #15591)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-a65c-4bd7-8c7d-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-a65c-4bd7-8c7d-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-a65c-4bd7-8c7d-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-a65c-4bd7-8c7d-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myaccountsgoogle.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3756,14 +3756,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-b95c-42f0-ab69-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-b95c-42f0-ab69-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mg-mail-yahoo.us (MISP Attribute #15593)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mg-mail-yahoo.us (MISP Attribute #15593)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-b95c-42f0-ab69-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-b95c-42f0-ab69-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-b95c-42f0-ab69-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-b95c-42f0-ab69-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mg-mail-yahoo.us</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3777,14 +3777,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-dadc-4b51-963d-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-dadc-4b51-963d-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: files-mail-qq.online (MISP Attribute #15594)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: files-mail-qq.online (MISP Attribute #15594)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-dadc-4b51-963d-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-dadc-4b51-963d-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-dadc-4b51-963d-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-dadc-4b51-963d-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">files-mail-qq.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3798,14 +3798,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-0718-42ca-a7e2-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-0718-42ca-a7e2-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mydrive-google.asia (MISP Attribute #15595)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mydrive-google.asia (MISP Attribute #15595)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-0718-42ca-a7e2-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-0718-42ca-a7e2-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-0718-42ca-a7e2-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-0718-42ca-a7e2-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mydrive-google.asia</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3819,14 +3819,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-4e2c-43dc-b683-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-4e2c-43dc-b683-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drivegoogle.biz (MISP Attribute #15596)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drivegoogle.biz (MISP Attribute #15596)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-4e2c-43dc-b683-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-4e2c-43dc-b683-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-4e2c-43dc-b683-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-4e2c-43dc-b683-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drivegoogle.biz</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3840,14 +3840,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-5284-467a-af2a-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-5284-467a-af2a-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myaccounts-google.online (MISP Attribute #15597)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myaccounts-google.online (MISP Attribute #15597)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-5284-467a-af2a-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-5284-467a-af2a-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-5284-467a-af2a-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-5284-467a-af2a-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myaccounts-google.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3861,14 +3861,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58f90cf2-98f0-4a03-a482-53928e96ca05" timestamp="2017-04-20T15:33:06+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58f90cf2-98f0-4a03-a482-53928e96ca05" timestamp="2017-04-20T15:33:06+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-gooog1e.info (MISP Attribute #15853)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-gooog1e.info (MISP Attribute #15853)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58f90cf2-98f0-4a03-a482-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58f90cf2-98f0-4a03-a482-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58f90cf2-98f0-4a03-a482-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58f90cf2-98f0-4a03-a482-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-gooog1e.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3882,14 +3882,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-56a4-4e03-ad12-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-56a4-4e03-ad12-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-qq.online (MISP Attribute #15598)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-qq.online (MISP Attribute #15598)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-56a4-4e03-ad12-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-56a4-4e03-ad12-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-56a4-4e03-ad12-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-56a4-4e03-ad12-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-qq.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3903,14 +3903,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-90d4-4f92-a61e-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-90d4-4f92-a61e-07298e96ca05" timestamp="2018-01-16T16:34:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mydrive-google.online (MISP Attribute #15599)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mydrive-google.online (MISP Attribute #15599)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-90d4-4f92-a61e-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-90d4-4f92-a61e-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-90d4-4f92-a61e-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-90d4-4f92-a61e-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mydrive-google.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3924,14 +3924,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58f9103e-e3a0-419f-80b8-5d828e96ca05" timestamp="2017-04-20T15:47:10+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58f9103e-e3a0-419f-80b8-5d828e96ca05" timestamp="2017-04-20T15:47:10+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-protect.space (MISP Attribute #15855)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-protect.space (MISP Attribute #15855)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58f9103e-e3a0-419f-80b8-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-58f9103e-e3a0-419f-80b8-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58f9103e-e3a0-419f-80b8-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58f9103e-e3a0-419f-80b8-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-protect.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3945,14 +3945,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-3fb4-4ae1-9474-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-3fb4-4ae1-9474-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myaccounts-google.info (MISP Attribute #15600)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myaccounts-google.info (MISP Attribute #15600)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-3fb4-4ae1-9474-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-3fb4-4ae1-9474-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-3fb4-4ae1-9474-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-3fb4-4ae1-9474-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myaccounts-google.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3966,14 +3966,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-ead0-4eae-891e-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-ead0-4eae-891e-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-mail-google.cf (MISP Attribute #15601)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-mail-google.cf (MISP Attribute #15601)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-ead0-4eae-891e-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-ead0-4eae-891e-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-ead0-4eae-891e-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-ead0-4eae-891e-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-mail-google.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3987,14 +3987,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-3504-44a3-9617-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-3504-44a3-9617-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-accounts-google.online (MISP Attribute #15602)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-accounts-google.online (MISP Attribute #15602)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-3504-44a3-9617-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-3504-44a3-9617-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-3504-44a3-9617-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-3504-44a3-9617-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-accounts-google.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4008,14 +4008,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-0730-4b97-aeba-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-0730-4b97-aeba-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsdrive-google.space (MISP Attribute #15603)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsdrive-google.space (MISP Attribute #15603)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-0730-4b97-aeba-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-0730-4b97-aeba-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-0730-4b97-aeba-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-0730-4b97-aeba-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsdrive-google.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4029,14 +4029,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-8410-4810-ac33-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-8410-4810-ac33-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsmail-google.ml (MISP Attribute #15604)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsmail-google.ml (MISP Attribute #15604)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-8410-4810-ac33-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-8410-4810-ac33-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-8410-4810-ac33-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-8410-4810-ac33-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsmail-google.ml</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4050,14 +4050,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-c228-40b2-b26f-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-c228-40b2-b26f-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-accounts-gooogle.com (MISP Attribute #15605)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-accounts-gooogle.com (MISP Attribute #15605)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-c228-40b2-b26f-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-c228-40b2-b26f-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-c228-40b2-b26f-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-c228-40b2-b26f-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-accounts-gooogle.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4071,14 +4071,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-db48-45a2-b841-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-db48-45a2-b841-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https-myaccounts-google.space (MISP Attribute #15606)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https-myaccounts-google.space (MISP Attribute #15606)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-db48-45a2-b841-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-db48-45a2-b841-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-db48-45a2-b841-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-db48-45a2-b841-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https-myaccounts-google.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4092,14 +4092,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-5f50-470e-b879-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-5f50-470e-b879-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-mail-google.com (MISP Attribute #15608)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-mail-google.com (MISP Attribute #15608)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-5f50-470e-b879-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-5f50-470e-b879-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-5f50-470e-b879-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-5f50-470e-b879-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-mail-google.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4113,14 +4113,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-b2a4-4870-8b10-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-b2a4-4870-8b10-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https-drive-google.gq (MISP Attribute #15609)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https-drive-google.gq (MISP Attribute #15609)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-b2a4-4870-8b10-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-b2a4-4870-8b10-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-b2a4-4870-8b10-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-b2a4-4870-8b10-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">https-drive-google.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4134,14 +4134,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58fe51b3-ae50-45a7-ab7f-53928e96ca05" timestamp="2017-04-24T15:27:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58fe51b3-ae50-45a7-ab7f-53928e96ca05" timestamp="2017-04-24T15:27:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: email-163.space (MISP Attribute #15865)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: email-163.space (MISP Attribute #15865)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58fe51b3-ae50-45a7-ab7f-53928e96ca05">
-                                        <cybox:Object id=":DomainName-58fe51b3-ae50-45a7-ab7f-53928e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58fe51b3-ae50-45a7-ab7f-53928e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58fe51b3-ae50-45a7-ab7f-53928e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">email-163.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4155,14 +4155,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58fe5290-6718-4a5b-9ec2-5d828e96ca05" timestamp="2017-04-24T15:31:28+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58fe5290-6718-4a5b-9ec2-5d828e96ca05" timestamp="2017-04-24T15:31:28+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: drive-gooog1e.space (MISP Attribute #15866)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: drive-gooog1e.space (MISP Attribute #15866)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58fe5290-6718-4a5b-9ec2-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-58fe5290-6718-4a5b-9ec2-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58fe5290-6718-4a5b-9ec2-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58fe5290-6718-4a5b-9ec2-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">drive-gooog1e.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4176,14 +4176,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-3948-484b-8f15-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-3948-484b-8f15-07298e96ca05" timestamp="2018-01-16T16:34:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsdrive-mail-google.gq (MISP Attribute #15612)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsdrive-mail-google.gq (MISP Attribute #15612)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-3948-484b-8f15-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-3948-484b-8f15-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-3948-484b-8f15-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-3948-484b-8f15-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsdrive-mail-google.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4197,14 +4197,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-58fe5c42-db88-4f68-a450-5d828e96ca05" timestamp="2017-04-24T16:12:50+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-58fe5c42-db88-4f68-a450-5d828e96ca05" timestamp="2017-04-24T16:12:50+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-attachment-usercontent.space (MISP Attribute #15868)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-attachment-usercontent.space (MISP Attribute #15868)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-58fe5c42-db88-4f68-a450-5d828e96ca05">
-                                        <cybox:Object id=":DomainName-58fe5c42-db88-4f68-a450-5d828e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-58fe5c42-db88-4f68-a450-5d828e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-58fe5c42-db88-4f68-a450-5d828e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-attachment-usercontent.space</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4218,14 +4218,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e58ea-2fe8-495b-89d6-06de8e96ca05" timestamp="2018-01-16T14:56:26+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e58ea-2fe8-495b-89d6-06de8e96ca05" timestamp="2018-01-16T14:56:26+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: phpinfo.pw (MISP Attribute #17916)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: phpinfo.pw (MISP Attribute #17916)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e58ea-2fe8-495b-89d6-06de8e96ca05">
-                                        <cybox:Object id=":DomainName-5a5e58ea-2fe8-495b-89d6-06de8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e58ea-2fe8-495b-89d6-06de8e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a5e58ea-2fe8-495b-89d6-06de8e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">phpinfo.pw</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4239,14 +4239,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-f124-4da4-b7dc-07298e96ca05" timestamp="2018-01-16T16:34:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-f124-4da4-b7dc-07298e96ca05" timestamp="2018-01-16T16:34:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myaccounts-google.tk (MISP Attribute #15613)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myaccounts-google.tk (MISP Attribute #15613)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-f124-4da4-b7dc-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-f124-4da4-b7dc-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-f124-4da4-b7dc-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-f124-4da4-b7dc-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myaccounts-google.tk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4260,14 +4260,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-0d88-4d42-8935-07298e96ca05" timestamp="2018-01-16T16:34:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-0d88-4d42-8935-07298e96ca05" timestamp="2018-01-16T16:34:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsaccounts-drive-google.gq (MISP Attribute #15614)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsaccounts-drive-google.gq (MISP Attribute #15614)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-0d88-4d42-8935-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-0d88-4d42-8935-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-0d88-4d42-8935-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-0d88-4d42-8935-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsaccounts-drive-google.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4281,14 +4281,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-587fa322-d888-4b55-bb55-07298e96ca05" timestamp="2018-01-16T16:34:19+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-587fa322-d888-4b55-bb55-07298e96ca05" timestamp="2018-01-16T16:34:19+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: httpsaccount-google.gq (MISP Attribute #15615)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: httpsaccount-google.gq (MISP Attribute #15615)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-587fa322-d888-4b55-bb55-07298e96ca05">
-                                        <cybox:Object id=":DomainName-587fa322-d888-4b55-bb55-07298e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-587fa322-d888-4b55-bb55-07298e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-587fa322-d888-4b55-bb55-07298e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">httpsaccount-google.gq</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4302,14 +4302,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e59b5-fc40-4c1d-8e76-06de8e96ca05" timestamp="2018-01-16T14:59:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e59b5-fc40-4c1d-8e76-06de8e96ca05" timestamp="2018-01-16T14:59:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 104.207.132.165 (MISP Attribute #17917)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 104.207.132.165 (MISP Attribute #17917)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e59b5-fc40-4c1d-8e76-06de8e96ca05">
-                                        <cybox:Object id=":Address-5a5e59b5-fc40-4c1d-8e76-06de8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e59b5-fc40-4c1d-8e76-06de8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5a5e59b5-fc40-4c1d-8e76-06de8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">104.207.132.165</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -4323,14 +4323,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e59b5-adf0-4031-80bb-06de8e96ca05" timestamp="2018-01-16T14:59:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e59b5-adf0-4031-80bb-06de8e96ca05" timestamp="2018-01-16T14:59:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 45.63.0.49 (MISP Attribute #17918)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 45.63.0.49 (MISP Attribute #17918)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e59b5-adf0-4031-80bb-06de8e96ca05">
-                                        <cybox:Object id=":Address-5a5e59b5-adf0-4031-80bb-06de8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e59b5-adf0-4031-80bb-06de8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5a5e59b5-adf0-4031-80bb-06de8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">45.63.0.49</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -4344,14 +4344,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e59b5-c328-49e9-9334-06de8e96ca05" timestamp="2018-01-16T14:59:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e59b5-c328-49e9-9334-06de8e96ca05" timestamp="2018-01-16T14:59:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 115.126.39.107 (MISP Attribute #17919)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 115.126.39.107 (MISP Attribute #17919)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e59b5-c328-49e9-9334-06de8e96ca05">
-                                        <cybox:Object id=":Address-5a5e59b5-c328-49e9-9334-06de8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e59b5-c328-49e9-9334-06de8e96ca05">
+                                        <cybox:Object id="citizenlab:Address-5a5e59b5-c328-49e9-9334-06de8e96ca05">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">115.126.39.107</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -4365,14 +4365,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e59f3-a7b8-403d-8836-06df8e96ca05" timestamp="2018-01-16T15:00:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e59f3-a7b8-403d-8836-06df8e96ca05" timestamp="2018-01-16T15:00:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 8e44755f02e9769c95dd9528ca1f462e (MISP Attribute #17920)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 8e44755f02e9769c95dd9528ca1f462e (MISP Attribute #17920)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e59f3-a7b8-403d-8836-06df8e96ca05">
-                                        <cybox:Object id=":File-5a5e59f3-a7b8-403d-8836-06df8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e59f3-a7b8-403d-8836-06df8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a5e59f3-a7b8-403d-8836-06df8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -4391,14 +4391,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5a0d-d630-49f5-beab-06df8e96ca05" timestamp="2018-01-16T15:01:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5a0d-d630-49f5-beab-06df8e96ca05" timestamp="2018-01-16T15:01:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 381f8f812a8609134eff661157d88d32da029af1 (MISP Attribute #17922)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 381f8f812a8609134eff661157d88d32da029af1 (MISP Attribute #17922)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e5a0d-d630-49f5-beab-06df8e96ca05">
-                                        <cybox:Object id=":File-5a5e5a0d-d630-49f5-beab-06df8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e5a0d-d630-49f5-beab-06df8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a5e5a0d-d630-49f5-beab-06df8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -4417,14 +4417,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a5e5a05-dfd4-4771-beff-06df8e96ca05" timestamp="2018-01-16T15:01:09+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a5e5a05-dfd4-4771-beff-06df8e96ca05" timestamp="2018-01-16T15:01:09+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 654e952324bddf09ca7b014bfdf79103c643d21d648182f911a65d7c907803b8 (MISP Attribute #17921)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 654e952324bddf09ca7b014bfdf79103c643d21d648182f911a65d7c907803b8 (MISP Attribute #17921)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a5e5a05-dfd4-4771-beff-06df8e96ca05">
-                                        <cybox:Object id=":File-5a5e5a05-dfd4-4771-beff-06df8e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a5e5a05-dfd4-4771-beff-06df8e96ca05">
+                                        <cybox:Object id="citizenlab:File-5a5e5a05-dfd4-4771-beff-06df8e96ca05">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>

--- a/201803_BadTraffic/stix.xml
+++ b/201803_BadTraffic/stix.xml
@@ -58,20 +58,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-ca68db1c-662a-4001-9285-522950e31bc1" version="1.1.1" timestamp="2018-03-07T19:23:42.090147+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-ca68db1c-662a-4001-9285-522950e31bc1" version="1.1.1" timestamp="2018-03-07T19:23:42.090147+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-5a84a4bc-1498-4808-9cf1-6ce78e96ca05" version="1.1.1" timestamp="2018-03-07T14:22:42+00:00">
+            <stix:Package id="citizenlab:STIXPackage-5a84a4bc-1498-4808-9cf1-6ce78e96ca05" version="1.1.1" timestamp="2018-03-07T14:22:42+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Bad Traffic (MISP Event #134)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-5a84a4bc-1498-4808-9cf1-6ce78e96ca05" timestamp="2018-03-07T14:23:18+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-5a84a4bc-1498-4808-9cf1-6ce78e96ca05" timestamp="2018-03-07T14:23:18+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Bad Traffic</incident:Title>
                         <incident:External_ID source="MISP Event">134</incident:External_ID>
                         <incident:Time>
@@ -82,14 +82,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-1c94-40ca-b487-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-1c94-40ca-b487-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: a070fd2cce434a6f0b0d0fa6d3278d22 (MISP Attribute #18176)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: a070fd2cce434a6f0b0d0fa6d3278d22 (MISP Attribute #18176)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-1c94-40ca-b487-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-1c94-40ca-b487-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-1c94-40ca-b487-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-1c94-40ca-b487-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -108,14 +108,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-bb2c-495d-a460-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-bb2c-495d-a460-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: be6f2a03dfddbaf1166854730961d13c (MISP Attribute #18177)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: be6f2a03dfddbaf1166854730961d13c (MISP Attribute #18177)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-bb2c-495d-a460-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-bb2c-495d-a460-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-bb2c-495d-a460-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-bb2c-495d-a460-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -134,14 +134,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-af4c-40fc-8e98-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-af4c-40fc-8e98-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: d7ec065cc3f563928504f80692578d2f (MISP Attribute #18178)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: d7ec065cc3f563928504f80692578d2f (MISP Attribute #18178)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-af4c-40fc-8e98-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-af4c-40fc-8e98-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-af4c-40fc-8e98-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-af4c-40fc-8e98-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -160,14 +160,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-c054-4a65-8ff3-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-c054-4a65-8ff3-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: f344da38958dbc730ddebc10660cd451 (MISP Attribute #18179)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: f344da38958dbc730ddebc10660cd451 (MISP Attribute #18179)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-c054-4a65-8ff3-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-c054-4a65-8ff3-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-c054-4a65-8ff3-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-c054-4a65-8ff3-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -186,14 +186,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-e354-4d5d-bafb-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-e354-4d5d-bafb-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: fa90508007b94a4dbfeb8b48d5443ec8 (MISP Attribute #18180)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: fa90508007b94a4dbfeb8b48d5443ec8 (MISP Attribute #18180)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-e354-4d5d-bafb-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-e354-4d5d-bafb-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-e354-4d5d-bafb-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-e354-4d5d-bafb-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -212,14 +212,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-c1f8-45f5-abd0-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-c1f8-45f5-abd0-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 001316808aa7108b467e8ecc06139c2e (MISP Attribute #18181)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 001316808aa7108b467e8ecc06139c2e (MISP Attribute #18181)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-c1f8-45f5-abd0-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-c1f8-45f5-abd0-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-c1f8-45f5-abd0-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-c1f8-45f5-abd0-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -238,14 +238,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-9dd4-42eb-aef1-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-9dd4-42eb-aef1-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 5c3f0dcf4aaa699b50154aa245923c86 (MISP Attribute #18182)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 5c3f0dcf4aaa699b50154aa245923c86 (MISP Attribute #18182)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-9dd4-42eb-aef1-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-9dd4-42eb-aef1-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-9dd4-42eb-aef1-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-9dd4-42eb-aef1-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -264,14 +264,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-5d38-493a-a73c-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-5d38-493a-a73c-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 7fd98d6bb1e9d6bcf2e1984e812c1e46 (MISP Attribute #18183)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 7fd98d6bb1e9d6bcf2e1984e812c1e46 (MISP Attribute #18183)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-5d38-493a-a73c-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-5d38-493a-a73c-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-5d38-493a-a73c-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-5d38-493a-a73c-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -290,14 +290,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-f83c-46dd-9ceb-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-f83c-46dd-9ceb-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 89180820b47bb11ccf0c8505371e98d1 (MISP Attribute #18184)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 89180820b47bb11ccf0c8505371e98d1 (MISP Attribute #18184)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-f83c-46dd-9ceb-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-f83c-46dd-9ceb-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-f83c-46dd-9ceb-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-f83c-46dd-9ceb-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -316,14 +316,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-bbec-446d-a785-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-bbec-446d-a785-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 8bb2ba6f1cfa3bd99146688cd1e76bb0 (MISP Attribute #18185)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 8bb2ba6f1cfa3bd99146688cd1e76bb0 (MISP Attribute #18185)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-bbec-446d-a785-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-bbec-446d-a785-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-bbec-446d-a785-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-bbec-446d-a785-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -342,14 +342,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-1de8-45fc-8681-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-1de8-45fc-8681-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 8c8eb5cfc5642a773c5f2b5f59148aa3 (MISP Attribute #18186)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 8c8eb5cfc5642a773c5f2b5f59148aa3 (MISP Attribute #18186)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-1de8-45fc-8681-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-1de8-45fc-8681-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-1de8-45fc-8681-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-1de8-45fc-8681-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -368,14 +368,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-887c-4c49-baa1-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-887c-4c49-baa1-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 8fea3de31a58415c3fec2e6dd4095575 (MISP Attribute #18187)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 8fea3de31a58415c3fec2e6dd4095575 (MISP Attribute #18187)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-887c-4c49-baa1-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-887c-4c49-baa1-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-887c-4c49-baa1-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-887c-4c49-baa1-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -394,14 +394,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-2ee4-46ad-9e1f-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-2ee4-46ad-9e1f-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 9b0de56f7f862db73e223f41099fc74c (MISP Attribute #18188)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 9b0de56f7f862db73e223f41099fc74c (MISP Attribute #18188)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-2ee4-46ad-9e1f-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-2ee4-46ad-9e1f-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-2ee4-46ad-9e1f-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-2ee4-46ad-9e1f-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -420,14 +420,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-e6dc-44c8-a030-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-e6dc-44c8-a030-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: be8a344487bcfea66de8e0f0f14d869e (MISP Attribute #18189)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: be8a344487bcfea66de8e0f0f14d869e (MISP Attribute #18189)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-e6dc-44c8-a030-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-e6dc-44c8-a030-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-e6dc-44c8-a030-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-e6dc-44c8-a030-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -446,14 +446,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-56e8-4a86-b564-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-56e8-4a86-b564-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: df0045bd4168893922480f7ccb29860a (MISP Attribute #18190)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: df0045bd4168893922480f7ccb29860a (MISP Attribute #18190)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-56e8-4a86-b564-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-56e8-4a86-b564-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-56e8-4a86-b564-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-56e8-4a86-b564-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -472,14 +472,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-87ac-4368-b185-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-87ac-4368-b185-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: e436e849d9496ef3f651c1904786c78f (MISP Attribute #18191)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: e436e849d9496ef3f651c1904786c78f (MISP Attribute #18191)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-87ac-4368-b185-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-87ac-4368-b185-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-87ac-4368-b185-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-87ac-4368-b185-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -498,14 +498,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-d490-4f27-be9b-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-d490-4f27-be9b-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: e80d8a0c35133f7485d8e87ade903919 (MISP Attribute #18192)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: e80d8a0c35133f7485d8e87ade903919 (MISP Attribute #18192)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-d490-4f27-be9b-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-d490-4f27-be9b-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-d490-4f27-be9b-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-d490-4f27-be9b-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -524,14 +524,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-f230-436a-b587-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-f230-436a-b587-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: f36e67109ae368c9db109d0a41b5817c (MISP Attribute #18193)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: f36e67109ae368c9db109d0a41b5817c (MISP Attribute #18193)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-f230-436a-b587-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-f230-436a-b587-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-f230-436a-b587-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-f230-436a-b587-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -550,14 +550,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-1034-4a7d-8335-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-1034-4a7d-8335-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 08b8b4787f3ce90c6c1483cc127b1cdc (MISP Attribute #18194)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 08b8b4787f3ce90c6c1483cc127b1cdc (MISP Attribute #18194)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-1034-4a7d-8335-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-1034-4a7d-8335-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-1034-4a7d-8335-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-1034-4a7d-8335-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -576,14 +576,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-4b84-43af-a448-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-4b84-43af-a448-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 205a5502ff0da4a471c4dad0e06c6c57 (MISP Attribute #18195)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 205a5502ff0da4a471c4dad0e06c6c57 (MISP Attribute #18195)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-4b84-43af-a448-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-4b84-43af-a448-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-4b84-43af-a448-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-4b84-43af-a448-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -602,14 +602,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-0d40-42e6-8472-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-0d40-42e6-8472-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 32bc51088953377d601c6b27ca7484a9 (MISP Attribute #18196)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 32bc51088953377d601c6b27ca7484a9 (MISP Attribute #18196)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-0d40-42e6-8472-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-0d40-42e6-8472-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-0d40-42e6-8472-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-0d40-42e6-8472-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -628,14 +628,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-4d40-4614-a23e-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-4d40-4614-a23e-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 3729531c71163cddcded7e70c02a3004 (MISP Attribute #18197)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 3729531c71163cddcded7e70c02a3004 (MISP Attribute #18197)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-4d40-4614-a23e-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-4d40-4614-a23e-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-4d40-4614-a23e-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-4d40-4614-a23e-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -654,14 +654,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-0d08-4751-b2a6-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-0d08-4751-b2a6-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 43b39fd4ddc386092372da19f6278c25 (MISP Attribute #18198)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 43b39fd4ddc386092372da19f6278c25 (MISP Attribute #18198)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-0d08-4751-b2a6-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-0d08-4751-b2a6-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-0d08-4751-b2a6-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-0d08-4751-b2a6-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -680,14 +680,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-29e0-421c-9135-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-29e0-421c-9135-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 4fe4094302c26e7ea2c58f5ca9f7f993 (MISP Attribute #18199)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 4fe4094302c26e7ea2c58f5ca9f7f993 (MISP Attribute #18199)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-29e0-421c-9135-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-29e0-421c-9135-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-29e0-421c-9135-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-29e0-421c-9135-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -706,14 +706,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-ba64-42f1-9505-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-ba64-42f1-9505-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 58239ea5747d3375278ce7c04db22c1b (MISP Attribute #18200)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 58239ea5747d3375278ce7c04db22c1b (MISP Attribute #18200)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-ba64-42f1-9505-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-ba64-42f1-9505-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-ba64-42f1-9505-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-ba64-42f1-9505-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -732,14 +732,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-ff78-4858-a1e3-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-ff78-4858-a1e3-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 6491df10c766be9c487fb9495d04df6e (MISP Attribute #18201)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 6491df10c766be9c487fb9495d04df6e (MISP Attribute #18201)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-ff78-4858-a1e3-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-ff78-4858-a1e3-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-ff78-4858-a1e3-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-ff78-4858-a1e3-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -758,14 +758,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-a0c8-4282-8b2b-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-a0c8-4282-8b2b-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 6a442a610c047a7a306a12f423978bfb (MISP Attribute #18202)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 6a442a610c047a7a306a12f423978bfb (MISP Attribute #18202)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-a0c8-4282-8b2b-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-a0c8-4282-8b2b-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-a0c8-4282-8b2b-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-a0c8-4282-8b2b-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -784,14 +784,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-0668-4191-b597-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-0668-4191-b597-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 6ce947913231bd968c86a2737bae7bba (MISP Attribute #18203)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 6ce947913231bd968c86a2737bae7bba (MISP Attribute #18203)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-0668-4191-b597-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-0668-4191-b597-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-0668-4191-b597-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-0668-4191-b597-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -810,14 +810,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-359c-4b66-afb6-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-359c-4b66-afb6-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 7ad8ad340c084f8185e2bb18cbfde891 (MISP Attribute #18204)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 7ad8ad340c084f8185e2bb18cbfde891 (MISP Attribute #18204)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-359c-4b66-afb6-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-359c-4b66-afb6-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-359c-4b66-afb6-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-359c-4b66-afb6-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -836,14 +836,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-55f8-4be5-8e12-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-55f8-4be5-8e12-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 90373539c60529153d0d6b0cc857e845 (MISP Attribute #18205)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 90373539c60529153d0d6b0cc857e845 (MISP Attribute #18205)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-55f8-4be5-8e12-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-55f8-4be5-8e12-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-55f8-4be5-8e12-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-55f8-4be5-8e12-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -862,14 +862,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-9cb8-477d-a13f-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-9cb8-477d-a13f-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: a5ae6e0d74052d4f889f2538fdd7cb9b (MISP Attribute #18206)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: a5ae6e0d74052d4f889f2538fdd7cb9b (MISP Attribute #18206)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-9cb8-477d-a13f-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-9cb8-477d-a13f-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-9cb8-477d-a13f-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-9cb8-477d-a13f-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -888,14 +888,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-43dc-4fd9-b2b3-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-43dc-4fd9-b2b3-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 08d971f5f4707ae6ea56ed2f243c38b7 (MISP Attribute #18169)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 08d971f5f4707ae6ea56ed2f243c38b7 (MISP Attribute #18169)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-43dc-4fd9-b2b3-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-43dc-4fd9-b2b3-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-43dc-4fd9-b2b3-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-43dc-4fd9-b2b3-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -914,14 +914,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-bb18-4c5d-879d-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-bb18-4c5d-879d-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 20755b98d7c094747b75b157413e3422 (MISP Attribute #18170)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 20755b98d7c094747b75b157413e3422 (MISP Attribute #18170)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-bb18-4c5d-879d-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-bb18-4c5d-879d-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-bb18-4c5d-879d-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-bb18-4c5d-879d-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -940,14 +940,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-50e4-4d9e-85c8-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-50e4-4d9e-85c8-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 3632fb080545d3518d57320466f96cb3 (MISP Attribute #18171)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 3632fb080545d3518d57320466f96cb3 (MISP Attribute #18171)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-50e4-4d9e-85c8-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-50e4-4d9e-85c8-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-50e4-4d9e-85c8-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-50e4-4d9e-85c8-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -966,14 +966,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-0ba0-4c9f-91f1-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-0ba0-4c9f-91f1-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 40383bee9846ecbd78581402e3379051 (MISP Attribute #18172)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 40383bee9846ecbd78581402e3379051 (MISP Attribute #18172)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-0ba0-4c9f-91f1-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-0ba0-4c9f-91f1-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-0ba0-4c9f-91f1-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-0ba0-4c9f-91f1-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -992,14 +992,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-5038-4cff-8b98-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-5038-4cff-8b98-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 449ba12127133ecd0440a558b083468c (MISP Attribute #18173)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 449ba12127133ecd0440a558b083468c (MISP Attribute #18173)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-5038-4cff-8b98-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-5038-4cff-8b98-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-5038-4cff-8b98-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-5038-4cff-8b98-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1018,14 +1018,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-4cf0-4b40-9d1f-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-4cf0-4b40-9d1f-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 461446151be0033a668782c2d7ba58cb (MISP Attribute #18174)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 461446151be0033a668782c2d7ba58cb (MISP Attribute #18174)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-4cf0-4b40-9d1f-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-4cf0-4b40-9d1f-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-4cf0-4b40-9d1f-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-4cf0-4b40-9d1f-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1044,14 +1044,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebaec-1fdc-4320-a7d2-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebaec-1fdc-4320-a7d2-65188064ab0b" timestamp="2018-03-06T10:59:40+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 56bc314bc0d4a0a230a4de2bf978b5ae (MISP Attribute #18175)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 56bc314bc0d4a0a230a4de2bf978b5ae (MISP Attribute #18175)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebaec-1fdc-4320-a7d2-65188064ab0b">
-                                        <cybox:Object id=":File-5a9ebaec-1fdc-4320-a7d2-65188064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebaec-1fdc-4320-a7d2-65188064ab0b">
+                                        <cybox:Object id="citizenlab:File-5a9ebaec-1fdc-4320-a7d2-65188064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1070,14 +1070,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5aa03a55-d3dc-4b53-a6e4-67a48064ab0b" timestamp="2018-03-07T14:15:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5aa03a55-d3dc-4b53-a6e4-67a48064ab0b" timestamp="2018-03-07T14:15:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: document.downloadingsystem.com (MISP Attribute #18208)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: document.downloadingsystem.com (MISP Attribute #18208)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5aa03a55-d3dc-4b53-a6e4-67a48064ab0b">
-                                        <cybox:Object id=":DomainName-5aa03a55-d3dc-4b53-a6e4-67a48064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5aa03a55-d3dc-4b53-a6e4-67a48064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5aa03a55-d3dc-4b53-a6e4-67a48064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">document.downloadingsystem.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1091,14 +1091,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5aa03a55-6920-413a-a285-67a48064ab0b" timestamp="2018-03-07T14:15:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5aa03a55-6920-413a-a285-67a48064ab0b" timestamp="2018-03-07T14:15:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: epoch.englishdownloaders.today (MISP Attribute #18209)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: epoch.englishdownloaders.today (MISP Attribute #18209)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5aa03a55-6920-413a-a285-67a48064ab0b">
-                                        <cybox:Object id=":DomainName-5aa03a55-6920-413a-a285-67a48064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5aa03a55-6920-413a-a285-67a48064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5aa03a55-6920-413a-a285-67a48064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">epoch.englishdownloaders.today</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1112,14 +1112,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5aa03a55-0118-4f2a-9ab5-67a48064ab0b" timestamp="2018-03-07T14:15:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5aa03a55-0118-4f2a-9ab5-67a48064ab0b" timestamp="2018-03-07T14:15:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: internet.downloadingdocuments.com (MISP Attribute #18210)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: internet.downloadingdocuments.com (MISP Attribute #18210)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5aa03a55-0118-4f2a-9ab5-67a48064ab0b">
-                                        <cybox:Object id=":DomainName-5aa03a55-0118-4f2a-9ab5-67a48064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5aa03a55-0118-4f2a-9ab5-67a48064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5aa03a55-0118-4f2a-9ab5-67a48064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">internet.downloadingdocuments.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1133,14 +1133,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5aa03a55-e36c-4dc5-934d-67a48064ab0b" timestamp="2018-03-07T14:15:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5aa03a55-e36c-4dc5-934d-67a48064ab0b" timestamp="2018-03-07T14:15:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: system.filedownloaders.com (MISP Attribute #18211)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: system.filedownloaders.com (MISP Attribute #18211)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5aa03a55-e36c-4dc5-934d-67a48064ab0b">
-                                        <cybox:Object id=":DomainName-5aa03a55-e36c-4dc5-934d-67a48064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5aa03a55-e36c-4dc5-934d-67a48064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5aa03a55-e36c-4dc5-934d-67a48064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">system.filedownloaders.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1154,14 +1154,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5aa03a55-7f20-4130-9def-67a48064ab0b" timestamp="2018-03-07T14:15:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5aa03a55-7f20-4130-9def-67a48064ab0b" timestamp="2018-03-07T14:15:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: upd-ms3-app-state.com (MISP Attribute #18212)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: upd-ms3-app-state.com (MISP Attribute #18212)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5aa03a55-7f20-4130-9def-67a48064ab0b">
-                                        <cybox:Object id=":DomainName-5aa03a55-7f20-4130-9def-67a48064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5aa03a55-7f20-4130-9def-67a48064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5aa03a55-7f20-4130-9def-67a48064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">upd-ms3-app-state.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1175,14 +1175,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5aa03c02-8520-4c2c-8ae7-67a28064ab0b" timestamp="2018-03-07T14:22:42+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5aa03c02-8520-4c2c-8ae7-67a28064ab0b" timestamp="2018-03-07T14:22:42+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: bombinate.winload.info (MISP Attribute #18213)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: bombinate.winload.info (MISP Attribute #18213)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5aa03c02-8520-4c2c-8ae7-67a28064ab0b">
-                                        <cybox:Object id=":DomainName-5aa03c02-8520-4c2c-8ae7-67a28064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5aa03c02-8520-4c2c-8ae7-67a28064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5aa03c02-8520-4c2c-8ae7-67a28064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bombinate.winload.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1196,14 +1196,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5aa03c02-e238-4288-9217-67a28064ab0b" timestamp="2018-03-07T14:22:42+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5aa03c02-e238-4288-9217-67a28064ab0b" timestamp="2018-03-07T14:22:42+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: epoch.uploaders.online (MISP Attribute #18214)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: epoch.uploaders.online (MISP Attribute #18214)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5aa03c02-e238-4288-9217-67a28064ab0b">
-                                        <cybox:Object id=":DomainName-5aa03c02-e238-4288-9217-67a28064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5aa03c02-e238-4288-9217-67a28064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5aa03c02-e238-4288-9217-67a28064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">epoch.uploaders.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1217,14 +1217,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5aa03c02-0bd0-42ee-ade7-67a28064ab0b" timestamp="2018-03-07T14:22:42+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5aa03c02-0bd0-42ee-ade7-67a28064ab0b" timestamp="2018-03-07T14:22:42+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: solitude.filedownloads.online (MISP Attribute #18215)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: solitude.filedownloads.online (MISP Attribute #18215)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5aa03c02-0bd0-42ee-ade7-67a28064ab0b">
-                                        <cybox:Object id=":DomainName-5aa03c02-0bd0-42ee-ade7-67a28064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5aa03c02-0bd0-42ee-ade7-67a28064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5aa03c02-0bd0-42ee-ade7-67a28064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">solitude.filedownloads.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1238,14 +1238,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-5b58-489e-90e2-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-5b58-489e-90e2-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: download.downloading.shop (MISP Attribute #18152)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: download.downloading.shop (MISP Attribute #18152)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-5b58-489e-90e2-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-5b58-489e-90e2-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-5b58-489e-90e2-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-5b58-489e-90e2-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">download.downloading.shop</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1259,14 +1259,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-1cf8-44f7-9995-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-1cf8-44f7-9995-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: downloading.syriantelecom.co (MISP Attribute #18153)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: downloading.syriantelecom.co (MISP Attribute #18153)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-1cf8-44f7-9995-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-1cf8-44f7-9995-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-1cf8-44f7-9995-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-1cf8-44f7-9995-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">downloading.syriantelecom.co</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1280,14 +1280,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-e0ac-49ac-b6fa-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-e0ac-49ac-b6fa-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: download.syriantelecommunications.co (MISP Attribute #18154)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: download.syriantelecommunications.co (MISP Attribute #18154)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-e0ac-49ac-b6fa-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-e0ac-49ac-b6fa-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-e0ac-49ac-b6fa-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-e0ac-49ac-b6fa-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">download.syriantelecommunications.co</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1301,14 +1301,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-49a8-4bb1-81d7-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-49a8-4bb1-81d7-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: redirection.bid (MISP Attribute #18155)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: redirection.bid (MISP Attribute #18155)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-49a8-4bb1-81d7-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-49a8-4bb1-81d7-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-49a8-4bb1-81d7-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-49a8-4bb1-81d7-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">redirection.bid</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1322,14 +1322,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-def0-4a56-9745-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-def0-4a56-9745-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: downloading.internetdownloading.co (MISP Attribute #18156)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: downloading.internetdownloading.co (MISP Attribute #18156)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-def0-4a56-9745-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-def0-4a56-9745-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-def0-4a56-9745-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-def0-4a56-9745-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">downloading.internetdownloading.co</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1343,14 +1343,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-f734-4a44-a766-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-f734-4a44-a766-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: download.downloadering.co (MISP Attribute #18157)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: download.downloadering.co (MISP Attribute #18157)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-f734-4a44-a766-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-f734-4a44-a766-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-f734-4a44-a766-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-f734-4a44-a766-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">download.downloadering.co</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1364,14 +1364,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-193c-4062-8a28-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-193c-4062-8a28-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: updserv-east-cdn3.com (MISP Attribute #18158)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: updserv-east-cdn3.com (MISP Attribute #18158)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-193c-4062-8a28-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-193c-4062-8a28-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-193c-4062-8a28-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-193c-4062-8a28-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">updserv-east-cdn3.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1385,14 +1385,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-1dc4-4139-92f9-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-1dc4-4139-92f9-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: computing.downloaders.today (MISP Attribute #18159)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: computing.downloaders.today (MISP Attribute #18159)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-1dc4-4139-92f9-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-1dc4-4139-92f9-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-1dc4-4139-92f9-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-1dc4-4139-92f9-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">computing.downloaders.today</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1406,14 +1406,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-dd2c-446e-94a1-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-dd2c-446e-94a1-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: storage.computingdownloads.life (MISP Attribute #18160)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: storage.computingdownloads.life (MISP Attribute #18160)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-dd2c-446e-94a1-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-dd2c-446e-94a1-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-dd2c-446e-94a1-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-dd2c-446e-94a1-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">storage.computingdownloads.life</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1427,14 +1427,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-479c-4201-b823-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-479c-4201-b823-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: window.processingdownloads.today (MISP Attribute #18161)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: window.processingdownloads.today (MISP Attribute #18161)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-479c-4201-b823-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-479c-4201-b823-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-479c-4201-b823-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-479c-4201-b823-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">window.processingdownloads.today</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1448,14 +1448,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-389c-4de0-be65-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-389c-4de0-be65-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ms-cdn-88.com (MISP Attribute #18162)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ms-cdn-88.com (MISP Attribute #18162)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-389c-4de0-be65-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-389c-4de0-be65-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-389c-4de0-be65-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-389c-4de0-be65-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ms-cdn-88.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1469,14 +1469,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-41d4-4b46-8c16-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-41d4-4b46-8c16-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: solitude.file-download.today (MISP Attribute #18163)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: solitude.file-download.today (MISP Attribute #18163)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-41d4-4b46-8c16-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-41d4-4b46-8c16-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-41d4-4b46-8c16-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-41d4-4b46-8c16-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">solitude.file-download.today</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1490,14 +1490,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-c2ac-45da-902c-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-c2ac-45da-902c-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: system.documentations.live (MISP Attribute #18164)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: system.documentations.live (MISP Attribute #18164)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-c2ac-45da-902c-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-c2ac-45da-902c-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-c2ac-45da-902c-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-c2ac-45da-902c-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">system.documentations.live</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1511,14 +1511,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-adc4-48ac-8d5d-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-adc4-48ac-8d5d-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: epiphany.download-document.world (MISP Attribute #18165)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: epiphany.download-document.world (MISP Attribute #18165)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-adc4-48ac-8d5d-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-adc4-48ac-8d5d-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-adc4-48ac-8d5d-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-adc4-48ac-8d5d-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">epiphany.download-document.world</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1532,14 +1532,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-b9b8-412b-9929-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-b9b8-412b-9929-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: epoch.wind-files.today (MISP Attribute #18166)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: epoch.wind-files.today (MISP Attribute #18166)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-b9b8-412b-9929-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-b9b8-412b-9929-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-b9b8-412b-9929-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-b9b8-412b-9929-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">epoch.wind-files.today</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1553,14 +1553,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-caf4-41b4-8e69-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-caf4-41b4-8e69-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: internet.document-management.today (MISP Attribute #18167)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: internet.document-management.today (MISP Attribute #18167)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-caf4-41b4-8e69-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-caf4-41b4-8e69-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-caf4-41b4-8e69-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-caf4-41b4-8e69-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">internet.document-management.today</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1574,14 +1574,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a9ebab6-b230-4313-9195-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a9ebab6-b230-4313-9195-630f8064ab0b" timestamp="2018-03-06T10:58:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: cdn-upd-ms6.com (MISP Attribute #18168)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: cdn-upd-ms6.com (MISP Attribute #18168)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a9ebab6-b230-4313-9195-630f8064ab0b">
-                                        <cybox:Object id=":DomainName-5a9ebab6-b230-4313-9195-630f8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5a9ebab6-b230-4313-9195-630f8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5a9ebab6-b230-4313-9195-630f8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">cdn-upd-ms6.com</DomainNameObj:Value>
                                             </cybox:Properties>

--- a/201808_FamiliarFeeling/stix.xml
+++ b/201808_FamiliarFeeling/stix.xml
@@ -58,20 +58,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-38927f2c-b91d-45e7-9f74-d2cb50509a6b" version="1.1.1" timestamp="2018-08-04T10:27:32.017919+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-38927f2c-b91d-45e7-9f74-d2cb50509a6b" version="1.1.1" timestamp="2018-08-04T10:27:32.017919+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-5a71edc8-26a8-43fb-8271-5c948e96ca05" version="1.1.1" timestamp="2018-08-04T06:17:18+00:00">
+            <stix:Package id="citizenlab:STIXPackage-5a71edc8-26a8-43fb-8271-5c948e96ca05" version="1.1.1" timestamp="2018-08-04T06:17:18+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Familiar Feeling: A Malware Campaign  Targeting the Tibetan Diaspora Resurfaces</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-5a71edc8-26a8-43fb-8271-5c948e96ca05" timestamp="2018-08-04T06:25:10+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-5a71edc8-26a8-43fb-8271-5c948e96ca05" timestamp="2018-08-04T06:25:10+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Familiar Feeling: A Malware Campaign  Targeting the Tibetan Diaspora Resurfaces</incident:Title>
                         <incident:External_ID source="MISP Event">133</incident:External_ID>
                         <incident:Time>
@@ -82,14 +82,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-f658-4b36-9ac8-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-f658-4b36-9ac8-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 91e976f76cc027931fed4cf70702efff (MISP Attribute #18346)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 91e976f76cc027931fed4cf70702efff (MISP Attribute #18346)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-f658-4b36-9ac8-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-f658-4b36-9ac8-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-f658-4b36-9ac8-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-f658-4b36-9ac8-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -108,14 +108,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-7f80-448a-992b-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-7f80-448a-992b-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 57ffde3504934e25904bcc57d27f9217 (MISP Attribute #18347)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 57ffde3504934e25904bcc57d27f9217 (MISP Attribute #18347)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-7f80-448a-992b-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-7f80-448a-992b-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-7f80-448a-992b-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-7f80-448a-992b-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -134,14 +134,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-3318-46b2-9cd8-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-3318-46b2-9cd8-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 75b86a01196854919626e87d5bd45a38 (MISP Attribute #18348)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 75b86a01196854919626e87d5bd45a38 (MISP Attribute #18348)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-3318-46b2-9cd8-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-3318-46b2-9cd8-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-3318-46b2-9cd8-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-3318-46b2-9cd8-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -160,14 +160,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-9788-4a4c-b5a9-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-9788-4a4c-b5a9-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: c25acaa45b0cf65a39c8413fa99e1fe8 (MISP Attribute #18349)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: c25acaa45b0cf65a39c8413fa99e1fe8 (MISP Attribute #18349)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-9788-4a4c-b5a9-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-9788-4a4c-b5a9-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-9788-4a4c-b5a9-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-9788-4a4c-b5a9-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -186,14 +186,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-86ec-442d-b077-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-86ec-442d-b077-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 4d85904b15c0adc8664f71bc2c5496bf (MISP Attribute #18350)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 4d85904b15c0adc8664f71bc2c5496bf (MISP Attribute #18350)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-86ec-442d-b077-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-86ec-442d-b077-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-86ec-442d-b077-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-86ec-442d-b077-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -212,14 +212,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-5c00-46f9-b147-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-5c00-46f9-b147-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 88e85fb6074ae50a3ccc9b410805ffe5 (MISP Attribute #18351)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 88e85fb6074ae50a3ccc9b410805ffe5 (MISP Attribute #18351)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-5c00-46f9-b147-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-5c00-46f9-b147-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-5c00-46f9-b147-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-5c00-46f9-b147-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -238,14 +238,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-7318-4bf3-8278-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-7318-4bf3-8278-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 058a5d47f8834fccfff8971f0544e387 (MISP Attribute #18352)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 058a5d47f8834fccfff8971f0544e387 (MISP Attribute #18352)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-7318-4bf3-8278-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-7318-4bf3-8278-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-7318-4bf3-8278-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-7318-4bf3-8278-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -264,14 +264,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-8bcc-4a7e-aa47-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-8bcc-4a7e-aa47-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 124c475d67aa8391f5220efcc64ca5b3 (MISP Attribute #18353)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 124c475d67aa8391f5220efcc64ca5b3 (MISP Attribute #18353)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-8bcc-4a7e-aa47-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-8bcc-4a7e-aa47-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-8bcc-4a7e-aa47-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-8bcc-4a7e-aa47-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -290,14 +290,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-56dc-4bb8-800d-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-56dc-4bb8-800d-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 054bad7ec0e19cec931078d45382fee6 (MISP Attribute #18354)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 054bad7ec0e19cec931078d45382fee6 (MISP Attribute #18354)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-56dc-4bb8-800d-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-56dc-4bb8-800d-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-56dc-4bb8-800d-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-56dc-4bb8-800d-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -316,14 +316,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-b82c-4e03-aa1b-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-b82c-4e03-aa1b-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: b1c114ae9172a3bacc5c6b30c410f354 (MISP Attribute #18355)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: b1c114ae9172a3bacc5c6b30c410f354 (MISP Attribute #18355)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-b82c-4e03-aa1b-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-b82c-4e03-aa1b-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-b82c-4e03-aa1b-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-b82c-4e03-aa1b-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -342,14 +342,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c65-cb5c-4c8a-b8db-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c65-cb5c-4c8a-b8db-15688064ab0b" timestamp="2018-08-04T06:13:57+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 72c88c4a9d2316b266a6702374411a99 (MISP Attribute #18356)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 72c88c4a9d2316b266a6702374411a99 (MISP Attribute #18356)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c65-cb5c-4c8a-b8db-15688064ab0b">
-                                        <cybox:Object id=":File-5b657c65-cb5c-4c8a-b8db-15688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c65-cb5c-4c8a-b8db-15688064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657c65-cb5c-4c8a-b8db-15688064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -368,14 +368,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657d14-2854-4f64-9d64-72cf8064ab0b" timestamp="2018-08-04T06:16:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657d14-2854-4f64-9d64-72cf8064ab0b" timestamp="2018-08-04T06:16:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 67e866c461c285853b225d2b2c850c4f (MISP Attribute #18357)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 67e866c461c285853b225d2b2c850c4f (MISP Attribute #18357)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657d14-2854-4f64-9d64-72cf8064ab0b">
-                                        <cybox:Object id=":File-5b657d14-2854-4f64-9d64-72cf8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657d14-2854-4f64-9d64-72cf8064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657d14-2854-4f64-9d64-72cf8064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -394,14 +394,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657d14-0654-4e9b-b833-72cf8064ab0b" timestamp="2018-08-04T06:16:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657d14-0654-4e9b-b833-72cf8064ab0b" timestamp="2018-08-04T06:16:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: e1b03f5837533ecc9a05e19650d68e1d (MISP Attribute #18358)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: e1b03f5837533ecc9a05e19650d68e1d (MISP Attribute #18358)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657d14-0654-4e9b-b833-72cf8064ab0b">
-                                        <cybox:Object id=":File-5b657d14-0654-4e9b-b833-72cf8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657d14-0654-4e9b-b833-72cf8064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657d14-0654-4e9b-b833-72cf8064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -420,14 +420,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657d14-8f34-41e0-ba68-72cf8064ab0b" timestamp="2018-08-04T06:16:52+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657d14-8f34-41e0-ba68-72cf8064ab0b" timestamp="2018-08-04T06:16:52+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 11e0f3e1c7d8855ed7f1dcfce4b7702a (MISP Attribute #18359)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 11e0f3e1c7d8855ed7f1dcfce4b7702a (MISP Attribute #18359)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657d14-8f34-41e0-ba68-72cf8064ab0b">
-                                        <cybox:Object id=":File-5b657d14-8f34-41e0-ba68-72cf8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657d14-8f34-41e0-ba68-72cf8064ab0b">
+                                        <cybox:Object id="citizenlab:File-5b657d14-8f34-41e0-ba68-72cf8064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -446,7 +446,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c33-0f28-4582-acc2-72cd8064ab0b" timestamp="2018-08-04T06:13:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c33-0f28-4582-acc2-72cd8064ab0b" timestamp="2018-08-04T06:13:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: bqfkdrmnhh0623@gmail.com (MISP Attribute #18343)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: bqfkdrmnhh0623@gmail.com (MISP Attribute #18343)</indicator:Description>
@@ -459,7 +459,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c43-9d0c-49d7-97a8-72cc8064ab0b" timestamp="2018-08-04T06:13:23+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c43-9d0c-49d7-97a8-72cc8064ab0b" timestamp="2018-08-04T06:13:23+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: huang ning (MISP Attribute #18344)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: huang ning (MISP Attribute #18344)</indicator:Description>
@@ -472,7 +472,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c55-0d84-46ef-9e3b-167e8064ab0b" timestamp="2018-08-04T06:13:41+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c55-0d84-46ef-9e3b-167e8064ab0b" timestamp="2018-08-04T06:13:41+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: 8677687877 (MISP Attribute #18345)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: 8677687877 (MISP Attribute #18345)</indicator:Description>
@@ -485,14 +485,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a71edfd-5044-404c-8b48-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a71edfd-5044-404c-8b48-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: commail.co (MISP Attribute #18048)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: commail.co (MISP Attribute #18048)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a71edfd-5044-404c-8b48-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a71edfd-5044-404c-8b48-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a71edfd-5044-404c-8b48-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a71edfd-5044-404c-8b48-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">commail.co</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -506,14 +506,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a71edfd-f620-4e5f-bc15-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a71edfd-f620-4e5f-bc15-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tibetfrum.info (MISP Attribute #18049)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tibetfrum.info (MISP Attribute #18049)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a71edfd-f620-4e5f-bc15-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a71edfd-f620-4e5f-bc15-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a71edfd-f620-4e5f-bc15-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a71edfd-f620-4e5f-bc15-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tibetfrum.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -527,14 +527,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a71edfd-6f60-4192-8e0f-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a71edfd-6f60-4192-8e0f-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tibethouse.info (MISP Attribute #18050)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tibethouse.info (MISP Attribute #18050)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a71edfd-6f60-4192-8e0f-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a71edfd-6f60-4192-8e0f-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a71edfd-6f60-4192-8e0f-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a71edfd-6f60-4192-8e0f-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tibethouse.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -548,14 +548,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a71edfd-1054-4f90-b881-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a71edfd-1054-4f90-b881-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tibetnews.info (MISP Attribute #18051)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tibetnews.info (MISP Attribute #18051)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a71edfd-1054-4f90-b881-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a71edfd-1054-4f90-b881-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a71edfd-1054-4f90-b881-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a71edfd-1054-4f90-b881-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tibetnews.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -569,14 +569,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a71edfd-2d74-416f-b7f1-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a71edfd-2d74-416f-b7f1-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: daynew.today (MISP Attribute #18052)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: daynew.today (MISP Attribute #18052)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a71edfd-2d74-416f-b7f1-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a71edfd-2d74-416f-b7f1-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a71edfd-2d74-416f-b7f1-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a71edfd-2d74-416f-b7f1-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">daynew.today</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -590,14 +590,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a71edfd-3760-46ea-ac88-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a71edfd-3760-46ea-ac88-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: daynews.today (MISP Attribute #18053)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: daynews.today (MISP Attribute #18053)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a71edfd-3760-46ea-ac88-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a71edfd-3760-46ea-ac88-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a71edfd-3760-46ea-ac88-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a71edfd-3760-46ea-ac88-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">daynews.today</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -611,14 +611,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a71edfd-1460-419f-bf27-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a71edfd-1460-419f-bf27-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tibetnews.today (MISP Attribute #18054)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tibetnews.today (MISP Attribute #18054)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a71edfd-1460-419f-bf27-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a71edfd-1460-419f-bf27-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a71edfd-1460-419f-bf27-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a71edfd-1460-419f-bf27-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tibetnews.today</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -632,14 +632,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a71edfd-f73c-4213-9784-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a71edfd-f73c-4213-9784-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: comemails.email (MISP Attribute #18055)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: comemails.email (MISP Attribute #18055)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a71edfd-f73c-4213-9784-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a71edfd-f73c-4213-9784-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a71edfd-f73c-4213-9784-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a71edfd-f73c-4213-9784-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">comemails.email</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -653,14 +653,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5a71edfd-65f0-498f-8143-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5a71edfd-65f0-498f-8143-09238e96ca05" timestamp="2018-01-31T11:25:33+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: comemail.email (MISP Attribute #18056)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: comemail.email (MISP Attribute #18056)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5a71edfd-65f0-498f-8143-09238e96ca05">
-                                        <cybox:Object id=":DomainName-5a71edfd-65f0-498f-8143-09238e96ca05">
+                                    <indicator:Observable id="citizenlab:observable-5a71edfd-65f0-498f-8143-09238e96ca05">
+                                        <cybox:Object id="citizenlab:DomainName-5a71edfd-65f0-498f-8143-09238e96ca05">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">comemail.email</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -674,14 +674,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c1b-de48-4c26-a83a-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c1b-de48-4c26-a83a-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google.comemail.email (MISP Attribute #18336)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google.comemail.email (MISP Attribute #18336)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c1b-de48-4c26-a83a-72cb8064ab0b">
-                                        <cybox:Object id=":DomainName-5b657c1b-de48-4c26-a83a-72cb8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c1b-de48-4c26-a83a-72cb8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5b657c1b-de48-4c26-a83a-72cb8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google.comemail.email</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -695,14 +695,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c1b-46f4-4103-9646-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c1b-46f4-4103-9646-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google.comemails.email (MISP Attribute #18337)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google.comemails.email (MISP Attribute #18337)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c1b-46f4-4103-9646-72cb8064ab0b">
-                                        <cybox:Object id=":DomainName-5b657c1b-46f4-4103-9646-72cb8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c1b-46f4-4103-9646-72cb8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5b657c1b-46f4-4103-9646-72cb8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google.comemails.email</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -716,14 +716,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c1b-7ab4-4be5-bdfa-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c1b-7ab4-4be5-bdfa-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google.commail.co (MISP Attribute #18338)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google.commail.co (MISP Attribute #18338)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c1b-7ab4-4be5-bdfa-72cb8064ab0b">
-                                        <cybox:Object id=":DomainName-5b657c1b-7ab4-4be5-bdfa-72cb8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c1b-7ab4-4be5-bdfa-72cb8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5b657c1b-7ab4-4be5-bdfa-72cb8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google.commail.co</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -737,14 +737,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c1b-9da8-4d2a-be4e-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c1b-9da8-4d2a-be4e-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: google.commail.email (MISP Attribute #18339)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: google.commail.email (MISP Attribute #18339)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c1b-9da8-4d2a-be4e-72cb8064ab0b">
-                                        <cybox:Object id=":DomainName-5b657c1b-9da8-4d2a-be4e-72cb8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c1b-9da8-4d2a-be4e-72cb8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5b657c1b-9da8-4d2a-be4e-72cb8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">google.commail.email</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -758,14 +758,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c1b-8868-476a-ad15-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c1b-8868-476a-ad15-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail.google.commail.co (MISP Attribute #18340)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail.google.commail.co (MISP Attribute #18340)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c1b-8868-476a-ad15-72cb8064ab0b">
-                                        <cybox:Object id=":DomainName-5b657c1b-8868-476a-ad15-72cb8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c1b-8868-476a-ad15-72cb8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5b657c1b-8868-476a-ad15-72cb8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail.google.commail.co</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -779,14 +779,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c1b-7b50-4ccb-8487-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c1b-7b50-4ccb-8487-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.comemail.email (MISP Attribute #18341)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.comemail.email (MISP Attribute #18341)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c1b-7b50-4ccb-8487-72cb8064ab0b">
-                                        <cybox:Object id=":DomainName-5b657c1b-7b50-4ccb-8487-72cb8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c1b-7b50-4ccb-8487-72cb8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5b657c1b-7b50-4ccb-8487-72cb8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.comemail.email</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -800,14 +800,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657c1b-5dc0-4f64-8569-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657c1b-5dc0-4f64-8569-72cb8064ab0b" timestamp="2018-08-04T06:12:43+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.google.comemails.email (MISP Attribute #18342)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.google.comemails.email (MISP Attribute #18342)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657c1b-5dc0-4f64-8569-72cb8064ab0b">
-                                        <cybox:Object id=":DomainName-5b657c1b-5dc0-4f64-8569-72cb8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657c1b-5dc0-4f64-8569-72cb8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5b657c1b-5dc0-4f64-8569-72cb8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.google.comemails.email</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -821,14 +821,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657bbb-48f4-4cc2-a236-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657bbb-48f4-4cc2-a236-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 27.126.186.222 (MISP Attribute #18330)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 27.126.186.222 (MISP Attribute #18330)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657bbb-48f4-4cc2-a236-72cf8064ab0b">
-                                        <cybox:Object id=":Address-5b657bbb-48f4-4cc2-a236-72cf8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657bbb-48f4-4cc2-a236-72cf8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5b657bbb-48f4-4cc2-a236-72cf8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">27.126.186.222</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -842,14 +842,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657bbb-e338-4722-af6a-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657bbb-e338-4722-af6a-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 103.55.24.196 (MISP Attribute #18331)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 103.55.24.196 (MISP Attribute #18331)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657bbb-e338-4722-af6a-72cf8064ab0b">
-                                        <cybox:Object id=":Address-5b657bbb-e338-4722-af6a-72cf8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657bbb-e338-4722-af6a-72cf8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5b657bbb-e338-4722-af6a-72cf8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">103.55.24.196</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -863,14 +863,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657bbb-eed0-4569-a919-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657bbb-eed0-4569-a919-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 203.189.232.207 (MISP Attribute #18332)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 203.189.232.207 (MISP Attribute #18332)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657bbb-eed0-4569-a919-72cf8064ab0b">
-                                        <cybox:Object id=":Address-5b657bbb-eed0-4569-a919-72cf8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657bbb-eed0-4569-a919-72cf8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5b657bbb-eed0-4569-a919-72cf8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">203.189.232.207</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -884,14 +884,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657bbb-d594-49ae-8e85-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657bbb-d594-49ae-8e85-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 45.127.97.222 (MISP Attribute #18333)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 45.127.97.222 (MISP Attribute #18333)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657bbb-d594-49ae-8e85-72cf8064ab0b">
-                                        <cybox:Object id=":Address-5b657bbb-d594-49ae-8e85-72cf8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657bbb-d594-49ae-8e85-72cf8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5b657bbb-d594-49ae-8e85-72cf8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">45.127.97.222</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -905,14 +905,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657bbb-9bdc-4b23-b160-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657bbb-9bdc-4b23-b160-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 115.126.86.151 (MISP Attribute #18334)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 115.126.86.151 (MISP Attribute #18334)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657bbb-9bdc-4b23-b160-72cf8064ab0b">
-                                        <cybox:Object id=":Address-5b657bbb-9bdc-4b23-b160-72cf8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657bbb-9bdc-4b23-b160-72cf8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5b657bbb-9bdc-4b23-b160-72cf8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">115.126.86.151</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -926,14 +926,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657bbb-f600-4013-bb4b-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657bbb-f600-4013-bb4b-72cf8064ab0b" timestamp="2018-08-04T06:11:07+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 27.126.176.169 (MISP Attribute #18335)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 27.126.176.169 (MISP Attribute #18335)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657bbb-f600-4013-bb4b-72cf8064ab0b">
-                                        <cybox:Object id=":Address-5b657bbb-f600-4013-bb4b-72cf8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657bbb-f600-4013-bb4b-72cf8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5b657bbb-f600-4013-bb4b-72cf8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">27.126.176.169</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -947,14 +947,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5b657d2e-f628-4a1e-b142-72cb8064ab0b" timestamp="2018-08-04T06:17:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5b657d2e-f628-4a1e-b142-72cb8064ab0b" timestamp="2018-08-04T06:17:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: tibetanparliarnent@yahoo.com (MISP Attribute #18360)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: tibetanparliarnent@yahoo.com (MISP Attribute #18360)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5b657d2e-f628-4a1e-b142-72cb8064ab0b">
-                                        <cybox:Object id=":EmailMessage-5b657d2e-f628-4a1e-b142-72cb8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5b657d2e-f628-4a1e-b142-72cb8064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5b657d2e-f628-4a1e-b142-72cb8064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">

--- a/201810_TheKingdomCameToCanada/stix.xml
+++ b/201810_TheKingdomCameToCanada/stix.xml
@@ -58,20 +58,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-7dcd1bb3-5361-4e47-b0ef-3acaeee6a84b" version="1.1.1" timestamp="2018-10-01T19:46:38.446941+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-7dcd1bb3-5361-4e47-b0ef-3acaeee6a84b" version="1.1.1" timestamp="2018-10-01T19:46:38.446941+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-5bb27709-12a0-4240-b90e-6f848064ab0b" version="1.1.1" timestamp="2018-10-01T15:38:11+00:00">
+            <stix:Package id="citizenlab:STIXPackage-5bb27709-12a0-4240-b90e-6f848064ab0b" version="1.1.1" timestamp="2018-10-01T15:38:11+00:00">
                 <stix:STIX_Header>
                     <stix:Title>The Kingdom Came To Canada (MISP Event #138)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-5bb27709-12a0-4240-b90e-6f848064ab0b" timestamp="2018-10-01T15:44:51+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-5bb27709-12a0-4240-b90e-6f848064ab0b" timestamp="2018-10-01T15:44:51+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>The Kingdom Came To Canada</incident:Title>
                         <incident:External_ID source="MISP Event">138</incident:External_ID>
                         <incident:Time>
@@ -82,14 +82,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb277a3-277c-4cc9-a7d0-4c668064ab0b" timestamp="2018-10-01T15:38:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb277a3-277c-4cc9-a7d0-4c668064ab0b" timestamp="2018-10-01T15:38:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: beststores4u.com (MISP Attribute #18379)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: beststores4u.com (MISP Attribute #18379)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb277a3-277c-4cc9-a7d0-4c668064ab0b">
-                                        <cybox:Object id=":DomainName-5bb277a3-277c-4cc9-a7d0-4c668064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb277a3-277c-4cc9-a7d0-4c668064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb277a3-277c-4cc9-a7d0-4c668064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">beststores4u.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -103,14 +103,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb277a3-ac80-403b-a3a7-4c668064ab0b" timestamp="2018-10-01T15:38:11+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb277a3-ac80-403b-a3a7-4c668064ab0b" timestamp="2018-10-01T15:38:11+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: cheapapartmentsaroundme.com (MISP Attribute #18380)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: cheapapartmentsaroundme.com (MISP Attribute #18380)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb277a3-ac80-403b-a3a7-4c668064ab0b">
-                                        <cybox:Object id=":DomainName-5bb277a3-ac80-403b-a3a7-4c668064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb277a3-ac80-403b-a3a7-4c668064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb277a3-ac80-403b-a3a7-4c668064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">cheapapartmentsaroundme.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -124,14 +124,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-5a18-4c67-9a35-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-5a18-4c67-9a35-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: akhbar-arabia.com (MISP Attribute #18361)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: akhbar-arabia.com (MISP Attribute #18361)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-5a18-4c67-9a35-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-5a18-4c67-9a35-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-5a18-4c67-9a35-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-5a18-4c67-9a35-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">akhbar-arabia.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -145,14 +145,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-17dc-4422-b198-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-17dc-4422-b198-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: all-sales.info (MISP Attribute #18362)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: all-sales.info (MISP Attribute #18362)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-17dc-4422-b198-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-17dc-4422-b198-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-17dc-4422-b198-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-17dc-4422-b198-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">all-sales.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -166,14 +166,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-36c4-4621-abf9-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-36c4-4621-abf9-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: arabnews365.com (MISP Attribute #18363)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: arabnews365.com (MISP Attribute #18363)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-36c4-4621-abf9-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-36c4-4621-abf9-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-36c4-4621-abf9-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-36c4-4621-abf9-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">arabnews365.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -187,14 +187,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-a8fc-4c13-8aed-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-a8fc-4c13-8aed-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: arabworld.biz (MISP Attribute #18364)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: arabworld.biz (MISP Attribute #18364)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-a8fc-4c13-8aed-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-a8fc-4c13-8aed-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-a8fc-4c13-8aed-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-a8fc-4c13-8aed-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">arabworld.biz</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -208,14 +208,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-ebd0-4410-b335-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-ebd0-4410-b335-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: daily-sport.news (MISP Attribute #18365)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: daily-sport.news (MISP Attribute #18365)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-ebd0-4410-b335-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-ebd0-4410-b335-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-ebd0-4410-b335-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-ebd0-4410-b335-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">daily-sport.news</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -229,14 +229,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-a91c-45dc-99ae-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-a91c-45dc-99ae-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: dinneraroundyou.com (MISP Attribute #18366)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: dinneraroundyou.com (MISP Attribute #18366)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-a91c-45dc-99ae-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-a91c-45dc-99ae-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-a91c-45dc-99ae-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-a91c-45dc-99ae-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dinneraroundyou.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -250,14 +250,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-2ef0-4e54-b5dd-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-2ef0-4e54-b5dd-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: findmyplants.com (MISP Attribute #18367)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: findmyplants.com (MISP Attribute #18367)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-2ef0-4e54-b5dd-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-2ef0-4e54-b5dd-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-2ef0-4e54-b5dd-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-2ef0-4e54-b5dd-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">findmyplants.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -271,14 +271,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-cc98-4611-8d13-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-cc98-4611-8d13-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: housesfurniture.com (MISP Attribute #18368)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: housesfurniture.com (MISP Attribute #18368)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-cc98-4611-8d13-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-cc98-4611-8d13-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-cc98-4611-8d13-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-cc98-4611-8d13-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">housesfurniture.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -292,14 +292,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-4fb0-4727-9c47-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-4fb0-4727-9c47-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: kingdom-deals.com (MISP Attribute #18369)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: kingdom-deals.com (MISP Attribute #18369)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-4fb0-4727-9c47-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-4fb0-4727-9c47-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-4fb0-4727-9c47-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-4fb0-4727-9c47-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">kingdom-deals.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -313,14 +313,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-11e4-4591-b2d2-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-11e4-4591-b2d2-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: kingdom-news.com (MISP Attribute #18370)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: kingdom-news.com (MISP Attribute #18370)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-11e4-4591-b2d2-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-11e4-4591-b2d2-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-11e4-4591-b2d2-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-11e4-4591-b2d2-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">kingdom-news.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -334,14 +334,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-f954-4227-9e89-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-f954-4227-9e89-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: mideast-today.com (MISP Attribute #18371)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: mideast-today.com (MISP Attribute #18371)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-f954-4227-9e89-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-f954-4227-9e89-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-f954-4227-9e89-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-f954-4227-9e89-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mideast-today.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -355,14 +355,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-6e5c-496e-975b-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-6e5c-496e-975b-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: muslim-world.info (MISP Attribute #18372)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: muslim-world.info (MISP Attribute #18372)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-6e5c-496e-975b-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-6e5c-496e-975b-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-6e5c-496e-975b-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-6e5c-496e-975b-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">muslim-world.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -376,14 +376,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-9834-4835-9cd0-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-9834-4835-9cd0-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: news-gazette.info (MISP Attribute #18373)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: news-gazette.info (MISP Attribute #18373)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-9834-4835-9cd0-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-9834-4835-9cd0-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-9834-4835-9cd0-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-9834-4835-9cd0-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">news-gazette.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -397,14 +397,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-1d34-42cc-b869-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-1d34-42cc-b869-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: nouvelles247.com (MISP Attribute #18374)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: nouvelles247.com (MISP Attribute #18374)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-1d34-42cc-b869-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-1d34-42cc-b869-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-1d34-42cc-b869-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-1d34-42cc-b869-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">nouvelles247.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -418,14 +418,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb2777f-ad24-4ab7-bb07-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb2777f-ad24-4ab7-bb07-700d8064ab0b" timestamp="2018-10-01T15:37:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: promosdereve.com (MISP Attribute #18375)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: promosdereve.com (MISP Attribute #18375)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb2777f-ad24-4ab7-bb07-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb2777f-ad24-4ab7-bb07-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb2777f-ad24-4ab7-bb07-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb2777f-ad24-4ab7-bb07-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">promosdereve.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -439,14 +439,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb27780-e238-499c-a677-700d8064ab0b" timestamp="2018-10-01T15:37:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb27780-e238-499c-a677-700d8064ab0b" timestamp="2018-10-01T15:37:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: social-life.info (MISP Attribute #18376)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: social-life.info (MISP Attribute #18376)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb27780-e238-499c-a677-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb27780-e238-499c-a677-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb27780-e238-499c-a677-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb27780-e238-499c-a677-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">social-life.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -460,14 +460,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb27780-fe30-4662-9264-700d8064ab0b" timestamp="2018-10-01T15:37:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb27780-fe30-4662-9264-700d8064ab0b" timestamp="2018-10-01T15:37:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: sunday-deals.com (MISP Attribute #18377)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: sunday-deals.com (MISP Attribute #18377)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb27780-fe30-4662-9264-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb27780-fe30-4662-9264-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb27780-fe30-4662-9264-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb27780-fe30-4662-9264-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">sunday-deals.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -481,14 +481,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bb27780-ba04-4fa1-9198-700d8064ab0b" timestamp="2018-10-01T15:37:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bb27780-ba04-4fa1-9198-700d8064ab0b" timestamp="2018-10-01T15:37:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: wonderfulinsights.com (MISP Attribute #18378)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: wonderfulinsights.com (MISP Attribute #18378)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bb27780-ba04-4fa1-9198-700d8064ab0b">
-                                        <cybox:Object id=":DomainName-5bb27780-ba04-4fa1-9198-700d8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bb27780-ba04-4fa1-9198-700d8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bb27780-ba04-4fa1-9198-700d8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">wonderfulinsights.com</DomainNameObj:Value>
                                             </cybox:Properties>

--- a/201909_MissingLink/stix.xml
+++ b/201909_MissingLink/stix.xml
@@ -58,20 +58,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-99639f7e-a3dc-4663-9482-b63821367e3b" version="1.1.1" timestamp="2019-09-23T20:39:45.654572+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-99639f7e-a3dc-4663-9482-b63821367e3b" version="1.1.1" timestamp="2019-09-23T20:39:45.654572+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-5bec8d43-b990-4129-a9f4-45d08064ab0b" version="1.1.1" timestamp="2019-09-23T16:38:32+00:00">
+            <stix:Package id="citizenlab:STIXPackage-5bec8d43-b990-4129-a9f4-45d08064ab0b" version="1.1.1" timestamp="2019-09-23T16:38:32+00:00">
                 <stix:STIX_Header>
                     <stix:Title>MISSING LINK: Tibetan Groups Targeted with Mobile Exploits (MISP Event #140)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-5bec8d43-b990-4129-a9f4-45d08064ab0b" timestamp="2019-09-23T16:39:10+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-5bec8d43-b990-4129-a9f4-45d08064ab0b" timestamp="2019-09-23T16:39:10+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>MISSING LINK: Tibetan Groups Targeted with Mobile Exploits</incident:Title>
                         <incident:External_ID source="MISP Event">140</incident:External_ID>
                         <incident:Time>
@@ -82,14 +82,14 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Artifacts dropped</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76dfaf-574c-4253-b1f1-67578064ab0b" timestamp="2019-09-09T19:33:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76dfaf-574c-4253-b1f1-67578064ab0b" timestamp="2019-09-09T19:33:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Artifacts dropped: 0d2ee9ade24163613772fdda201af985d852ab506e3d3e7f07fb3fa8b0853560 (MISP Attribute #18567)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Artifacts dropped: 0d2ee9ade24163613772fdda201af985d852ab506e3d3e7f07fb3fa8b0853560 (MISP Attribute #18567)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76dfaf-574c-4253-b1f1-67578064ab0b">
-                                        <cybox:Object id=":File-5d76dfaf-574c-4253-b1f1-67578064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76dfaf-574c-4253-b1f1-67578064ab0b">
+                                        <cybox:Object id="citizenlab:File-5d76dfaf-574c-4253-b1f1-67578064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -108,7 +108,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c9b2-8b24-4fb2-8ff3-61dc8064ab0b" timestamp="2019-09-09T17:52:50+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c9b2-8b24-4fb2-8ff3-61dc8064ab0b" timestamp="2019-09-09T17:52:50+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: dashenqu832@outlook.com (MISP Attribute #18558)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: dashenqu832@outlook.com (MISP Attribute #18558)</indicator:Description>
@@ -121,7 +121,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c9b2-5654-4b42-a28f-61dc8064ab0b" timestamp="2019-09-09T17:52:50+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c9b2-5654-4b42-a28f-61dc8064ab0b" timestamp="2019-09-09T17:52:50+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: ornaments798@outlook.com (MISP Attribute #18559)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: ornaments798@outlook.com (MISP Attribute #18559)</indicator:Description>
@@ -134,14 +134,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c70f-df94-4cd0-b977-4cea8064ab0b" timestamp="2019-09-09T19:33:59+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c70f-df94-4cd0-b977-4cea8064ab0b" timestamp="2019-09-09T19:33:59+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.energy-mail.org (MISP Attribute #18542)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.energy-mail.org (MISP Attribute #18542)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c70f-df94-4cd0-b977-4cea8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c70f-df94-4cd0-b977-4cea8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c70f-df94-4cd0-b977-4cea8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c70f-df94-4cd0-b977-4cea8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.energy-mail.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -155,14 +155,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-95a0-4186-9d08-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-95a0-4186-9d08-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: antmoving.online (MISP Attribute #18546)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: antmoving.online (MISP Attribute #18546)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-95a0-4186-9d08-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-95a0-4186-9d08-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-95a0-4186-9d08-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-95a0-4186-9d08-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">antmoving.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -176,14 +176,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-be94-4716-9cc3-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-be94-4716-9cc3-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: beemail.online (MISP Attribute #18547)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: beemail.online (MISP Attribute #18547)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-be94-4716-9cc3-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-be94-4716-9cc3-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-be94-4716-9cc3-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-be94-4716-9cc3-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">beemail.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -197,14 +197,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-0998-4c3d-94fa-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-0998-4c3d-94fa-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: bf.mk (MISP Attribute #18548)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: bf.mk (MISP Attribute #18548)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-0998-4c3d-94fa-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-0998-4c3d-94fa-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-0998-4c3d-94fa-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-0998-4c3d-94fa-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bf.mk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -218,14 +218,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-77cc-4a32-b989-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-77cc-4a32-b989-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: energy-mail.org (MISP Attribute #18549)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: energy-mail.org (MISP Attribute #18549)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-77cc-4a32-b989-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-77cc-4a32-b989-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-77cc-4a32-b989-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-77cc-4a32-b989-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">energy-mail.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -239,14 +239,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-a620-4e86-969b-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-a620-4e86-969b-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: gmailapp.me (MISP Attribute #18550)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: gmailapp.me (MISP Attribute #18550)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-a620-4e86-969b-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-a620-4e86-969b-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-a620-4e86-969b-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-a620-4e86-969b-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">gmailapp.me</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -260,14 +260,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-8960-4e6c-be1c-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-8960-4e6c-be1c-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: izelense.com (MISP Attribute #18551)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: izelense.com (MISP Attribute #18551)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-8960-4e6c-be1c-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-8960-4e6c-be1c-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-8960-4e6c-be1c-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-8960-4e6c-be1c-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">izelense.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -281,14 +281,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-52b4-4bb9-b61b-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-52b4-4bb9-b61b-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailanalysis.services (MISP Attribute #18552)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailanalysis.services (MISP Attribute #18552)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-52b4-4bb9-b61b-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-52b4-4bb9-b61b-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-52b4-4bb9-b61b-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-52b4-4bb9-b61b-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailanalysis.services</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -302,14 +302,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-1b78-4933-98f8-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-1b78-4933-98f8-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailcontactanalysis.online (MISP Attribute #18553)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailcontactanalysis.online (MISP Attribute #18553)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-1b78-4933-98f8-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-1b78-4933-98f8-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-1b78-4933-98f8-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-1b78-4933-98f8-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailcontactanalysis.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -323,14 +323,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-3358-4897-a52b-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-3358-4897-a52b-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailnotes.online (MISP Attribute #18554)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailnotes.online (MISP Attribute #18554)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-3358-4897-a52b-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-3358-4897-a52b-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-3358-4897-a52b-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-3358-4897-a52b-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailnotes.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -344,14 +344,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-6be4-4b4a-9a37-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-6be4-4b4a-9a37-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: polarismail.services (MISP Attribute #18555)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: polarismail.services (MISP Attribute #18555)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-6be4-4b4a-9a37-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-6be4-4b4a-9a37-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-6be4-4b4a-9a37-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-6be4-4b4a-9a37-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">polarismail.services</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -365,14 +365,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-0cb4-4be5-b3d6-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-0cb4-4be5-b3d6-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: rf.mk (MISP Attribute #18556)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: rf.mk (MISP Attribute #18556)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-0cb4-4be5-b3d6-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-0cb4-4be5-b3d6-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-0cb4-4be5-b3d6-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-0cb4-4be5-b3d6-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">rf.mk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -386,14 +386,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c98c-f230-436d-a69f-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c98c-f230-436d-a69f-61de8064ab0b" timestamp="2019-09-09T17:52:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: walkingnote.online (MISP Attribute #18557)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: walkingnote.online (MISP Attribute #18557)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c98c-f230-436d-a69f-61de8064ab0b">
-                                        <cybox:Object id=":DomainName-5d76c98c-f230-436d-a69f-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c98c-f230-436d-a69f-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5d76c98c-f230-436d-a69f-61de8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">walkingnote.online</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -407,14 +407,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bec8d6d-71e0-40b6-add8-171c8064ab0b" timestamp="2018-11-14T16:02:55+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bec8d6d-71e0-40b6-add8-171c8064ab0b" timestamp="2018-11-14T16:02:55+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: www.msap.services (MISP Attribute #18406)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: www.msap.services (MISP Attribute #18406)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bec8d6d-71e0-40b6-add8-171c8064ab0b">
-                                        <cybox:Object id=":DomainName-5bec8d6d-71e0-40b6-add8-171c8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bec8d6d-71e0-40b6-add8-171c8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bec8d6d-71e0-40b6-add8-171c8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">www.msap.services</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -428,14 +428,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bec8d6d-6cc8-4aef-b8c9-171c8064ab0b" timestamp="2018-11-14T16:02:58+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bec8d6d-6cc8-4aef-b8c9-171c8064ab0b" timestamp="2018-11-14T16:02:58+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: msap.services (MISP Attribute #18407)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: msap.services (MISP Attribute #18407)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bec8d6d-6cc8-4aef-b8c9-171c8064ab0b">
-                                        <cybox:Object id=":DomainName-5bec8d6d-6cc8-4aef-b8c9-171c8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bec8d6d-6cc8-4aef-b8c9-171c8064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5bec8d6d-6cc8-4aef-b8c9-171c8064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">msap.services</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -449,14 +449,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c7a0-2dac-4e65-a0ca-67208064ab0b" timestamp="2019-09-09T17:44:00+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c7a0-2dac-4e65-a0ca-67208064ab0b" timestamp="2019-09-09T17:44:00+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 45.32.75.217 (MISP Attribute #18544)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 45.32.75.217 (MISP Attribute #18544)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c7a0-2dac-4e65-a0ca-67208064ab0b">
-                                        <cybox:Object id=":Address-5d76c7a0-2dac-4e65-a0ca-67208064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c7a0-2dac-4e65-a0ca-67208064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5d76c7a0-2dac-4e65-a0ca-67208064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">45.32.75.217</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -470,14 +470,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c7a0-3c28-4110-aa88-67208064ab0b" timestamp="2019-09-20T17:39:17+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c7a0-3c28-4110-aa88-67208064ab0b" timestamp="2019-09-20T17:39:17+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 45.76.149.154 (MISP Attribute #18545)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 45.76.149.154 (MISP Attribute #18545)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c7a0-3c28-4110-aa88-67208064ab0b">
-                                        <cybox:Object id=":Address-5d76c7a0-3c28-4110-aa88-67208064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c7a0-3c28-4110-aa88-67208064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5d76c7a0-3c28-4110-aa88-67208064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">45.76.149.154</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -491,14 +491,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76cc33-7aac-4eb8-a1be-66c48064ab0b" timestamp="2019-09-09T19:34:08+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76cc33-7aac-4eb8-a1be-66c48064ab0b" timestamp="2019-09-09T19:34:08+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 45.78.79.100 (MISP Attribute #18560)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 45.78.79.100 (MISP Attribute #18560)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76cc33-7aac-4eb8-a1be-66c48064ab0b">
-                                        <cybox:Object id=":Address-5d76cc33-7aac-4eb8-a1be-66c48064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76cc33-7aac-4eb8-a1be-66c48064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5d76cc33-7aac-4eb8-a1be-66c48064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">45.78.79.100</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -512,14 +512,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76cf56-94f8-4a16-84d5-67af8064ab0b" timestamp="2019-09-09T18:16:54+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76cf56-94f8-4a16-84d5-67af8064ab0b" timestamp="2019-09-09T18:16:54+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 149.28.93.11 (MISP Attribute #18561)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 149.28.93.11 (MISP Attribute #18561)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76cf56-94f8-4a16-84d5-67af8064ab0b">
-                                        <cybox:Object id=":Address-5d76cf56-94f8-4a16-84d5-67af8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76cf56-94f8-4a16-84d5-67af8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5d76cf56-94f8-4a16-84d5-67af8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">149.28.93.11</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -533,14 +533,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76d19b-0704-42fa-95c5-61df8064ab0b" timestamp="2019-09-09T19:34:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76d19b-0704-42fa-95c5-61df8064ab0b" timestamp="2019-09-09T19:34:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 95.169.2.57 (MISP Attribute #18562)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 95.169.2.57 (MISP Attribute #18562)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76d19b-0704-42fa-95c5-61df8064ab0b">
-                                        <cybox:Object id=":Address-5d76d19b-0704-42fa-95c5-61df8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76d19b-0704-42fa-95c5-61df8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5d76d19b-0704-42fa-95c5-61df8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">95.169.2.57</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -554,14 +554,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76d6f2-f44c-4b21-ba2d-67578064ab0b" timestamp="2019-09-09T18:49:22+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76d6f2-f44c-4b21-ba2d-67578064ab0b" timestamp="2019-09-09T18:49:22+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 206.189.65.198 (MISP Attribute #18563)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 206.189.65.198 (MISP Attribute #18563)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76d6f2-f44c-4b21-ba2d-67578064ab0b">
-                                        <cybox:Object id=":Address-5d76d6f2-f44c-4b21-ba2d-67578064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76d6f2-f44c-4b21-ba2d-67578064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5d76d6f2-f44c-4b21-ba2d-67578064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">206.189.65.198</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -575,14 +575,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76dae6-bdc4-4cca-8161-61de8064ab0b" timestamp="2019-09-09T19:06:14+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76dae6-bdc4-4cca-8161-61de8064ab0b" timestamp="2019-09-09T19:06:14+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 140.82.17.222 (MISP Attribute #18564)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 140.82.17.222 (MISP Attribute #18564)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76dae6-bdc4-4cca-8161-61de8064ab0b">
-                                        <cybox:Object id=":Address-5d76dae6-bdc4-4cca-8161-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76dae6-bdc4-4cca-8161-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5d76dae6-bdc4-4cca-8161-61de8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">140.82.17.222</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -596,14 +596,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76dcf6-f094-47a0-8fd4-4cea8064ab0b" timestamp="2019-09-09T19:35:01+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76dcf6-f094-47a0-8fd4-4cea8064ab0b" timestamp="2019-09-09T19:35:01+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 45.76.53.26 (MISP Attribute #18565)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 45.76.53.26 (MISP Attribute #18565)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76dcf6-f094-47a0-8fd4-4cea8064ab0b">
-                                        <cybox:Object id=":Address-5d76dcf6-f094-47a0-8fd4-4cea8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76dcf6-f094-47a0-8fd4-4cea8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5d76dcf6-f094-47a0-8fd4-4cea8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">45.76.53.26</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -617,14 +617,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76de15-2544-4f39-baed-61db8064ab0b" timestamp="2019-09-09T19:19:49+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76de15-2544-4f39-baed-61db8064ab0b" timestamp="2019-09-09T19:19:49+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 45.32.91.137 (MISP Attribute #18566)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 45.32.91.137 (MISP Attribute #18566)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76de15-2544-4f39-baed-61db8064ab0b">
-                                        <cybox:Object id=":Address-5d76de15-2544-4f39-baed-61db8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76de15-2544-4f39-baed-61db8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5d76de15-2544-4f39-baed-61db8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">45.32.91.137</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -638,14 +638,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bec8d7b-b658-4050-8b3c-45cc8064ab0b" timestamp="2019-09-20T17:41:18+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bec8d7b-b658-4050-8b3c-45cc8064ab0b" timestamp="2019-09-20T17:41:18+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 144.202.59.23 (MISP Attribute #18408)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 144.202.59.23 (MISP Attribute #18408)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bec8d7b-b658-4050-8b3c-45cc8064ab0b">
-                                        <cybox:Object id=":Address-5bec8d7b-b658-4050-8b3c-45cc8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bec8d7b-b658-4050-8b3c-45cc8064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5bec8d7b-b658-4050-8b3c-45cc8064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">144.202.59.23</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -659,14 +659,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bed8343-d968-4c72-a106-2b328064ab0b" timestamp="2019-09-20T17:40:08+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bed8343-d968-4c72-a106-2b328064ab0b" timestamp="2019-09-20T17:40:08+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 66.42.58.59 (MISP Attribute #18410)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 66.42.58.59 (MISP Attribute #18410)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bed8343-d968-4c72-a106-2b328064ab0b">
-                                        <cybox:Object id=":Address-5bed8343-d968-4c72-a106-2b328064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bed8343-d968-4c72-a106-2b328064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5bed8343-d968-4c72-a106-2b328064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">66.42.58.59</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -680,14 +680,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5bed84bf-8710-4cba-b9eb-05688064ab0b" timestamp="2018-11-15T09:37:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5bed84bf-8710-4cba-b9eb-05688064ab0b" timestamp="2018-11-15T09:37:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 43.251.16.87 (MISP Attribute #18411)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 43.251.16.87 (MISP Attribute #18411)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5bed84bf-8710-4cba-b9eb-05688064ab0b">
-                                        <cybox:Object id=":Address-5bed84bf-8710-4cba-b9eb-05688064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5bed84bf-8710-4cba-b9eb-05688064ab0b">
+                                        <cybox:Object id="citizenlab:Address-5bed84bf-8710-4cba-b9eb-05688064ab0b">
                                             <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr" is_source="false">
                                                 <AddressObj:Address_Value condition="Equals">43.251.16.87</AddressObj:Address_Value>
                                             </cybox:Properties>
@@ -701,14 +701,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-b878-442a-b476-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-b878-442a-b476-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/2z1WayM (MISP Attribute #18511)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/2z1WayM (MISP Attribute #18511)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-b878-442a-b476-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-b878-442a-b476-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-b878-442a-b476-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-b878-442a-b476-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2z1WayM</URIObj:Value>
                                             </cybox:Properties>
@@ -722,14 +722,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-b644-45e2-a9d7-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-b644-45e2-a9d7-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/1R7mqD (MISP Attribute #18512)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/1R7mqD (MISP Attribute #18512)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-b644-45e2-a9d7-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-b644-45e2-a9d7-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-b644-45e2-a9d7-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-b644-45e2-a9d7-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/1R7mqD</URIObj:Value>
                                             </cybox:Properties>
@@ -743,14 +743,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-14c4-4b77-85be-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-14c4-4b77-85be-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/2AYy61a (MISP Attribute #18513)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/2AYy61a (MISP Attribute #18513)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-14c4-4b77-85be-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-14c4-4b77-85be-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-14c4-4b77-85be-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-14c4-4b77-85be-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2AYy61a</URIObj:Value>
                                             </cybox:Properties>
@@ -764,14 +764,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-f8f0-4399-a2ae-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-f8f0-4399-a2ae-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http//www.msap.services/2bKr8Z (MISP Attribute #18514)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http//www.msap.services/2bKr8Z (MISP Attribute #18514)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-f8f0-4399-a2ae-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-f8f0-4399-a2ae-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-f8f0-4399-a2ae-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-f8f0-4399-a2ae-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http//www.msap.services/2bKr8Z</URIObj:Value>
                                             </cybox:Properties>
@@ -785,14 +785,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-a174-4130-a62c-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-a174-4130-a62c-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/6FeBOy (MISP Attribute #18515)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/6FeBOy (MISP Attribute #18515)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-a174-4130-a62c-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-a174-4130-a62c-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-a174-4130-a62c-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-a174-4130-a62c-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/6FeBOy</URIObj:Value>
                                             </cybox:Properties>
@@ -806,14 +806,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-ce00-497f-9284-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-ce00-497f-9284-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://suo.im/5ot25j (MISP Attribute #18516)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://suo.im/5ot25j (MISP Attribute #18516)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-ce00-497f-9284-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-ce00-497f-9284-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-ce00-497f-9284-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-ce00-497f-9284-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://suo.im/5ot25j</URIObj:Value>
                                             </cybox:Properties>
@@ -827,14 +827,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-1708-4847-8b18-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-1708-4847-8b18-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://news.cmitcsubs.tk:5000/web/info?org=aHR0cHM6Ly9kcml2ZS5nb29nbGUuY29tL29wZW4/aWQ9MUlTakl2eFoxX1g5YkdJSnQtMlpKeDRDRWwzdVVhRmlv (MISP Attribute #18517)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://news.cmitcsubs.tk:5000/web/info?org=aHR0cHM6Ly9kcml2ZS5nb29nbGUuY29tL29wZW4/aWQ9MUlTakl2eFoxX1g5YkdJSnQtMlpKeDRDRWwzdVVhRmlv (MISP Attribute #18517)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-1708-4847-8b18-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-1708-4847-8b18-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-1708-4847-8b18-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-1708-4847-8b18-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://news.cmitcsubs.tk:5000/web/info?org=aHR0cHM6Ly9kcml2ZS5nb29nbGUuY29tL29wZW4/aWQ9MUlTakl2eFoxX1g5YkdJSnQtMlpKeDRDRWwzdVVhRmlv</URIObj:Value>
                                             </cybox:Properties>
@@ -848,14 +848,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-bb64-4b8d-b773-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-bb64-4b8d-b773-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/yHJbS6 (MISP Attribute #18518)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/yHJbS6 (MISP Attribute #18518)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-bb64-4b8d-b773-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-bb64-4b8d-b773-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-bb64-4b8d-b773-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-bb64-4b8d-b773-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/yHJbS6</URIObj:Value>
                                             </cybox:Properties>
@@ -869,14 +869,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-d218-49a3-96f3-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-d218-49a3-96f3-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/2qHg3Xt (MISP Attribute #18519)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/2qHg3Xt (MISP Attribute #18519)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-d218-49a3-96f3-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-d218-49a3-96f3-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-d218-49a3-96f3-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-d218-49a3-96f3-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2qHg3Xt</URIObj:Value>
                                             </cybox:Properties>
@@ -890,14 +890,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-0658-494c-afb4-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-0658-494c-afb4-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/S5gDoN (MISP Attribute #18520)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/S5gDoN (MISP Attribute #18520)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-0658-494c-afb4-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-0658-494c-afb4-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-0658-494c-afb4-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-0658-494c-afb4-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/S5gDoN</URIObj:Value>
                                             </cybox:Properties>
@@ -911,14 +911,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-8624-44df-8338-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-8624-44df-8338-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/2T2CoeX (MISP Attribute #18521)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/2T2CoeX (MISP Attribute #18521)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-8624-44df-8338-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-8624-44df-8338-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-8624-44df-8338-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-8624-44df-8338-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2T2CoeX</URIObj:Value>
                                             </cybox:Properties>
@@ -932,14 +932,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-1170-4f0e-ade3-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-1170-4f0e-ade3-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/EzpOhU (MISP Attribute #18522)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/EzpOhU (MISP Attribute #18522)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-1170-4f0e-ade3-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-1170-4f0e-ade3-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-1170-4f0e-ade3-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-1170-4f0e-ade3-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/EzpOhU</URIObj:Value>
                                             </cybox:Properties>
@@ -953,14 +953,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-578c-4a96-88fe-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-578c-4a96-88fe-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/2PSvdau (MISP Attribute #18523)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/2PSvdau (MISP Attribute #18523)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-578c-4a96-88fe-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-578c-4a96-88fe-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-578c-4a96-88fe-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-578c-4a96-88fe-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2PSvdau</URIObj:Value>
                                             </cybox:Properties>
@@ -974,14 +974,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-7058-403d-a9b1-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-7058-403d-a9b1-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/GfHuRi (MISP Attribute #18524)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/GfHuRi (MISP Attribute #18524)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-7058-403d-a9b1-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-7058-403d-a9b1-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-7058-403d-a9b1-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-7058-403d-a9b1-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/GfHuRi</URIObj:Value>
                                             </cybox:Properties>
@@ -995,14 +995,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-5824-4b00-8dda-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-5824-4b00-8dda-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://suo.im/5okeFb (MISP Attribute #18525)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://suo.im/5okeFb (MISP Attribute #18525)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-5824-4b00-8dda-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-5824-4b00-8dda-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-5824-4b00-8dda-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-5824-4b00-8dda-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://suo.im/5okeFb</URIObj:Value>
                                             </cybox:Properties>
@@ -1016,14 +1016,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-b8ec-438c-8161-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-b8ec-438c-8161-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://news.cmitcsubs.tk:5000/web/info?org=aHR0cHM6Ly93d3cubnl0aW1lcy5jb20vMjAxOC8xMS8wMi9vYml0dWFyaWVzL2xvZGktZ3lhcmktZGVhZC5odG1s (MISP Attribute #18526)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://news.cmitcsubs.tk:5000/web/info?org=aHR0cHM6Ly93d3cubnl0aW1lcy5jb20vMjAxOC8xMS8wMi9vYml0dWFyaWVzL2xvZGktZ3lhcmktZGVhZC5odG1s (MISP Attribute #18526)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-b8ec-438c-8161-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-b8ec-438c-8161-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-b8ec-438c-8161-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-b8ec-438c-8161-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://news.cmitcsubs.tk:5000/web/info?org=aHR0cHM6Ly93d3cubnl0aW1lcy5jb20vMjAxOC8xMS8wMi9vYml0dWFyaWVzL2xvZGktZ3lhcmktZGVhZC5odG1s</URIObj:Value>
                                             </cybox:Properties>
@@ -1037,14 +1037,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-a530-4671-8fab-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-a530-4671-8fab-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/2SVPqdY (MISP Attribute #18527)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/2SVPqdY (MISP Attribute #18527)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-a530-4671-8fab-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-a530-4671-8fab-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-a530-4671-8fab-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-a530-4671-8fab-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2SVPqdY</URIObj:Value>
                                             </cybox:Properties>
@@ -1058,14 +1058,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-bd08-4528-9fab-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-bd08-4528-9fab-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/F8XGNe (MISP Attribute #18528)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/F8XGNe (MISP Attribute #18528)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-bd08-4528-9fab-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-bd08-4528-9fab-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-bd08-4528-9fab-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-bd08-4528-9fab-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/F8XGNe</URIObj:Value>
                                             </cybox:Properties>
@@ -1079,14 +1079,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-936c-411b-a0c9-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-936c-411b-a0c9-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/2QroNMt (MISP Attribute #18529)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/2QroNMt (MISP Attribute #18529)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-936c-411b-a0c9-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-936c-411b-a0c9-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-936c-411b-a0c9-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-936c-411b-a0c9-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2QroNMt</URIObj:Value>
                                             </cybox:Properties>
@@ -1100,14 +1100,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-2f9c-40b2-8cd5-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-2f9c-40b2-8cd5-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/70FtQX (MISP Attribute #18530)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/70FtQX (MISP Attribute #18530)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-2f9c-40b2-8cd5-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-2f9c-40b2-8cd5-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-2f9c-40b2-8cd5-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-2f9c-40b2-8cd5-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/70FtQX</URIObj:Value>
                                             </cybox:Properties>
@@ -1121,14 +1121,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-2150-4f97-80c4-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-2150-4f97-80c4-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://msap.services/yHJbS6 (MISP Attribute #18531)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://msap.services/yHJbS6 (MISP Attribute #18531)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-2150-4f97-80c4-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-2150-4f97-80c4-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-2150-4f97-80c4-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-2150-4f97-80c4-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://msap.services/yHJbS6</URIObj:Value>
                                             </cybox:Properties>
@@ -1142,14 +1142,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-0d28-4b27-9ac6-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-0d28-4b27-9ac6-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/2B4GwEf (MISP Attribute #18532)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/2B4GwEf (MISP Attribute #18532)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-0d28-4b27-9ac6-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-0d28-4b27-9ac6-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-0d28-4b27-9ac6-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-0d28-4b27-9ac6-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2B4GwEf</URIObj:Value>
                                             </cybox:Properties>
@@ -1163,14 +1163,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d3-8604-4125-b369-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d3-8604-4125-b369-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/XgL5A9 (MISP Attribute #18533)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/XgL5A9 (MISP Attribute #18533)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d3-8604-4125-b369-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d3-8604-4125-b369-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d3-8604-4125-b369-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d3-8604-4125-b369-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/XgL5A9</URIObj:Value>
                                             </cybox:Properties>
@@ -1184,14 +1184,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d4-7398-45b0-b5e9-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d4-7398-45b0-b5e9-61de8064ab0b" timestamp="2019-09-09T17:40:35+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/2T6pCMf (MISP Attribute #18534)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/2T6pCMf (MISP Attribute #18534)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d4-7398-45b0-b5e9-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d4-7398-45b0-b5e9-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d4-7398-45b0-b5e9-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d4-7398-45b0-b5e9-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2T6pCMf</URIObj:Value>
                                             </cybox:Properties>
@@ -1205,14 +1205,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d4-0854-4d51-8fb7-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d4-0854-4d51-8fb7-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/ZpzstM (MISP Attribute #18535)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/ZpzstM (MISP Attribute #18535)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d4-0854-4d51-8fb7-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d4-0854-4d51-8fb7-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d4-0854-4d51-8fb7-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d4-0854-4d51-8fb7-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/ZpzstM</URIObj:Value>
                                             </cybox:Properties>
@@ -1226,14 +1226,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d4-2fb8-46f2-a589-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d4-2fb8-46f2-a589-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://bit.ly/2Drl90q (MISP Attribute #18536)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://bit.ly/2Drl90q (MISP Attribute #18536)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d4-2fb8-46f2-a589-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d4-2fb8-46f2-a589-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d4-2fb8-46f2-a589-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d4-2fb8-46f2-a589-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://bit.ly/2Drl90q</URIObj:Value>
                                             </cybox:Properties>
@@ -1247,14 +1247,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d4-12f0-4f58-9a9b-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d4-12f0-4f58-9a9b-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://www.msap.services/ZQfqzs (MISP Attribute #18537)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://www.msap.services/ZQfqzs (MISP Attribute #18537)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d4-12f0-4f58-9a9b-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d4-12f0-4f58-9a9b-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d4-12f0-4f58-9a9b-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d4-12f0-4f58-9a9b-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://www.msap.services/ZQfqzs</URIObj:Value>
                                             </cybox:Properties>
@@ -1268,14 +1268,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d4-c2a8-4ee3-bf3d-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d4-c2a8-4ee3-bf3d-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://bit.ly/2MgSRwL (MISP Attribute #18538)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://bit.ly/2MgSRwL (MISP Attribute #18538)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d4-c2a8-4ee3-bf3d-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d4-c2a8-4ee3-bf3d-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d4-c2a8-4ee3-bf3d-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d4-c2a8-4ee3-bf3d-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://bit.ly/2MgSRwL</URIObj:Value>
                                             </cybox:Properties>
@@ -1289,14 +1289,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d4-52b4-413f-bf04-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d4-52b4-413f-bf04-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://www.energy-mail.org/B20V54 (MISP Attribute #18539)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://www.energy-mail.org/B20V54 (MISP Attribute #18539)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d4-52b4-413f-bf04-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d4-52b4-413f-bf04-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d4-52b4-413f-bf04-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d4-52b4-413f-bf04-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://www.energy-mail.org/B20V54</URIObj:Value>
                                             </cybox:Properties>
@@ -1310,14 +1310,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d4-dde0-484e-ac13-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d4-dde0-484e-ac13-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: https://bit.ly/2XePmYt (MISP Attribute #18540)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: https://bit.ly/2XePmYt (MISP Attribute #18540)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d4-dde0-484e-ac13-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d4-dde0-484e-ac13-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d4-dde0-484e-ac13-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d4-dde0-484e-ac13-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">https://bit.ly/2XePmYt</URIObj:Value>
                                             </cybox:Properties>
@@ -1331,14 +1331,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c6d4-3b64-4591-b0df-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c6d4-3b64-4591-b0df-61de8064ab0b" timestamp="2019-09-09T17:40:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://45.76.149.154:5000/web/info?org=aHR0cDovL3d3dy5waGF5dWwuY29tL25ld3MvYXJ0aWNsZS5hc3B4P2lkPTQxNDc0JmZiY2xpZD1Jd0FSM1RadGdjanppUkhNZFJuOEdhZ1RMUV9iMHFrX0VBZWY2YldxRU5SanhaZkkzRFdPNFpsRExPcFdz (MISP Attribute #18541)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://45.76.149.154:5000/web/info?org=aHR0cDovL3d3dy5waGF5dWwuY29tL25ld3MvYXJ0aWNsZS5hc3B4P2lkPTQxNDc0JmZiY2xpZD1Jd0FSM1RadGdjanppUkhNZFJuOEdhZ1RMUV9iMHFrX0VBZWY2YldxRU5SanhaZkkzRFdPNFpsRExPcFdz (MISP Attribute #18541)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c6d4-3b64-4591-b0df-61de8064ab0b">
-                                        <cybox:Object id=":URI-5d76c6d4-3b64-4591-b0df-61de8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c6d4-3b64-4591-b0df-61de8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c6d4-3b64-4591-b0df-61de8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://45.76.149.154:5000/web/info?org=aHR0cDovL3d3dy5waGF5dWwuY29tL25ld3MvYXJ0aWNsZS5hc3B4P2lkPTQxNDc0JmZiY2xpZD1Jd0FSM1RadGdjanppUkhNZFJuOEdhZ1RMUV9iMHFrX0VBZWY2YldxRU5SanhaZkkzRFdPNFpsRExPcFdz</URIObj:Value>
                                             </cybox:Properties>
@@ -1352,14 +1352,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76c730-b4c0-4746-af7e-61db8064ab0b" timestamp="2019-09-09T17:42:08+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76c730-b4c0-4746-af7e-61db8064ab0b" timestamp="2019-09-09T17:42:08+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: http://43.251.16.87:5000//dev/loader (MISP Attribute #18543)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: http://43.251.16.87:5000//dev/loader (MISP Attribute #18543)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76c730-b4c0-4746-af7e-61db8064ab0b">
-                                        <cybox:Object id=":URI-5d76c730-b4c0-4746-af7e-61db8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76c730-b4c0-4746-af7e-61db8064ab0b">
+                                        <cybox:Object id="citizenlab:URI-5d76c730-b4c0-4746-af7e-61db8064ab0b">
                                             <cybox:Properties xsi:type="URIObj:URIObjectType">
                                                 <URIObj:Value condition="Equals">http://43.251.16.87:5000//dev/loader</URIObj:Value>
                                             </cybox:Properties>
@@ -1373,13 +1373,13 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d892cd4-fba0-4c21-90d9-0b328064ab0b" timestamp="2019-09-23T16:36:36+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d892cd4-fba0-4c21-90d9-0b328064ab0b" timestamp="2019-09-23T16:36:36+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hots scot (MISP Attribute #18576)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Network activity: hots scot (MISP Attribute #18576)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d892cd4-fba0-4c21-90d9-0b328064ab0b">
-                                        <cybox:Object id=":HTTPSession-5d892cd4-fba0-4c21-90d9-0b328064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d892cd4-fba0-4c21-90d9-0b328064ab0b">
+                                        <cybox:Object id="citizenlab:HTTPSession-5d892cd4-fba0-4c21-90d9-0b328064ab0b">
                                             <cybox:Properties xsi:type="HTTPSessionObj:HTTPSessionObjectType">
                                                 <HTTPSessionObj:HTTP_Request_Response>
                                                     <HTTPSessionObj:HTTP_Client_Request>
@@ -1401,14 +1401,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76e2eb-abe8-44bb-8dbf-67578064ab0b" timestamp="2019-09-09T19:40:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76e2eb-abe8-44bb-8dbf-67578064ab0b" timestamp="2019-09-09T19:40:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: antmoving.online@gmail.com (MISP Attribute #18568)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: antmoving.online@gmail.com (MISP Attribute #18568)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76e2eb-abe8-44bb-8dbf-67578064ab0b">
-                                        <cybox:Object id=":EmailMessage-5d76e2eb-abe8-44bb-8dbf-67578064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76e2eb-abe8-44bb-8dbf-67578064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5d76e2eb-abe8-44bb-8dbf-67578064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1426,14 +1426,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76e2eb-df2c-4913-b458-67578064ab0b" timestamp="2019-09-09T19:40:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76e2eb-df2c-4913-b458-67578064ab0b" timestamp="2019-09-09T19:40:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: energymail.org@gmail.com (MISP Attribute #18569)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: energymail.org@gmail.com (MISP Attribute #18569)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76e2eb-df2c-4913-b458-67578064ab0b">
-                                        <cybox:Object id=":EmailMessage-5d76e2eb-df2c-4913-b458-67578064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76e2eb-df2c-4913-b458-67578064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5d76e2eb-df2c-4913-b458-67578064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1451,14 +1451,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76e2eb-e004-41d8-bc9d-67578064ab0b" timestamp="2019-09-09T19:40:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76e2eb-e004-41d8-bc9d-67578064ab0b" timestamp="2019-09-09T19:40:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: jameslewis199106@gmail.com (MISP Attribute #18570)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: jameslewis199106@gmail.com (MISP Attribute #18570)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76e2eb-e004-41d8-bc9d-67578064ab0b">
-                                        <cybox:Object id=":EmailMessage-5d76e2eb-e004-41d8-bc9d-67578064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76e2eb-e004-41d8-bc9d-67578064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5d76e2eb-e004-41d8-bc9d-67578064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1476,14 +1476,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d76e2eb-37c8-4b75-b5d7-67578064ab0b" timestamp="2019-09-09T19:40:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d76e2eb-37c8-4b75-b5d7-67578064ab0b" timestamp="2019-09-09T19:40:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: touchxun658@gmail.com (MISP Attribute #18571)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: touchxun658@gmail.com (MISP Attribute #18571)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d76e2eb-37c8-4b75-b5d7-67578064ab0b">
-                                        <cybox:Object id=":EmailMessage-5d76e2eb-37c8-4b75-b5d7-67578064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d76e2eb-37c8-4b75-b5d7-67578064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5d76e2eb-37c8-4b75-b5d7-67578064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -1501,14 +1501,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d8545bf-ec98-4d0c-a8a3-55038064ab0b" timestamp="2019-09-20T17:33:51+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d8545bf-ec98-4d0c-a8a3-55038064ab0b" timestamp="2019-09-20T17:33:51+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 6977e6098815cd91016be9d76f194ed4622640d03c6cdd66b1032306a2190af7 (MISP Attribute #18572)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 6977e6098815cd91016be9d76f194ed4622640d03c6cdd66b1032306a2190af7 (MISP Attribute #18572)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d8545bf-ec98-4d0c-a8a3-55038064ab0b">
-                                        <cybox:Object id=":File-5d8545bf-ec98-4d0c-a8a3-55038064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d8545bf-ec98-4d0c-a8a3-55038064ab0b">
+                                        <cybox:Object id="citizenlab:File-5d8545bf-ec98-4d0c-a8a3-55038064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1527,14 +1527,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d8545d4-ee30-435b-827e-55078064ab0b" timestamp="2019-09-20T17:34:12+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d8545d4-ee30-435b-827e-55078064ab0b" timestamp="2019-09-20T17:34:12+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: e510c361c8101384277dd95cc2c8e76715dd241f58553f592245b620422beaf3 (MISP Attribute #18573)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: e510c361c8101384277dd95cc2c8e76715dd241f58553f592245b620422beaf3 (MISP Attribute #18573)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d8545d4-ee30-435b-827e-55078064ab0b">
-                                        <cybox:Object id=":File-5d8545d4-ee30-435b-827e-55078064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d8545d4-ee30-435b-827e-55078064ab0b">
+                                        <cybox:Object id="citizenlab:File-5d8545d4-ee30-435b-827e-55078064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1553,14 +1553,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d8545e3-c264-43d8-9666-55068064ab0b" timestamp="2019-09-20T17:34:27+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d8545e3-c264-43d8-9666-55068064ab0b" timestamp="2019-09-20T17:34:27+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: 0d13e403303b52edae6beb76a6fe7ed454f340aae1246b9a3f55ca728da2d6aa (MISP Attribute #18574)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: 0d13e403303b52edae6beb76a6fe7ed454f340aae1246b9a3f55ca728da2d6aa (MISP Attribute #18574)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d8545e3-c264-43d8-9666-55068064ab0b">
-                                        <cybox:Object id=":File-5d8545e3-c264-43d8-9666-55068064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d8545e3-c264-43d8-9666-55068064ab0b">
+                                        <cybox:Object id="citizenlab:File-5d8545e3-c264-43d8-9666-55068064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>
@@ -1579,14 +1579,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5d854603-8bf4-44fe-96ae-47ce8064ab0b" timestamp="2019-09-20T17:34:59+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5d854603-8bf4-44fe-96ae-47ce8064ab0b" timestamp="2019-09-20T17:34:59+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: b85fe634f3c5b1022a1adbc21f3b85b58451ca2b89e9380fc5f22b9340a18b88 (MISP Attribute #18575)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">File Hash Watchlist</indicator:Type>
                                     <indicator:Description>Payload delivery: b85fe634f3c5b1022a1adbc21f3b85b58451ca2b89e9380fc5f22b9340a18b88 (MISP Attribute #18575)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5d854603-8bf4-44fe-96ae-47ce8064ab0b">
-                                        <cybox:Object id=":File-5d854603-8bf4-44fe-96ae-47ce8064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5d854603-8bf4-44fe-96ae-47ce8064ab0b">
+                                        <cybox:Object id="citizenlab:File-5d854603-8bf4-44fe-96ae-47ce8064ab0b">
                                             <cybox:Properties xsi:type="FileObj:FileObjectType">
                                                 <FileObj:Hashes>
                                                     <cyboxCommon:Hash>

--- a/202006_DarkBasin/stix.xml
+++ b/202006_DarkBasin/stix.xml
@@ -58,20 +58,20 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id=":Package-fdac5431-7aad-4a9a-ae61-c7c7e4ae7513" version="1.1.1" timestamp="2020-06-08T20:01:05.609338+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="citizenlab:Package-fdac5431-7aad-4a9a-ae61-c7c7e4ae7513" version="1.1.1" timestamp="2020-06-08T20:01:05.609338+00:00">
     <stix:STIX_Header>
         <stix:Title>Export from  MISP</stix:Title>
         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id=":STIXPackage-5ede96d1-41fc-4ee7-8a48-7a4a8064ab0b" version="1.1.1" timestamp="2020-06-08T15:57:34+00:00">
+            <stix:Package id="citizenlab:STIXPackage-5ede96d1-41fc-4ee7-8a48-7a4a8064ab0b" version="1.1.1" timestamp="2020-06-08T15:57:34+00:00">
                 <stix:STIX_Header>
                     <stix:Title>Dark Basin (MISP Event #147)</stix:Title>
                     <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Report</stix:Package_Intent>
                 </stix:STIX_Header>
                 <stix:Incidents>
-                    <stix:Incident id=":incident-5ede96d1-41fc-4ee7-8a48-7a4a8064ab0b" timestamp="2020-06-08T15:58:17+00:00" xsi:type='incident:IncidentType'>
+                    <stix:Incident id="citizenlab:incident-5ede96d1-41fc-4ee7-8a48-7a4a8064ab0b" timestamp="2020-06-08T15:58:17+00:00" xsi:type='incident:IncidentType'>
                         <incident:Title>Dark Basin</incident:Title>
                         <incident:External_ID source="MISP Event">147</incident:External_ID>
                         <incident:Time>
@@ -82,7 +82,7 @@
                         <incident:Related_Indicators>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede982e-23e4-4191-9863-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede982e-23e4-4191-9863-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: amanda.lovers@mail.com (MISP Attribute #19050)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: amanda.lovers@mail.com (MISP Attribute #19050)</indicator:Description>
@@ -95,7 +95,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede982e-bc48-4231-a1ed-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede982e-bc48-4231-a1ed-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: amanda.kruetner@mail.com (MISP Attribute #19051)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: amanda.kruetner@mail.com (MISP Attribute #19051)</indicator:Description>
@@ -108,7 +108,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede982e-3b90-4fc1-95fc-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede982e-3b90-4fc1-95fc-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: anurag.breja342@mail.com (MISP Attribute #19052)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: anurag.breja342@mail.com (MISP Attribute #19052)</indicator:Description>
@@ -121,7 +121,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede982e-8298-4b08-9fd4-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede982e-8298-4b08-9fd4-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: jacktanne@outlook.com (MISP Attribute #19053)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: jacktanne@outlook.com (MISP Attribute #19053)</indicator:Description>
@@ -134,7 +134,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede982e-9c50-4452-9aa5-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede982e-9c50-4452-9aa5-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: flaviatales@mail.com (MISP Attribute #19054)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: flaviatales@mail.com (MISP Attribute #19054)</indicator:Description>
@@ -147,7 +147,7 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Attribution</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede982e-c9f4-490e-9afd-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede982e-c9f4-490e-9afd-7a498064ab0b" timestamp="2020-06-08T15:57:34+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Attribution: robert.klein@europe.com (MISP Attribute #19055)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Description>Attribution: robert.klein@europe.com (MISP Attribute #19055)</indicator:Description>
@@ -160,14 +160,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-f598-4c2e-b774-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-f598-4c2e-b774-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailauthservice.com (MISP Attribute #18688)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailauthservice.com (MISP Attribute #18688)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-f598-4c2e-b774-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-f598-4c2e-b774-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-f598-4c2e-b774-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-f598-4c2e-b774-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailauthservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -181,14 +181,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3b48-441b-9258-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3b48-441b-9258-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: chromeperfection.com (MISP Attribute #18944)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: chromeperfection.com (MISP Attribute #18944)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3b48-441b-9258-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3b48-441b-9258-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3b48-441b-9258-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3b48-441b-9258-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">chromeperfection.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -202,14 +202,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-b984-4338-b5aa-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-b984-4338-b5aa-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailmappingservice.com (MISP Attribute #18689)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailmappingservice.com (MISP Attribute #18689)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-b984-4338-b5aa-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-b984-4338-b5aa-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-b984-4338-b5aa-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-b984-4338-b5aa-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailmappingservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -223,14 +223,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-133c-435b-a17d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-133c-435b-a17d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: trustedserviceonline.com (MISP Attribute #18945)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: trustedserviceonline.com (MISP Attribute #18945)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-133c-435b-a17d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-133c-435b-a17d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-133c-435b-a17d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-133c-435b-a17d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">trustedserviceonline.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -244,14 +244,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-b078-4d6f-b0ba-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-b078-4d6f-b0ba-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailservername299.com (MISP Attribute #18690)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailservername299.com (MISP Attribute #18690)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-b078-4d6f-b0ba-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-b078-4d6f-b0ba-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-b078-4d6f-b0ba-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-b078-4d6f-b0ba-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailservername299.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -265,14 +265,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-12b8-478f-9a4a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-12b8-478f-9a4a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: browserdirectservice.com (MISP Attribute #18946)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: browserdirectservice.com (MISP Attribute #18946)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-12b8-478f-9a4a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-12b8-478f-9a4a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-12b8-478f-9a4a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-12b8-478f-9a4a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">browserdirectservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -286,14 +286,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-4c68-4da6-9f19-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-4c68-4da6-9f19-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailvalidateservice.com (MISP Attribute #18691)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailvalidateservice.com (MISP Attribute #18691)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-4c68-4da6-9f19-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-4c68-4da6-9f19-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-4c68-4da6-9f19-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-4c68-4da6-9f19-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailvalidateservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -307,14 +307,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-69a0-414f-9baa-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-69a0-414f-9baa-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: browserredirect.com (MISP Attribute #18947)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: browserredirect.com (MISP Attribute #18947)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-69a0-414f-9baa-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-69a0-414f-9baa-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-69a0-414f-9baa-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-69a0-414f-9baa-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">browserredirect.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -328,14 +328,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-3484-42bd-ad35-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-3484-42bd-ad35-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostemailserver.com (MISP Attribute #18692)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostemailserver.com (MISP Attribute #18692)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-3484-42bd-ad35-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-3484-42bd-ad35-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-3484-42bd-ad35-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-3484-42bd-ad35-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostemailserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -349,14 +349,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-27cc-4146-b861-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-27cc-4146-b861-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: optionalblogging.com (MISP Attribute #18948)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: optionalblogging.com (MISP Attribute #18948)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-27cc-4146-b861-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-27cc-4146-b861-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-27cc-4146-b861-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-27cc-4146-b861-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">optionalblogging.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -370,14 +370,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-1408-409d-98b3-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-1408-409d-98b3-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailauthenticatorservice.com (MISP Attribute #18693)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailauthenticatorservice.com (MISP Attribute #18693)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-1408-409d-98b3-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-1408-409d-98b3-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-1408-409d-98b3-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-1408-409d-98b3-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailauthenticatorservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -391,14 +391,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-11b8-463d-8aee-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-11b8-463d-8aee-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: selectedmaxstores.com (MISP Attribute #18949)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: selectedmaxstores.com (MISP Attribute #18949)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-11b8-463d-8aee-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-11b8-463d-8aee-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-11b8-463d-8aee-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-11b8-463d-8aee-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">selectedmaxstores.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -412,14 +412,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-df3c-4741-afa8-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-df3c-4741-afa8-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailauthservice399.com (MISP Attribute #18694)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailauthservice399.com (MISP Attribute #18694)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-df3c-4741-afa8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-df3c-4741-afa8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-df3c-4741-afa8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-df3c-4741-afa8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailauthservice399.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -433,14 +433,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4c1c-4135-96a3-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4c1c-4135-96a3-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: auditionregistrationonline.com (MISP Attribute #18950)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: auditionregistrationonline.com (MISP Attribute #18950)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4c1c-4135-96a3-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4c1c-4135-96a3-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4c1c-4135-96a3-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4c1c-4135-96a3-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">auditionregistrationonline.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -454,14 +454,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-77a8-419e-8feb-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-77a8-419e-8feb-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailcollectorservice.com (MISP Attribute #18695)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailcollectorservice.com (MISP Attribute #18695)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-77a8-419e-8feb-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-77a8-419e-8feb-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-77a8-419e-8feb-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-77a8-419e-8feb-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailcollectorservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -475,14 +475,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4e40-4bc5-8730-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4e40-4bc5-8730-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: homeforallorphans.com (MISP Attribute #18951)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: homeforallorphans.com (MISP Attribute #18951)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4e40-4bc5-8730-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4e40-4bc5-8730-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4e40-4bc5-8730-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4e40-4bc5-8730-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">homeforallorphans.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -496,14 +496,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0d58-42d4-8444-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0d58-42d4-8444-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserverenterprise.com (MISP Attribute #18696)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserverenterprise.com (MISP Attribute #18696)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0d58-42d4-8444-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0d58-42d4-8444-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0d58-42d4-8444-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0d58-42d4-8444-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserverenterprise.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -517,14 +517,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-a0dc-4952-b5e7-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-a0dc-4952-b5e7-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: knowledgebaseonlineuk.com (MISP Attribute #18952)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: knowledgebaseonlineuk.com (MISP Attribute #18952)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-a0dc-4952-b5e7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-a0dc-4952-b5e7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-a0dc-4952-b5e7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-a0dc-4952-b5e7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">knowledgebaseonlineuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -538,14 +538,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-54c4-40da-ab7f-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-54c4-40da-ab7f-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailservershare.com (MISP Attribute #18697)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailservershare.com (MISP Attribute #18697)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-54c4-40da-ab7f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-54c4-40da-ab7f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-54c4-40da-ab7f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-54c4-40da-ab7f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailservershare.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -559,14 +559,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-a1d4-4af1-b30e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-a1d4-4af1-b30e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: promotespritialbelief.com (MISP Attribute #18953)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: promotespritialbelief.com (MISP Attribute #18953)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-a1d4-4af1-b30e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-a1d4-4af1-b30e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-a1d4-4af1-b30e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-a1d4-4af1-b30e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">promotespritialbelief.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -580,14 +580,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-ba84-4d86-8998-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-ba84-4d86-8998-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: networkshareserver.com (MISP Attribute #18698)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: networkshareserver.com (MISP Attribute #18698)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-ba84-4d86-8998-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-ba84-4d86-8998-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-ba84-4d86-8998-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-ba84-4d86-8998-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">networkshareserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -601,14 +601,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4918-4acf-8bc2-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4918-4acf-8bc2-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: getreadytorunhalfmarathon.com (MISP Attribute #18954)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: getreadytorunhalfmarathon.com (MISP Attribute #18954)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4918-4acf-8bc2-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4918-4acf-8bc2-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4918-4acf-8bc2-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4918-4acf-8bc2-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">getreadytorunhalfmarathon.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -622,14 +622,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-6ff4-4891-9efc-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-6ff4-4891-9efc-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainserver399.com (MISP Attribute #18699)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainserver399.com (MISP Attribute #18699)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-6ff4-4891-9efc-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-6ff4-4891-9efc-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-6ff4-4891-9efc-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-6ff4-4891-9efc-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainserver399.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -643,14 +643,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-995c-4825-96e8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-995c-4825-96e8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: getsetgoforhealth.com (MISP Attribute #18955)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: getsetgoforhealth.com (MISP Attribute #18955)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-995c-4825-96e8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-995c-4825-96e8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-995c-4825-96e8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-995c-4825-96e8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">getsetgoforhealth.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -664,14 +664,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-6238-4970-a66e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-6238-4970-a66e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostsecuremail544.com (MISP Attribute #18700)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostsecuremail544.com (MISP Attribute #18700)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-6238-4970-a66e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-6238-4970-a66e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-6238-4970-a66e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-6238-4970-a66e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostsecuremail544.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -685,14 +685,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-b4a4-4b8d-ae21-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-b4a4-4b8d-ae21-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linuxserverfast.com (MISP Attribute #18956)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linuxserverfast.com (MISP Attribute #18956)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-b4a4-4b8d-ae21-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-b4a4-4b8d-ae21-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-b4a4-4b8d-ae21-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-b4a4-4b8d-ae21-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linuxserverfast.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -706,14 +706,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-3aa4-42eb-9d3d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-3aa4-42eb-9d3d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shrtnerlnk.com (MISP Attribute #18701)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shrtnerlnk.com (MISP Attribute #18701)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-3aa4-42eb-9d3d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-3aa4-42eb-9d3d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-3aa4-42eb-9d3d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-3aa4-42eb-9d3d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shrtnerlnk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -727,14 +727,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-73d8-4115-838f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-73d8-4115-838f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tinyurlshortner.com (MISP Attribute #18957)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tinyurlshortner.com (MISP Attribute #18957)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-73d8-4115-838f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-73d8-4115-838f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-73d8-4115-838f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-73d8-4115-838f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tinyurlshortner.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -748,14 +748,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-ed18-48ee-a223-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-ed18-48ee-a223-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailingserver938.com (MISP Attribute #18702)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailingserver938.com (MISP Attribute #18702)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-ed18-48ee-a223-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-ed18-48ee-a223-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-ed18-48ee-a223-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-ed18-48ee-a223-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailingserver938.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -769,14 +769,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7b90-41ef-9af5-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7b90-41ef-9af5-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: msgrdrg.com (MISP Attribute #18958)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: msgrdrg.com (MISP Attribute #18958)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7b90-41ef-9af5-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7b90-41ef-9af5-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7b90-41ef-9af5-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7b90-41ef-9af5-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">msgrdrg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -790,14 +790,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0284-4135-adbb-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0284-4135-adbb-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailserver499.com (MISP Attribute #18703)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailserver499.com (MISP Attribute #18703)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0284-4135-adbb-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0284-4135-adbb-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0284-4135-adbb-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0284-4135-adbb-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailserver499.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -811,14 +811,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ea70-40df-ab83-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ea70-40df-ab83-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dnsserverprv.com (MISP Attribute #18959)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dnsserverprv.com (MISP Attribute #18959)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ea70-40df-ab83-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ea70-40df-ab83-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ea70-40df-ab83-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ea70-40df-ab83-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dnsserverprv.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -832,14 +832,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-1c10-41e3-a906-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-1c10-41e3-a906-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserverru2099.com (MISP Attribute #18704)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserverru2099.com (MISP Attribute #18704)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-1c10-41e3-a906-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-1c10-41e3-a906-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-1c10-41e3-a906-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-1c10-41e3-a906-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserverru2099.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -853,14 +853,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-8704-4ba7-b7b8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-8704-4ba7-b7b8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: economyservicesil.com (MISP Attribute #18960)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: economyservicesil.com (MISP Attribute #18960)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-8704-4ba7-b7b8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-8704-4ba7-b7b8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-8704-4ba7-b7b8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-8704-4ba7-b7b8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">economyservicesil.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -874,14 +874,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-650c-4b2f-9da1-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-650c-4b2f-9da1-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: netsecureserver399.com (MISP Attribute #18705)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: netsecureserver399.com (MISP Attribute #18705)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-650c-4b2f-9da1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-650c-4b2f-9da1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-650c-4b2f-9da1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-650c-4b2f-9da1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">netsecureserver399.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -895,14 +895,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d554-4553-833a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d554-4553-833a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: portfoliofasinating.com (MISP Attribute #18961)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: portfoliofasinating.com (MISP Attribute #18961)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d554-4553-833a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d554-4553-833a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d554-4553-833a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d554-4553-833a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">portfoliofasinating.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -916,14 +916,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-06d8-4dfd-899b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-06d8-4dfd-899b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: lnkshrtnr.com (MISP Attribute #18706)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: lnkshrtnr.com (MISP Attribute #18706)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-06d8-4dfd-899b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-06d8-4dfd-899b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-06d8-4dfd-899b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-06d8-4dfd-899b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">lnkshrtnr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -937,14 +937,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-214c-4a18-84c3-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-214c-4a18-84c3-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: selectiveservicemax.com (MISP Attribute #18962)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: selectiveservicemax.com (MISP Attribute #18962)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-214c-4a18-84c3-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-214c-4a18-84c3-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-214c-4a18-84c3-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-214c-4a18-84c3-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">selectiveservicemax.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -958,14 +958,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-abc4-47f7-8141-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-abc4-47f7-8141-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailsecurenode.com (MISP Attribute #18707)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailsecurenode.com (MISP Attribute #18707)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-abc4-47f7-8141-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-abc4-47f7-8141-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-abc4-47f7-8141-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-abc4-47f7-8141-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailsecurenode.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -979,14 +979,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-a520-446a-8154-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-a520-446a-8154-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: maxlaboratories.com (MISP Attribute #18963)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: maxlaboratories.com (MISP Attribute #18963)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-a520-446a-8154-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-a520-446a-8154-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-a520-446a-8154-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-a520-446a-8154-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">maxlaboratories.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1000,14 +1000,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-9570-481d-b627-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-9570-481d-b627-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostemailsecureserver.com (MISP Attribute #18708)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostemailsecureserver.com (MISP Attribute #18708)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-9570-481d-b627-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-9570-481d-b627-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-9570-481d-b627-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-9570-481d-b627-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostemailsecureserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1021,14 +1021,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1e04-4f54-9d73-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1e04-4f54-9d73-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostfeasta.com (MISP Attribute #18964)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostfeasta.com (MISP Attribute #18964)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1e04-4f54-9d73-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1e04-4f54-9d73-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1e04-4f54-9d73-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1e04-4f54-9d73-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostfeasta.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1042,14 +1042,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-55b4-4f05-bb4a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-55b4-4f05-bb4a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailmarknotes.com (MISP Attribute #18709)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailmarknotes.com (MISP Attribute #18709)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-55b4-4f05-bb4a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-55b4-4f05-bb4a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-55b4-4f05-bb4a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-55b4-4f05-bb4a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailmarknotes.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1063,14 +1063,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-e1a8-480a-85ca-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-e1a8-480a-85ca-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: readmytipsntricks.com (MISP Attribute #18965)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: readmytipsntricks.com (MISP Attribute #18965)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-e1a8-480a-85ca-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-e1a8-480a-85ca-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-e1a8-480a-85ca-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-e1a8-480a-85ca-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">readmytipsntricks.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1084,14 +1084,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-5dd8-4f6b-831e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-5dd8-4f6b-831e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailhostsecurehk.com (MISP Attribute #18710)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailhostsecurehk.com (MISP Attribute #18710)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-5dd8-4f6b-831e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-5dd8-4f6b-831e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-5dd8-4f6b-831e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-5dd8-4f6b-831e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailhostsecurehk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1105,14 +1105,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-15f0-4ebc-818d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-15f0-4ebc-818d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: backwaterreservoir.com (MISP Attribute #18966)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: backwaterreservoir.com (MISP Attribute #18966)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-15f0-4ebc-818d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-15f0-4ebc-818d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-15f0-4ebc-818d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-15f0-4ebc-818d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">backwaterreservoir.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1126,14 +1126,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-eb54-4f98-8f5d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-eb54-4f98-8f5d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailgatorservice.com (MISP Attribute #18711)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailgatorservice.com (MISP Attribute #18711)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-eb54-4f98-8f5d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-eb54-4f98-8f5d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-eb54-4f98-8f5d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-eb54-4f98-8f5d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailgatorservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1147,14 +1147,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-6930-47e1-ad77-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-6930-47e1-ad77-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: supportserviceeu.com (MISP Attribute #18967)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: supportserviceeu.com (MISP Attribute #18967)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-6930-47e1-ad77-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-6930-47e1-ad77-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-6930-47e1-ad77-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-6930-47e1-ad77-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">supportserviceeu.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1168,14 +1168,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-5ab4-4cec-8481-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-5ab4-4cec-8481-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: netsecureemailservice.com (MISP Attribute #18712)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: netsecureemailservice.com (MISP Attribute #18712)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-5ab4-4cec-8481-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-5ab4-4cec-8481-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-5ab4-4cec-8481-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-5ab4-4cec-8481-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">netsecureemailservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1189,14 +1189,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-2c70-49dc-9b5e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-2c70-49dc-9b5e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: bellsouthnetwork.com (MISP Attribute #18968)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: bellsouthnetwork.com (MISP Attribute #18968)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-2c70-49dc-9b5e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-2c70-49dc-9b5e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-2c70-49dc-9b5e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-2c70-49dc-9b5e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bellsouthnetwork.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1210,14 +1210,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-6764-490c-b5a6-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-6764-490c-b5a6-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linkshortnr.com (MISP Attribute #18713)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linkshortnr.com (MISP Attribute #18713)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-6764-490c-b5a6-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-6764-490c-b5a6-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-6764-490c-b5a6-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-6764-490c-b5a6-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linkshortnr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1231,14 +1231,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-886c-4f69-b4d5-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-886c-4f69-b4d5-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: homeremedytipntricks.com (MISP Attribute #18969)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: homeremedytipntricks.com (MISP Attribute #18969)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-886c-4f69-b4d5-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-886c-4f69-b4d5-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-886c-4f69-b4d5-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-886c-4f69-b4d5-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">homeremedytipntricks.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1252,14 +1252,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-03f8-4089-9ec3-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-03f8-4089-9ec3-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailhostingsecurenet.com (MISP Attribute #18714)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailhostingsecurenet.com (MISP Attribute #18714)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-03f8-4089-9ec3-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-03f8-4089-9ec3-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-03f8-4089-9ec3-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-03f8-4089-9ec3-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailhostingsecurenet.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1273,14 +1273,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-c58c-44a6-9981-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-c58c-44a6-9981-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: cathostingservice.com (MISP Attribute #18970)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: cathostingservice.com (MISP Attribute #18970)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-c58c-44a6-9981-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-c58c-44a6-9981-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-c58c-44a6-9981-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-c58c-44a6-9981-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">cathostingservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1294,14 +1294,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-d6fc-4d48-8374-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-d6fc-4d48-8374-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailtransferserver.com (MISP Attribute #18715)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailtransferserver.com (MISP Attribute #18715)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-d6fc-4d48-8374-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-d6fc-4d48-8374-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-d6fc-4d48-8374-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-d6fc-4d48-8374-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailtransferserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1315,14 +1315,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-792c-42eb-b93e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-792c-42eb-b93e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: economyfeeds.com (MISP Attribute #18971)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: economyfeeds.com (MISP Attribute #18971)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-792c-42eb-b93e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-792c-42eb-b93e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-792c-42eb-b93e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-792c-42eb-b93e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">economyfeeds.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1336,14 +1336,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-9de4-416e-82c6-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-9de4-416e-82c6-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emaildeliverysuccess.com (MISP Attribute #18716)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emaildeliverysuccess.com (MISP Attribute #18716)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-9de4-416e-82c6-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-9de4-416e-82c6-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-9de4-416e-82c6-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-9de4-416e-82c6-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emaildeliverysuccess.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1357,14 +1357,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-51e8-4732-bf38-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-51e8-4732-bf38-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: productdemoservice.com (MISP Attribute #18972)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: productdemoservice.com (MISP Attribute #18972)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-51e8-4732-bf38-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-51e8-4732-bf38-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-51e8-4732-bf38-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-51e8-4732-bf38-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">productdemoservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1378,14 +1378,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-7ca0-4ba3-8d25-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-7ca0-4ba3-8d25-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailmarkservice.com (MISP Attribute #18717)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailmarkservice.com (MISP Attribute #18717)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-7ca0-4ba3-8d25-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-7ca0-4ba3-8d25-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-7ca0-4ba3-8d25-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-7ca0-4ba3-8d25-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailmarkservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1399,14 +1399,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-0010-4ce9-aede-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-0010-4ce9-aede-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ultimateresponseservice.com (MISP Attribute #18973)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ultimateresponseservice.com (MISP Attribute #18973)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-0010-4ce9-aede-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-0010-4ce9-aede-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-0010-4ce9-aede-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-0010-4ce9-aede-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ultimateresponseservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1420,14 +1420,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-33a0-4ca5-8ef5-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-33a0-4ca5-8ef5-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailcommunicationservice.com (MISP Attribute #18718)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailcommunicationservice.com (MISP Attribute #18718)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-33a0-4ca5-8ef5-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-33a0-4ca5-8ef5-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-33a0-4ca5-8ef5-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-33a0-4ca5-8ef5-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailcommunicationservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1441,14 +1441,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-0a28-4f20-a141-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-0a28-4f20-a141-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: cyberserverusa.com (MISP Attribute #18974)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: cyberserverusa.com (MISP Attribute #18974)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-0a28-4f20-a141-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-0a28-4f20-a141-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-0a28-4f20-a141-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-0a28-4f20-a141-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">cyberserverusa.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1462,14 +1462,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-7aa0-48bf-ad8b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-7aa0-48bf-ad8b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailrockservice.com (MISP Attribute #18719)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailrockservice.com (MISP Attribute #18719)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-7aa0-48bf-ad8b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-7aa0-48bf-ad8b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-7aa0-48bf-ad8b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-7aa0-48bf-ad8b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailrockservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1483,14 +1483,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-06e8-4cda-9533-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-06e8-4cda-9533-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ecoserveraus.com (MISP Attribute #18975)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ecoserveraus.com (MISP Attribute #18975)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-06e8-4cda-9533-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-06e8-4cda-9533-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-06e8-4cda-9533-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-06e8-4cda-9533-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ecoserveraus.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1504,14 +1504,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-92e4-4d8e-a145-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-92e4-4d8e-a145-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainemailhostings.com (MISP Attribute #18720)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainemailhostings.com (MISP Attribute #18720)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-92e4-4d8e-a145-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-92e4-4d8e-a145-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-92e4-4d8e-a145-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-92e4-4d8e-a145-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainemailhostings.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1525,14 +1525,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-7710-4657-9242-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-7710-4657-9242-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: forumtechtopic.com (MISP Attribute #18976)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: forumtechtopic.com (MISP Attribute #18976)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-7710-4657-9242-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-7710-4657-9242-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-7710-4657-9242-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-7710-4657-9242-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">forumtechtopic.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1546,14 +1546,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-51b4-470b-8bc8-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-51b4-470b-8bc8-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: rockerhostings.com (MISP Attribute #18721)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: rockerhostings.com (MISP Attribute #18721)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-51b4-470b-8bc8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-51b4-470b-8bc8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-51b4-470b-8bc8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-51b4-470b-8bc8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">rockerhostings.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1567,14 +1567,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-a838-47c5-b462-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-a838-47c5-b462-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: interserver439.com (MISP Attribute #18977)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: interserver439.com (MISP Attribute #18977)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-a838-47c5-b462-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-a838-47c5-b462-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-a838-47c5-b462-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-a838-47c5-b462-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">interserver439.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1588,14 +1588,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-7ff4-4f69-890c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-7ff4-4f69-890c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basemailservice.com (MISP Attribute #18722)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basemailservice.com (MISP Attribute #18722)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-7ff4-4f69-890c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-7ff4-4f69-890c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-7ff4-4f69-890c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-7ff4-4f69-890c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basemailservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1609,14 +1609,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-b700-4dd5-8f65-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-b700-4dd5-8f65-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: nameserver3476.com (MISP Attribute #18978)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: nameserver3476.com (MISP Attribute #18978)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-b700-4dd5-8f65-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-b700-4dd5-8f65-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-b700-4dd5-8f65-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-b700-4dd5-8f65-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">nameserver3476.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1630,14 +1630,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-2178-458e-a517-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-2178-458e-a517-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostmailsecureserver.com (MISP Attribute #18723)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostmailsecureserver.com (MISP Attribute #18723)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-2178-458e-a517-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-2178-458e-a517-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-2178-458e-a517-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-2178-458e-a517-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostmailsecureserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1651,14 +1651,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-ed3c-4f42-ba2f-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-ed3c-4f42-ba2f-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: onlinemusicstoreuk.com (MISP Attribute #18979)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: onlinemusicstoreuk.com (MISP Attribute #18979)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-ed3c-4f42-ba2f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-ed3c-4f42-ba2f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-ed3c-4f42-ba2f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-ed3c-4f42-ba2f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">onlinemusicstoreuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1672,14 +1672,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-ffa4-4456-8d11-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-ffa4-4456-8d11-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailpostsecureservice.com (MISP Attribute #18724)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailpostsecureservice.com (MISP Attribute #18724)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-ffa4-4456-8d11-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-ffa4-4456-8d11-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-ffa4-4456-8d11-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-ffa4-4456-8d11-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailpostsecureservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1693,14 +1693,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-b35c-450a-93ba-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-b35c-450a-93ba-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: chatserverrussia.com (MISP Attribute #18980)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: chatserverrussia.com (MISP Attribute #18980)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-b35c-450a-93ba-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-b35c-450a-93ba-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-b35c-450a-93ba-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-b35c-450a-93ba-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">chatserverrussia.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1714,14 +1714,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-26c0-48ae-be69-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-26c0-48ae-be69-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: strurl.click (MISP Attribute #18725)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: strurl.click (MISP Attribute #18725)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-26c0-48ae-be69-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-26c0-48ae-be69-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-26c0-48ae-be69-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-26c0-48ae-be69-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">strurl.click</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1735,14 +1735,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-b734-45bc-ac73-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-b734-45bc-ac73-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: secureemailserver65.com (MISP Attribute #18981)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: secureemailserver65.com (MISP Attribute #18981)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-b734-45bc-ac73-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-b734-45bc-ac73-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-b734-45bc-ac73-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-b734-45bc-ac73-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">secureemailserver65.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1756,14 +1756,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-90f0-4667-8747-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-90f0-4667-8747-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: securemailhost46.com (MISP Attribute #18726)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: securemailhost46.com (MISP Attribute #18726)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-90f0-4667-8747-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-90f0-4667-8747-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-90f0-4667-8747-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-90f0-4667-8747-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">securemailhost46.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1777,14 +1777,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-11c4-44d6-8fb5-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-11c4-44d6-8fb5-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: snaphosterservice.com (MISP Attribute #18982)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: snaphosterservice.com (MISP Attribute #18982)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-11c4-44d6-8fb5-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-11c4-44d6-8fb5-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-11c4-44d6-8fb5-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-11c4-44d6-8fb5-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">snaphosterservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1798,14 +1798,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-9658-41ca-8e4e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-9658-41ca-8e4e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostmailsecure.com (MISP Attribute #18727)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostmailsecure.com (MISP Attribute #18727)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-9658-41ca-8e4e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-9658-41ca-8e4e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-9658-41ca-8e4e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-9658-41ca-8e4e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostmailsecure.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1819,14 +1819,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-4364-4cc2-a094-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-4364-4cc2-a094-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: siteadminhk.com (MISP Attribute #18983)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: siteadminhk.com (MISP Attribute #18983)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-4364-4cc2-a094-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-4364-4cc2-a094-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-4364-4cc2-a094-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-4364-4cc2-a094-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">siteadminhk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1840,14 +1840,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-fc84-4a5c-a9b1-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-fc84-4a5c-a9b1-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailpostsecure.com (MISP Attribute #18728)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailpostsecure.com (MISP Attribute #18728)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-fc84-4a5c-a9b1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-fc84-4a5c-a9b1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-fc84-4a5c-a9b1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-fc84-4a5c-a9b1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailpostsecure.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1861,14 +1861,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-e82c-404a-9286-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-e82c-404a-9286-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: nameserverredirect.com (MISP Attribute #18984)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: nameserverredirect.com (MISP Attribute #18984)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-e82c-404a-9286-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-e82c-404a-9286-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-e82c-404a-9286-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-e82c-404a-9286-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">nameserverredirect.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1882,14 +1882,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-cdf8-44a2-948a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-cdf8-44a2-948a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailsecurehost.com (MISP Attribute #18729)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailsecurehost.com (MISP Attribute #18729)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-cdf8-44a2-948a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-cdf8-44a2-948a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-cdf8-44a2-948a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-cdf8-44a2-948a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailsecurehost.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1903,14 +1903,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-1da0-4549-96cc-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-1da0-4549-96cc-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: affiliatedomainservice.com (MISP Attribute #18985)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: affiliatedomainservice.com (MISP Attribute #18985)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-1da0-4549-96cc-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-1da0-4549-96cc-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-1da0-4549-96cc-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-1da0-4549-96cc-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">affiliatedomainservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1924,14 +1924,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-a3b8-455c-ab4c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-a3b8-455c-ab4c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailapiservice.com (MISP Attribute #18730)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailapiservice.com (MISP Attribute #18730)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-a3b8-455c-ab4c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-a3b8-455c-ab4c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-a3b8-455c-ab4c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-a3b8-455c-ab4c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailapiservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1945,14 +1945,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-db3c-441b-afc6-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-db3c-441b-afc6-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: siteadmineurope.com (MISP Attribute #18986)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: siteadmineurope.com (MISP Attribute #18986)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-db3c-441b-afc6-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-db3c-441b-afc6-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-db3c-441b-afc6-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-db3c-441b-afc6-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">siteadmineurope.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1966,14 +1966,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-e3dc-4e89-afab-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-e3dc-4e89-afab-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailchimpservice.com (MISP Attribute #18731)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailchimpservice.com (MISP Attribute #18731)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-e3dc-4e89-afab-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-e3dc-4e89-afab-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-e3dc-4e89-afab-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-e3dc-4e89-afab-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailchimpservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -1987,14 +1987,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-199c-47f6-bb3d-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-199c-47f6-bb3d-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: sitebloginfo.com (MISP Attribute #18987)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: sitebloginfo.com (MISP Attribute #18987)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-199c-47f6-bb3d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-199c-47f6-bb3d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-199c-47f6-bb3d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-199c-47f6-bb3d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">sitebloginfo.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2008,14 +2008,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-deb8-4412-95d1-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-deb8-4412-95d1-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: postmarkapiservice.com (MISP Attribute #18732)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: postmarkapiservice.com (MISP Attribute #18732)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-deb8-4412-95d1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-deb8-4412-95d1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-deb8-4412-95d1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-deb8-4412-95d1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">postmarkapiservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2029,14 +2029,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-d444-40a9-a6e0-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-d444-40a9-a6e0-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: xpertdomain.com (MISP Attribute #18988)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: xpertdomain.com (MISP Attribute #18988)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-d444-40a9-a6e0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-d444-40a9-a6e0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-d444-40a9-a6e0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-d444-40a9-a6e0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">xpertdomain.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2050,14 +2050,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-bc48-433f-ba2f-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-bc48-433f-ba2f-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: loginservercheck.com (MISP Attribute #18733)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: loginservercheck.com (MISP Attribute #18733)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-bc48-433f-ba2f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-bc48-433f-ba2f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-bc48-433f-ba2f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-bc48-433f-ba2f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">loginservercheck.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2071,14 +2071,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-b878-4327-a297-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-b878-4327-a297-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: aplsrvrer.com (MISP Attribute #18989)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: aplsrvrer.com (MISP Attribute #18989)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-b878-4327-a297-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-b878-4327-a297-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-b878-4327-a297-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-b878-4327-a297-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">aplsrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2092,14 +2092,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-90dc-40ea-9a33-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-90dc-40ea-9a33-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: checkmailserverhk.com (MISP Attribute #18734)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: checkmailserverhk.com (MISP Attribute #18734)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-90dc-40ea-9a33-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-90dc-40ea-9a33-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-90dc-40ea-9a33-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-90dc-40ea-9a33-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">checkmailserverhk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2113,14 +2113,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-c86c-4e8e-bb6f-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-c86c-4e8e-bb6f-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: bsrvrer.com (MISP Attribute #18990)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: bsrvrer.com (MISP Attribute #18990)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-c86c-4e8e-bb6f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-c86c-4e8e-bb6f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-c86c-4e8e-bb6f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-c86c-4e8e-bb6f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bsrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2134,14 +2134,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-a478-4713-a96a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-a478-4713-a96a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shortlinkcut.com (MISP Attribute #18735)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shortlinkcut.com (MISP Attribute #18735)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-a478-4713-a96a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-a478-4713-a96a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-a478-4713-a96a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-a478-4713-a96a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shortlinkcut.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2155,14 +2155,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-8f54-43b7-83ef-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-8f54-43b7-83ef-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: csrvrer.com (MISP Attribute #18991)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: csrvrer.com (MISP Attribute #18991)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-8f54-43b7-83ef-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-8f54-43b7-83ef-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-8f54-43b7-83ef-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-8f54-43b7-83ef-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">csrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2176,14 +2176,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0f94-4924-8a79-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0f94-4924-8a79-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserverhollandservice.com (MISP Attribute #18736)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserverhollandservice.com (MISP Attribute #18736)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0f94-4924-8a79-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0f94-4924-8a79-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0f94-4924-8a79-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0f94-4924-8a79-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserverhollandservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2197,14 +2197,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-0254-48bb-8890-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-0254-48bb-8890-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dsrvrer.com (MISP Attribute #18992)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dsrvrer.com (MISP Attribute #18992)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-0254-48bb-8890-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-0254-48bb-8890-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-0254-48bb-8890-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-0254-48bb-8890-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dsrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2218,14 +2218,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-a3b4-4400-8ce4-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-a3b4-4400-8ce4-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: postserviceemaildomain.com (MISP Attribute #18737)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: postserviceemaildomain.com (MISP Attribute #18737)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-a3b4-4400-8ce4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-a3b4-4400-8ce4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-a3b4-4400-8ce4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-a3b4-4400-8ce4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">postserviceemaildomain.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2239,14 +2239,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-d6c4-4236-ad25-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-d6c4-4236-ad25-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: esrvrer.com (MISP Attribute #18993)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: esrvrer.com (MISP Attribute #18993)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-d6c4-4236-ad25-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-d6c4-4236-ad25-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-d6c4-4236-ad25-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-d6c4-4236-ad25-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">esrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2260,14 +2260,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-e694-4282-9f6a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-e694-4282-9f6a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webhostwebcare.com (MISP Attribute #18738)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webhostwebcare.com (MISP Attribute #18738)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-e694-4282-9f6a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-e694-4282-9f6a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-e694-4282-9f6a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-e694-4282-9f6a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webhostwebcare.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2281,14 +2281,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-d9b0-45f0-892c-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-d9b0-45f0-892c-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: isrvrer.com (MISP Attribute #18994)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: isrvrer.com (MISP Attribute #18994)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-d9b0-45f0-892c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-d9b0-45f0-892c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-d9b0-45f0-892c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-d9b0-45f0-892c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">isrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2302,14 +2302,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-7628-40c5-86c9-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-7628-40c5-86c9-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: santanaservice.com (MISP Attribute #18739)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: santanaservice.com (MISP Attribute #18739)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-7628-40c5-86c9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-7628-40c5-86c9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-7628-40c5-86c9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-7628-40c5-86c9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">santanaservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2323,14 +2323,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-450c-4d31-a992-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-450c-4d31-a992-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: zsrvrer.com (MISP Attribute #18995)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: zsrvrer.com (MISP Attribute #18995)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-450c-4d31-a992-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-450c-4d31-a992-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-450c-4d31-a992-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-450c-4d31-a992-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">zsrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2344,14 +2344,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-6d40-4201-8e7b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-6d40-4201-8e7b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailhostholland.com (MISP Attribute #18740)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailhostholland.com (MISP Attribute #18740)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-6d40-4201-8e7b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-6d40-4201-8e7b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-6d40-4201-8e7b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-6d40-4201-8e7b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailhostholland.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2365,14 +2365,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-0cfc-4388-816d-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-0cfc-4388-816d-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: inrsrvrer.com (MISP Attribute #18996)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: inrsrvrer.com (MISP Attribute #18996)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-0cfc-4388-816d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-0cfc-4388-816d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-0cfc-4388-816d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-0cfc-4388-816d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">inrsrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2386,14 +2386,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-96bc-4de2-9a3f-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-96bc-4de2-9a3f-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: maillinkservice.com (MISP Attribute #18741)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: maillinkservice.com (MISP Attribute #18741)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-96bc-4de2-9a3f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-96bc-4de2-9a3f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-96bc-4de2-9a3f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-96bc-4de2-9a3f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">maillinkservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2407,14 +2407,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-9774-4c94-9234-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-9774-4c94-9234-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mnrsrvrer.com (MISP Attribute #18997)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mnrsrvrer.com (MISP Attribute #18997)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-9774-4c94-9234-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-9774-4c94-9234-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-9774-4c94-9234-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-9774-4c94-9234-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mnrsrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2428,14 +2428,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-afd0-4e7b-a76d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-afd0-4e7b-a76d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hkdrillonline.com (MISP Attribute #18742)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hkdrillonline.com (MISP Attribute #18742)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-afd0-4e7b-a76d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-afd0-4e7b-a76d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-afd0-4e7b-a76d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-afd0-4e7b-a76d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hkdrillonline.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2449,14 +2449,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-c684-4c87-9e52-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-c684-4c87-9e52-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mvrsrvrer.com (MISP Attribute #18998)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mvrsrvrer.com (MISP Attribute #18998)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-c684-4c87-9e52-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-c684-4c87-9e52-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-c684-4c87-9e52-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-c684-4c87-9e52-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mvrsrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2470,14 +2470,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-9908-4265-9d9c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-9908-4265-9d9c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostsecuremail.com (MISP Attribute #18743)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostsecuremail.com (MISP Attribute #18743)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-9908-4265-9d9c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-9908-4265-9d9c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-9908-4265-9d9c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-9908-4265-9d9c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostsecuremail.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2491,14 +2491,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-9d4c-4204-83e2-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-9d4c-4204-83e2-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: imgsrvrer.com (MISP Attribute #18999)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: imgsrvrer.com (MISP Attribute #18999)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-9d4c-4204-83e2-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-9d4c-4204-83e2-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-9d4c-4204-83e2-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-9d4c-4204-83e2-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">imgsrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2512,14 +2512,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-c774-403d-88f0-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-c774-403d-88f0-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailannounceservice.com (MISP Attribute #18744)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailannounceservice.com (MISP Attribute #18744)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-c774-403d-88f0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-c774-403d-88f0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-c774-403d-88f0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-c774-403d-88f0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailannounceservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2533,14 +2533,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-1f50-44e9-b3a6-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-1f50-44e9-b3a6-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: nrgrsrvrer.com (MISP Attribute #19000)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: nrgrsrvrer.com (MISP Attribute #19000)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-1f50-44e9-b3a6-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-1f50-44e9-b3a6-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-1f50-44e9-b3a6-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-1f50-44e9-b3a6-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">nrgrsrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2554,14 +2554,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-322c-450d-ad4a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-322c-450d-ad4a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverforshort.com (MISP Attribute #18745)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverforshort.com (MISP Attribute #18745)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-322c-450d-ad4a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-322c-450d-ad4a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-322c-450d-ad4a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-322c-450d-ad4a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverforshort.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2575,14 +2575,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-07ac-483b-97b8-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-07ac-483b-97b8-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: minrsrvr.com (MISP Attribute #19001)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: minrsrvr.com (MISP Attribute #19001)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-07ac-483b-97b8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-07ac-483b-97b8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-07ac-483b-97b8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-07ac-483b-97b8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">minrsrvr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2596,14 +2596,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-b478-4eef-87bf-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-b478-4eef-87bf-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hathwaynetwork.com (MISP Attribute #18746)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hathwaynetwork.com (MISP Attribute #18746)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-b478-4eef-87bf-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-b478-4eef-87bf-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-b478-4eef-87bf-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-b478-4eef-87bf-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hathwaynetwork.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2617,14 +2617,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-be08-4f6d-86b8-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-be08-4f6d-86b8-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: intrsrvrer.com (MISP Attribute #19002)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: intrsrvrer.com (MISP Attribute #19002)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-be08-4f6d-86b8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-be08-4f6d-86b8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-be08-4f6d-86b8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-be08-4f6d-86b8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">intrsrvrer.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2638,14 +2638,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-4514-446e-b980-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-4514-446e-b980-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: servermain43.com (MISP Attribute #18747)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: servermain43.com (MISP Attribute #18747)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-4514-446e-b980-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-4514-446e-b980-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-4514-446e-b980-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-4514-446e-b980-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">servermain43.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2659,14 +2659,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-6654-47da-adb0-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-6654-47da-adb0-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-msrgr.info (MISP Attribute #19003)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-msrgr.info (MISP Attribute #19003)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-6654-47da-adb0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-6654-47da-adb0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-6654-47da-adb0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-6654-47da-adb0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-msrgr.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2680,14 +2680,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-8024-4293-b1ec-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-8024-4293-b1ec-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainsserver4f.com (MISP Attribute #18748)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainsserver4f.com (MISP Attribute #18748)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-8024-4293-b1ec-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-8024-4293-b1ec-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-8024-4293-b1ec-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-8024-4293-b1ec-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainsserver4f.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2701,14 +2701,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-7df4-4194-9704-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-7df4-4194-9704-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-oa-en-us.com (MISP Attribute #19004)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-oa-en-us.com (MISP Attribute #19004)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-7df4-4194-9704-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-7df4-4194-9704-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-7df4-4194-9704-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-7df4-4194-9704-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-oa-en-us.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2722,14 +2722,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0440-45bf-af15-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0440-45bf-af15-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainblacklistcheck.com (MISP Attribute #18749)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainblacklistcheck.com (MISP Attribute #18749)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0440-45bf-af15-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0440-45bf-af15-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0440-45bf-af15-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0440-45bf-af15-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainblacklistcheck.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2743,14 +2743,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-74c4-4434-a43a-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-74c4-4434-a43a-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mrgrhr.com (MISP Attribute #19005)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mrgrhr.com (MISP Attribute #19005)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-74c4-4434-a43a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-74c4-4434-a43a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-74c4-4434-a43a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-74c4-4434-a43a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mrgrhr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2764,14 +2764,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-4a5c-467a-93ee-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-4a5c-467a-93ee-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serversap54.com (MISP Attribute #18750)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serversap54.com (MISP Attribute #18750)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-4a5c-467a-93ee-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-4a5c-467a-93ee-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-4a5c-467a-93ee-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-4a5c-467a-93ee-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serversap54.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2785,14 +2785,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-c058-4beb-ba35-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-c058-4beb-ba35-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-nh-en-us.com (MISP Attribute #19006)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-nh-en-us.com (MISP Attribute #19006)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-c058-4beb-ba35-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-c058-4beb-ba35-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-c058-4beb-ba35-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-c058-4beb-ba35-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-nh-en-us.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2806,14 +2806,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-e4d8-40c7-bb37-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-e4d8-40c7-bb37-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: sapserverhike.com (MISP Attribute #18751)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: sapserverhike.com (MISP Attribute #18751)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-e4d8-40c7-bb37-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-e4d8-40c7-bb37-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-e4d8-40c7-bb37-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-e4d8-40c7-bb37-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">sapserverhike.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2827,14 +2827,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-6c8c-46e5-b610-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-6c8c-46e5-b610-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-io-en-us.com (MISP Attribute #19007)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-io-en-us.com (MISP Attribute #19007)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-6c8c-46e5-b610-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-6c8c-46e5-b610-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-6c8c-46e5-b610-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-6c8c-46e5-b610-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-io-en-us.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2848,14 +2848,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-b5e8-4554-98f1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-b5e8-4554-98f1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainserveractive.com (MISP Attribute #18752)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainserveractive.com (MISP Attribute #18752)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-b5e8-4554-98f1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-b5e8-4554-98f1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-b5e8-4554-98f1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-b5e8-4554-98f1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainserveractive.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2869,14 +2869,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-18c0-4297-9099-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-18c0-4297-9099-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: msrdr.com (MISP Attribute #19008)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: msrdr.com (MISP Attribute #19008)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-18c0-4297-9099-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-18c0-4297-9099-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-18c0-4297-9099-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-18c0-4297-9099-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">msrdr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2890,14 +2890,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-583c-4616-a682-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-583c-4616-a682-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: netsecurehostingmy.com (MISP Attribute #18753)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: netsecurehostingmy.com (MISP Attribute #18753)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-583c-4616-a682-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-583c-4616-a682-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-583c-4616-a682-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-583c-4616-a682-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">netsecurehostingmy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2911,14 +2911,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-ce54-4e66-a5fd-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-ce54-4e66-a5fd-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: msrwr.com (MISP Attribute #19009)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: msrwr.com (MISP Attribute #19009)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-ce54-4e66-a5fd-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-ce54-4e66-a5fd-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-ce54-4e66-a5fd-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-ce54-4e66-a5fd-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">msrwr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2932,14 +2932,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-bf8c-42fc-bc23-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-bf8c-42fc-bc23-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: pageredirectservice.com (MISP Attribute #18754)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: pageredirectservice.com (MISP Attribute #18754)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-bf8c-42fc-bc23-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-bf8c-42fc-bc23-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-bf8c-42fc-bc23-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-bf8c-42fc-bc23-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">pageredirectservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2953,14 +2953,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-8898-4c9a-8424-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-8898-4c9a-8424-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mgrsr.com (MISP Attribute #19010)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mgrsr.com (MISP Attribute #19010)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-8898-4c9a-8424-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-8898-4c9a-8424-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-8898-4c9a-8424-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-8898-4c9a-8424-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mgrsr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2974,14 +2974,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-8bac-43ad-88c1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-8bac-43ad-88c1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailbaseserverhl.com (MISP Attribute #18755)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailbaseserverhl.com (MISP Attribute #18755)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-8bac-43ad-88c1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-8bac-43ad-88c1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-8bac-43ad-88c1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-8bac-43ad-88c1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailbaseserverhl.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -2995,14 +2995,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-d518-4de6-90a3-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-d518-4de6-90a3-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-en-us.co.uk (MISP Attribute #19011)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-en-us.co.uk (MISP Attribute #19011)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-d518-4de6-90a3-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-d518-4de6-90a3-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-d518-4de6-90a3-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-d518-4de6-90a3-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-en-us.co.uk</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3016,14 +3016,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-abc8-4549-93d6-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-abc8-4549-93d6-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: logincontrolserver.com (MISP Attribute #18756)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: logincontrolserver.com (MISP Attribute #18756)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-abc8-4549-93d6-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-abc8-4549-93d6-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-abc8-4549-93d6-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-abc8-4549-93d6-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">logincontrolserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3037,14 +3037,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-2e18-429a-be6d-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-2e18-429a-be6d-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-er-en-us.com (MISP Attribute #19012)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-er-en-us.com (MISP Attribute #19012)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-2e18-429a-be6d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-2e18-429a-be6d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-2e18-429a-be6d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-2e18-429a-be6d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-er-en-us.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3058,14 +3058,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-dc28-4fac-bc85-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-dc28-4fac-bc85-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: baseserveremailbg.com (MISP Attribute #18757)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: baseserveremailbg.com (MISP Attribute #18757)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-dc28-4fac-bc85-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-dc28-4fac-bc85-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-dc28-4fac-bc85-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-dc28-4fac-bc85-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">baseserveremailbg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3079,14 +3079,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-9e88-4d0c-8afa-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-9e88-4d0c-8afa-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-ar-en-us.com (MISP Attribute #19013)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-ar-en-us.com (MISP Attribute #19013)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-9e88-4d0c-8afa-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-9e88-4d0c-8afa-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-9e88-4d0c-8afa-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-9e88-4d0c-8afa-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-ar-en-us.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3100,14 +3100,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-f004-43fc-91f8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-f004-43fc-91f8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linkforwrder.com (MISP Attribute #18758)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linkforwrder.com (MISP Attribute #18758)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-f004-43fc-91f8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-f004-43fc-91f8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-f004-43fc-91f8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-f004-43fc-91f8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linkforwrder.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3121,14 +3121,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-f404-4140-99d1-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-f404-4140-99d1-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: secureserver9898.com (MISP Attribute #19014)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: secureserver9898.com (MISP Attribute #19014)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-f404-4140-99d1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-f404-4140-99d1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-f404-4140-99d1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-f404-4140-99d1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">secureserver9898.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3142,14 +3142,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1060-4d92-a2c9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1060-4d92-a2c9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailsecureservers.com (MISP Attribute #18759)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailsecureservers.com (MISP Attribute #18759)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1060-4d92-a2c9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1060-4d92-a2c9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1060-4d92-a2c9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1060-4d92-a2c9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailsecureservers.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3163,14 +3163,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-40e8-417c-892e-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-40e8-417c-892e-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: deferrer.website (MISP Attribute #19015)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: deferrer.website (MISP Attribute #19015)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-40e8-417c-892e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-40e8-417c-892e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-40e8-417c-892e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-40e8-417c-892e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">deferrer.website</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3184,14 +3184,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1d98-411f-854f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1d98-411f-854f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserveroutlook.com (MISP Attribute #18760)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserveroutlook.com (MISP Attribute #18760)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1d98-411f-854f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1d98-411f-854f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1d98-411f-854f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1d98-411f-854f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserveroutlook.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3205,14 +3205,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-571c-406b-835a-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-571c-406b-835a-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: look-com.org (MISP Attribute #19016)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: look-com.org (MISP Attribute #19016)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-571c-406b-835a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-571c-406b-835a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-571c-406b-835a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-571c-406b-835a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">look-com.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3226,14 +3226,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-6e00-4107-b39f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-6e00-4107-b39f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: websecurehostings.com (MISP Attribute #18761)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: websecurehostings.com (MISP Attribute #18761)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-6e00-4107-b39f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-6e00-4107-b39f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-6e00-4107-b39f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-6e00-4107-b39f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">websecurehostings.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3247,14 +3247,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-d024-4581-b7dc-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-d024-4581-b7dc-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-com.org (MISP Attribute #19017)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-com.org (MISP Attribute #19017)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-d024-4581-b7dc-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-d024-4581-b7dc-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-d024-4581-b7dc-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-d024-4581-b7dc-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-com.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3268,14 +3268,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d254-42f4-8dce-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d254-42f4-8dce-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: anothershortnr.com (MISP Attribute #18762)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: anothershortnr.com (MISP Attribute #18762)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d254-42f4-8dce-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d254-42f4-8dce-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d254-42f4-8dce-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d254-42f4-8dce-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">anothershortnr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3289,14 +3289,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-643c-42d9-bae7-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-643c-42d9-bae7-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ppleid.org (MISP Attribute #19018)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ppleid.org (MISP Attribute #19018)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-643c-42d9-bae7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-643c-42d9-bae7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-643c-42d9-bae7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-643c-42d9-bae7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ppleid.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3310,14 +3310,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-83c0-4085-9855-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-83c0-4085-9855-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserverdirect3994.com (MISP Attribute #18763)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserverdirect3994.com (MISP Attribute #18763)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-83c0-4085-9855-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-83c0-4085-9855-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-83c0-4085-9855-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-83c0-4085-9855-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserverdirect3994.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3331,14 +3331,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-4f78-44e0-b1d4-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-4f78-44e0-b1d4-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-biz.website (MISP Attribute #19019)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-biz.website (MISP Attribute #19019)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-4f78-44e0-b1d4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-4f78-44e0-b1d4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-4f78-44e0-b1d4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-4f78-44e0-b1d4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-biz.website</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3352,14 +3352,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-898c-4a02-9d5c-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-898c-4a02-9d5c-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserver39.com (MISP Attribute #18764)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserver39.com (MISP Attribute #18764)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-898c-4a02-9d5c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-898c-4a02-9d5c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-898c-4a02-9d5c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-898c-4a02-9d5c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserver39.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3373,14 +3373,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-899c-409f-b5d0-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-899c-409f-b5d0-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-com-us.com (MISP Attribute #19020)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-com-us.com (MISP Attribute #19020)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-899c-409f-b5d0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-899c-409f-b5d0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-899c-409f-b5d0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-899c-409f-b5d0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-com-us.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3394,14 +3394,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-9a00-4765-a6a3-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-9a00-4765-a6a3-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailserver4859.com (MISP Attribute #18765)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailserver4859.com (MISP Attribute #18765)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-9a00-4765-a6a3-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-9a00-4765-a6a3-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-9a00-4765-a6a3-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-9a00-4765-a6a3-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailserver4859.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3415,14 +3415,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-e6e8-43d0-9760-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-e6e8-43d0-9760-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-com.website (MISP Attribute #19021)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-com.website (MISP Attribute #19021)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-e6e8-43d0-9760-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-e6e8-43d0-9760-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-e6e8-43d0-9760-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-e6e8-43d0-9760-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-com.website</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3436,14 +3436,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-a3b4-404d-aab6-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-a3b4-404d-aab6-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linkfollowservice.com (MISP Attribute #18766)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linkfollowservice.com (MISP Attribute #18766)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-a3b4-404d-aab6-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-a3b4-404d-aab6-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-a3b4-404d-aab6-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-a3b4-404d-aab6-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linkfollowservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3457,14 +3457,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-b21c-4c11-afb7-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-b21c-4c11-afb7-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-hl-en-us.com (MISP Attribute #19022)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-hl-en-us.com (MISP Attribute #19022)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-b21c-4c11-afb7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-b21c-4c11-afb7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-b21c-4c11-afb7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-b21c-4c11-afb7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-hl-en-us.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3478,14 +3478,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d928-4ccf-9dfe-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d928-4ccf-9dfe-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: netsecuremailhosting.com (MISP Attribute #18767)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: netsecuremailhosting.com (MISP Attribute #18767)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d928-4ccf-9dfe-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d928-4ccf-9dfe-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d928-4ccf-9dfe-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d928-4ccf-9dfe-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">netsecuremailhosting.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3499,14 +3499,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-6964-4b95-96e4-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-6964-4b95-96e4-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-mail-us.com (MISP Attribute #19023)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-mail-us.com (MISP Attribute #19023)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-6964-4b95-96e4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-6964-4b95-96e4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-6964-4b95-96e4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-6964-4b95-96e4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-mail-us.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3520,14 +3520,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-292c-4c75-9e27-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-292c-4c75-9e27-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserviceloginonline.com (MISP Attribute #18768)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserviceloginonline.com (MISP Attribute #18768)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-292c-4c75-9e27-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-292c-4c75-9e27-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-292c-4c75-9e27-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-292c-4c75-9e27-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserviceloginonline.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3541,14 +3541,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-d77c-4cf9-8adc-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-d77c-4cf9-8adc-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-mail.net (MISP Attribute #19024)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-mail.net (MISP Attribute #19024)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-d77c-4cf9-8adc-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-d77c-4cf9-8adc-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-d77c-4cf9-8adc-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-d77c-4cf9-8adc-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-mail.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3562,14 +3562,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7354-4483-95e8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7354-4483-95e8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailauthorizationservice.com (MISP Attribute #18769)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailauthorizationservice.com (MISP Attribute #18769)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7354-4483-95e8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7354-4483-95e8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7354-4483-95e8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7354-4483-95e8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailauthorizationservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3583,14 +3583,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-15ec-4c50-8e7e-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-15ec-4c50-8e7e-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-us-en-us.com (MISP Attribute #19025)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-us-en-us.com (MISP Attribute #19025)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-15ec-4c50-8e7e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-15ec-4c50-8e7e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-15ec-4c50-8e7e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-15ec-4c50-8e7e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-us-en-us.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3604,14 +3604,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ef18-4011-a98e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ef18-4011-a98e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailauthservice.com (MISP Attribute #18770)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailauthservice.com (MISP Attribute #18770)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ef18-4011-a98e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ef18-4011-a98e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ef18-4011-a98e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ef18-4011-a98e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailauthservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3625,14 +3625,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-2518-4f2b-a1c2-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-2518-4f2b-a1c2-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webmailmanageruk.com (MISP Attribute #19026)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webmailmanageruk.com (MISP Attribute #19026)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-2518-4f2b-a1c2-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-2518-4f2b-a1c2-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-2518-4f2b-a1c2-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-2518-4f2b-a1c2-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webmailmanageruk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3646,14 +3646,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-6c6c-4931-8c5a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-6c6c-4931-8c5a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: trackserviceonline.xyz (MISP Attribute #18771)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: trackserviceonline.xyz (MISP Attribute #18771)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-6c6c-4931-8c5a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-6c6c-4931-8c5a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-6c6c-4931-8c5a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-6c6c-4931-8c5a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">trackserviceonline.xyz</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3667,14 +3667,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-5f3c-4034-8163-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-5f3c-4034-8163-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: websitemanagerusa.com (MISP Attribute #19027)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: websitemanagerusa.com (MISP Attribute #19027)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-5f3c-4034-8163-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-5f3c-4034-8163-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-5f3c-4034-8163-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-5f3c-4034-8163-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">websitemanagerusa.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3688,14 +3688,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-138c-440a-9b4f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-138c-440a-9b4f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: affliatedomainservice.com (MISP Attribute #18772)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: affliatedomainservice.com (MISP Attribute #18772)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-138c-440a-9b4f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-138c-440a-9b4f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-138c-440a-9b4f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-138c-440a-9b4f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">affliatedomainservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3709,14 +3709,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-19e4-4a62-b752-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-19e4-4a62-b752-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: transferserver33.com (MISP Attribute #19028)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: transferserver33.com (MISP Attribute #19028)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-19e4-4a62-b752-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-19e4-4a62-b752-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-19e4-4a62-b752-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-19e4-4a62-b752-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">transferserver33.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3730,14 +3730,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d3ac-4247-822d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d3ac-4247-822d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: upgradetravelservice.com (MISP Attribute #18773)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: upgradetravelservice.com (MISP Attribute #18773)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d3ac-4247-822d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d3ac-4247-822d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d3ac-4247-822d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d3ac-4247-822d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">upgradetravelservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3751,14 +3751,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-df18-4891-b6a8-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-df18-4891-b6a8-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: websiteadminuk.com (MISP Attribute #19029)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: websiteadminuk.com (MISP Attribute #19029)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-df18-4891-b6a8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-df18-4891-b6a8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-df18-4891-b6a8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-df18-4891-b6a8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">websiteadminuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3772,14 +3772,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-a390-4424-8619-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-a390-4424-8619-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-authmail.com (MISP Attribute #18774)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-authmail.com (MISP Attribute #18774)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-a390-4424-8619-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-a390-4424-8619-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-a390-4424-8619-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-a390-4424-8619-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-authmail.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3793,14 +3793,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-2214-4607-80a7-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-2214-4607-80a7-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: budgtoffmy.com (MISP Attribute #19030)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: budgtoffmy.com (MISP Attribute #19030)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-2214-4607-80a7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-2214-4607-80a7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-2214-4607-80a7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-2214-4607-80a7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">budgtoffmy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3814,14 +3814,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-b44c-48af-9023-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-b44c-48af-9023-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webredirect.click (MISP Attribute #18775)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webredirect.click (MISP Attribute #18775)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-b44c-48af-9023-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-b44c-48af-9023-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-b44c-48af-9023-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-b44c-48af-9023-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webredirect.click</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3835,14 +3835,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-b2f0-4a05-ba80-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-b2f0-4a05-ba80-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: budgtoffru.com (MISP Attribute #19031)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: budgtoffru.com (MISP Attribute #19031)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-b2f0-4a05-ba80-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-b2f0-4a05-ba80-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-b2f0-4a05-ba80-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-b2f0-4a05-ba80-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">budgtoffru.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3856,14 +3856,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1134-4ece-8e78-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1134-4ece-8e78-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: javaservermy.com (MISP Attribute #18776)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: javaservermy.com (MISP Attribute #18776)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1134-4ece-8e78-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1134-4ece-8e78-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1134-4ece-8e78-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1134-4ece-8e78-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">javaservermy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3877,14 +3877,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-9ae8-4036-9084-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-9ae8-4036-9084-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverforhelplux.com (MISP Attribute #19032)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverforhelplux.com (MISP Attribute #19032)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-9ae8-4036-9084-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-9ae8-4036-9084-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-9ae8-4036-9084-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-9ae8-4036-9084-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverforhelplux.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3898,14 +3898,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-22b8-40e6-afe3-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-22b8-40e6-afe3-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailcommute.com (MISP Attribute #18777)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailcommute.com (MISP Attribute #18777)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-22b8-40e6-afe3-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-22b8-40e6-afe3-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-22b8-40e6-afe3-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-22b8-40e6-afe3-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailcommute.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3919,14 +3919,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-5aa4-4e2b-82b2-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-5aa4-4e2b-82b2-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverforhelpmy.com (MISP Attribute #19033)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverforhelpmy.com (MISP Attribute #19033)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-5aa4-4e2b-82b2-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-5aa4-4e2b-82b2-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-5aa4-4e2b-82b2-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-5aa4-4e2b-82b2-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverforhelpmy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3940,14 +3940,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-e93c-400b-8a1d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-e93c-400b-8a1d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shortenup.com (MISP Attribute #18778)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shortenup.com (MISP Attribute #18778)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-e93c-400b-8a1d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-e93c-400b-8a1d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-e93c-400b-8a1d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-e93c-400b-8a1d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shortenup.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3961,14 +3961,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-f224-46ff-b495-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-f224-46ff-b495-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linuxbasicru3.com (MISP Attribute #19034)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linuxbasicru3.com (MISP Attribute #19034)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-f224-46ff-b495-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-f224-46ff-b495-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-f224-46ff-b495-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-f224-46ff-b495-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linuxbasicru3.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -3982,14 +3982,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-e350-4f53-baba-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-e350-4f53-baba-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: assuredreturnplan.com (MISP Attribute #18779)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: assuredreturnplan.com (MISP Attribute #18779)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-e350-4f53-baba-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-e350-4f53-baba-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-e350-4f53-baba-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-e350-4f53-baba-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">assuredreturnplan.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4003,14 +4003,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-4ac0-4551-a821-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-4ac0-4551-a821-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: nigeriaoilleaks.com (MISP Attribute #19035)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: nigeriaoilleaks.com (MISP Attribute #19035)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-4ac0-4551-a821-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-4ac0-4551-a821-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-4ac0-4551-a821-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-4ac0-4551-a821-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">nigeriaoilleaks.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4024,14 +4024,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-da3c-4adb-904b-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-da3c-4adb-904b-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: optionaldesigners.com (MISP Attribute #18780)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: optionaldesigners.com (MISP Attribute #18780)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-da3c-4adb-904b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-da3c-4adb-904b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-da3c-4adb-904b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-da3c-4adb-904b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">optionaldesigners.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4045,14 +4045,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-602c-4aa9-bbb0-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-602c-4aa9-bbb0-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ondemand.pushthisurl.com (MISP Attribute #19036)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ondemand.pushthisurl.com (MISP Attribute #19036)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-602c-4aa9-bbb0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-602c-4aa9-bbb0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-602c-4aa9-bbb0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-602c-4aa9-bbb0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ondemand.pushthisurl.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4066,14 +4066,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-e7d8-4879-aa9c-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-e7d8-4879-aa9c-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: post-manager.com (MISP Attribute #18781)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: post-manager.com (MISP Attribute #18781)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-e7d8-4879-aa9c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-e7d8-4879-aa9c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-e7d8-4879-aa9c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-e7d8-4879-aa9c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">post-manager.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4087,14 +4087,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-a220-4201-9852-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-a220-4201-9852-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: saferedirect.pw (MISP Attribute #19037)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: saferedirect.pw (MISP Attribute #19037)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-a220-4201-9852-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-a220-4201-9852-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-a220-4201-9852-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-a220-4201-9852-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">saferedirect.pw</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4108,14 +4108,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-6d20-4054-87fc-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-6d20-4054-87fc-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: racksackserveruk.com (MISP Attribute #18782)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: racksackserveruk.com (MISP Attribute #18782)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-6d20-4054-87fc-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-6d20-4054-87fc-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-6d20-4054-87fc-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-6d20-4054-87fc-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">racksackserveruk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4129,14 +4129,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974c-0c50-4fca-ba3b-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974c-0c50-4fca-ba3b-7a498064ab0b" timestamp="2020-06-08T15:53:48+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shortserver1.com (MISP Attribute #19038)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shortserver1.com (MISP Attribute #19038)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974c-0c50-4fca-ba3b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974c-0c50-4fca-ba3b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974c-0c50-4fca-ba3b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974c-0c50-4fca-ba3b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shortserver1.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4150,14 +4150,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-dc24-4f46-8aff-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-dc24-4f46-8aff-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: netgeoserversg.com (MISP Attribute #18783)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: netgeoserversg.com (MISP Attribute #18783)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-dc24-4f46-8aff-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-dc24-4f46-8aff-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-dc24-4f46-8aff-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-dc24-4f46-8aff-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">netgeoserversg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4171,14 +4171,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-693c-4ffc-97a6-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-693c-4ffc-97a6-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: blogserverlx.com (MISP Attribute #18784)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: blogserverlx.com (MISP Attribute #18784)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-693c-4ffc-97a6-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-693c-4ffc-97a6-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-693c-4ffc-97a6-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-693c-4ffc-97a6-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">blogserverlx.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4192,14 +4192,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7674-4e17-9971-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7674-4e17-9971-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dotnetserverhk.com (MISP Attribute #18785)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dotnetserverhk.com (MISP Attribute #18785)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7674-4e17-9971-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7674-4e17-9971-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7674-4e17-9971-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7674-4e17-9971-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dotnetserverhk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4213,14 +4213,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d768-4621-beeb-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d768-4621-beeb-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: capitalinvestmentsllp.com (MISP Attribute #18786)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: capitalinvestmentsllp.com (MISP Attribute #18786)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d768-4621-beeb-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d768-4621-beeb-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d768-4621-beeb-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d768-4621-beeb-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">capitalinvestmentsllp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4234,14 +4234,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-b218-498c-9aa8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-b218-498c-9aa8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: frwrdrurl.com (MISP Attribute #18787)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: frwrdrurl.com (MISP Attribute #18787)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-b218-498c-9aa8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-b218-498c-9aa8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-b218-498c-9aa8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-b218-498c-9aa8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">frwrdrurl.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4255,14 +4255,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3930-4de3-8ded-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3930-4de3-8ded-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: offshoretoursntravels.com (MISP Attribute #18788)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: offshoretoursntravels.com (MISP Attribute #18788)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3930-4de3-8ded-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3930-4de3-8ded-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3930-4de3-8ded-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3930-4de3-8ded-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">offshoretoursntravels.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4276,14 +4276,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3538-441f-8489-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3538-441f-8489-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shipnyatchholland.com (MISP Attribute #18789)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shipnyatchholland.com (MISP Attribute #18789)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3538-441f-8489-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3538-441f-8489-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3538-441f-8489-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3538-441f-8489-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shipnyatchholland.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4297,14 +4297,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4cfc-4fb4-8b9b-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4cfc-4fb4-8b9b-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hollandtourandtravel.com (MISP Attribute #18790)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hollandtourandtravel.com (MISP Attribute #18790)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4cfc-4fb4-8b9b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4cfc-4fb4-8b9b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4cfc-4fb4-8b9b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4cfc-4fb4-8b9b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hollandtourandtravel.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4318,14 +4318,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-6b64-457f-86c4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-6b64-457f-86c4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tricktravelbooking.com (MISP Attribute #18791)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tricktravelbooking.com (MISP Attribute #18791)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-6b64-457f-86c4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-6b64-457f-86c4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-6b64-457f-86c4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-6b64-457f-86c4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tricktravelbooking.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4339,14 +4339,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7edc-4931-a120-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7edc-4931-a120-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hongkongshippingcompany.com (MISP Attribute #18792)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hongkongshippingcompany.com (MISP Attribute #18792)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7edc-4931-a120-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7edc-4931-a120-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7edc-4931-a120-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7edc-4931-a120-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hongkongshippingcompany.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4360,14 +4360,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-9d20-47f0-ae1a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-9d20-47f0-ae1a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: offshorecompanyllp.com (MISP Attribute #18793)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: offshorecompanyllp.com (MISP Attribute #18793)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-9d20-47f0-ae1a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-9d20-47f0-ae1a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-9d20-47f0-ae1a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-9d20-47f0-ae1a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">offshorecompanyllp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4381,14 +4381,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-885c-427b-9a04-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-885c-427b-9a04-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hardcoretechnologiesllp.com (MISP Attribute #18794)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hardcoretechnologiesllp.com (MISP Attribute #18794)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-885c-427b-9a04-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-885c-427b-9a04-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-885c-427b-9a04-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-885c-427b-9a04-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hardcoretechnologiesllp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4402,14 +4402,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-6ee8-4c07-a877-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-6ee8-4c07-a877-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: strongwingtechnologies.com (MISP Attribute #18795)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: strongwingtechnologies.com (MISP Attribute #18795)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-6ee8-4c07-a877-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-6ee8-4c07-a877-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-6ee8-4c07-a877-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-6ee8-4c07-a877-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">strongwingtechnologies.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4423,14 +4423,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3634-4a5f-b63d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3634-4a5f-b63d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: watchmanservice.com (MISP Attribute #18796)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: watchmanservice.com (MISP Attribute #18796)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3634-4a5f-b63d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3634-4a5f-b63d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3634-4a5f-b63d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3634-4a5f-b63d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">watchmanservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4444,14 +4444,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1bf8-4a3a-a1a1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1bf8-4a3a-a1a1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hiretechservicehg.com (MISP Attribute #18797)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hiretechservicehg.com (MISP Attribute #18797)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1bf8-4a3a-a1a1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1bf8-4a3a-a1a1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1bf8-4a3a-a1a1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1bf8-4a3a-a1a1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hiretechservicehg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4465,14 +4465,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-2930-48c9-b7ec-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-2930-48c9-b7ec-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: internetmarketingservicehg.com (MISP Attribute #18798)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: internetmarketingservicehg.com (MISP Attribute #18798)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-2930-48c9-b7ec-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-2930-48c9-b7ec-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-2930-48c9-b7ec-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-2930-48c9-b7ec-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">internetmarketingservicehg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4486,14 +4486,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-f07c-459d-bbfd-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-f07c-459d-bbfd-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: prwebsiteuk.com (MISP Attribute #18799)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: prwebsiteuk.com (MISP Attribute #18799)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-f07c-459d-bbfd-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-f07c-459d-bbfd-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-f07c-459d-bbfd-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-f07c-459d-bbfd-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">prwebsiteuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4507,14 +4507,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-9504-4c77-90af-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-9504-4c77-90af-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: selectyourgroom.com (MISP Attribute #18800)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: selectyourgroom.com (MISP Attribute #18800)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-9504-4c77-90af-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-9504-4c77-90af-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-9504-4c77-90af-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-9504-4c77-90af-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">selectyourgroom.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4528,14 +4528,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5228-4bc7-ac4a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5228-4bc7-ac4a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: exchangeserverformailing.com (MISP Attribute #18801)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: exchangeserverformailing.com (MISP Attribute #18801)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5228-4bc7-ac4a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5228-4bc7-ac4a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5228-4bc7-ac4a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5228-4bc7-ac4a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">exchangeserverformailing.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4549,14 +4549,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-0394-4fcb-ab1d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-0394-4fcb-ab1d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: loginservicesmailsonlinesaccounts.com (MISP Attribute #18802)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: loginservicesmailsonlinesaccounts.com (MISP Attribute #18802)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-0394-4fcb-ab1d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-0394-4fcb-ab1d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-0394-4fcb-ab1d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-0394-4fcb-ab1d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">loginservicesmailsonlinesaccounts.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4570,14 +4570,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-54c4-4074-9a98-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-54c4-4074-9a98-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: redirectserviceonline.com (MISP Attribute #18803)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: redirectserviceonline.com (MISP Attribute #18803)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-54c4-4074-9a98-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-54c4-4074-9a98-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-54c4-4074-9a98-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-54c4-4074-9a98-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">redirectserviceonline.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4591,14 +4591,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ac34-420a-ada9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ac34-420a-ada9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: strongbolthostinghk.com (MISP Attribute #18804)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: strongbolthostinghk.com (MISP Attribute #18804)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ac34-420a-ada9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ac34-420a-ada9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ac34-420a-ada9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ac34-420a-ada9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">strongbolthostinghk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4612,14 +4612,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-53d4-4528-b91f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-53d4-4528-b91f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: dotnerserversg.com (MISP Attribute #18805)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: dotnerserversg.com (MISP Attribute #18805)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-53d4-4528-b91f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-53d4-4528-b91f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-53d4-4528-b91f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-53d4-4528-b91f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">dotnerserversg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4633,14 +4633,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-8d54-4966-b6ce-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-8d54-4966-b6ce-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: netserviceru.com (MISP Attribute #18806)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: netserviceru.com (MISP Attribute #18806)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-8d54-4966-b6ce-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-8d54-4966-b6ce-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-8d54-4966-b6ce-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-8d54-4966-b6ce-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">netserviceru.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4654,14 +4654,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-048c-4ae5-900c-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-048c-4ae5-900c-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: sapserverhg.com (MISP Attribute #18807)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: sapserverhg.com (MISP Attribute #18807)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-048c-4ae5-900c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-048c-4ae5-900c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-048c-4ae5-900c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-048c-4ae5-900c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">sapserverhg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4675,14 +4675,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-98ac-4c09-a078-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-98ac-4c09-a078-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: srvrgruk.com (MISP Attribute #18808)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: srvrgruk.com (MISP Attribute #18808)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-98ac-4c09-a078-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-98ac-4c09-a078-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-98ac-4c09-a078-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-98ac-4c09-a078-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">srvrgruk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4696,14 +4696,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5e04-4a75-8dde-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5e04-4a75-8dde-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainformailinguk.com (MISP Attribute #18809)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainformailinguk.com (MISP Attribute #18809)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5e04-4a75-8dde-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5e04-4a75-8dde-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5e04-4a75-8dde-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5e04-4a75-8dde-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainformailinguk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4717,14 +4717,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5ebc-4d75-a571-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5ebc-4d75-a571-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: exchangeserver2345.com (MISP Attribute #18810)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: exchangeserver2345.com (MISP Attribute #18810)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5ebc-4d75-a571-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5ebc-4d75-a571-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5ebc-4d75-a571-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5ebc-4d75-a571-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">exchangeserver2345.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4738,14 +4738,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5740-4f87-978e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5740-4f87-978e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tnyurlservice.com (MISP Attribute #18811)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tnyurlservice.com (MISP Attribute #18811)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5740-4f87-978e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5740-4f87-978e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5740-4f87-978e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5740-4f87-978e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tnyurlservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4759,14 +4759,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3340-4c3f-bf88-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3340-4c3f-bf88-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserver39490.com (MISP Attribute #18812)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserver39490.com (MISP Attribute #18812)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3340-4c3f-bf88-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3340-4c3f-bf88-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3340-4c3f-bf88-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3340-4c3f-bf88-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserver39490.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4780,14 +4780,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-48ac-49f7-aa25-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-48ac-49f7-aa25-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserveroginusa.com (MISP Attribute #18813)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserveroginusa.com (MISP Attribute #18813)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-48ac-49f7-aa25-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-48ac-49f7-aa25-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-48ac-49f7-aa25-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-48ac-49f7-aa25-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserveroginusa.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4801,14 +4801,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-f180-4a01-92f0-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-f180-4a01-92f0-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserverdomaineu.com (MISP Attribute #18814)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserverdomaineu.com (MISP Attribute #18814)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-f180-4a01-92f0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-f180-4a01-92f0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-f180-4a01-92f0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-f180-4a01-92f0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserverdomaineu.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4822,14 +4822,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-c100-45b4-81df-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-c100-45b4-81df-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserverdomainhk.com (MISP Attribute #18815)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserverdomainhk.com (MISP Attribute #18815)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-c100-45b4-81df-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-c100-45b4-81df-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-c100-45b4-81df-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-c100-45b4-81df-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserverdomainhk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4843,14 +4843,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ab10-4ab3-a06d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ab10-4ab3-a06d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserverdomainuk.com (MISP Attribute #18816)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserverdomainuk.com (MISP Attribute #18816)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ab10-4ab3-a06d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ab10-4ab3-a06d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ab10-4ab3-a06d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ab10-4ab3-a06d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserverdomainuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4864,14 +4864,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7edc-4057-baba-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7edc-4057-baba-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserverdomainusa.com (MISP Attribute #18817)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserverdomainusa.com (MISP Attribute #18817)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7edc-4057-baba-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7edc-4057-baba-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7edc-4057-baba-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7edc-4057-baba-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserverdomainusa.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4885,14 +4885,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7244-43e1-92cc-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7244-43e1-92cc-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainhostnetworkuk.com (MISP Attribute #18818)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainhostnetworkuk.com (MISP Attribute #18818)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7244-43e1-92cc-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7244-43e1-92cc-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7244-43e1-92cc-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7244-43e1-92cc-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainhostnetworkuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4906,14 +4906,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4de0-4c57-9268-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4de0-4c57-9268-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainhostnetworkusa.com (MISP Attribute #18819)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainhostnetworkusa.com (MISP Attribute #18819)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4de0-4c57-9268-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4de0-4c57-9268-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4de0-4c57-9268-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4de0-4c57-9268-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainhostnetworkusa.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4927,14 +4927,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-2d00-4dc6-8bb2-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-2d00-4dc6-8bb2-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainhostworkeu.com (MISP Attribute #18820)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainhostworkeu.com (MISP Attribute #18820)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-2d00-4dc6-8bb2-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-2d00-4dc6-8bb2-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-2d00-4dc6-8bb2-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-2d00-4dc6-8bb2-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainhostworkeu.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4948,14 +4948,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-eed4-4938-84d1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-eed4-4938-84d1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainlocalhostingeu.com (MISP Attribute #18821)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainlocalhostingeu.com (MISP Attribute #18821)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-eed4-4938-84d1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-eed4-4938-84d1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-eed4-4938-84d1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-eed4-4938-84d1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainlocalhostingeu.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4969,14 +4969,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3594-4998-b9e1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3594-4998-b9e1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainlocalhostinghk.com (MISP Attribute #18822)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainlocalhostinghk.com (MISP Attribute #18822)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3594-4998-b9e1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3594-4998-b9e1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3594-4998-b9e1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3594-4998-b9e1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainlocalhostinghk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -4990,14 +4990,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-44dc-476e-999f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-44dc-476e-999f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainlocalhostinguk.com (MISP Attribute #18823)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainlocalhostinguk.com (MISP Attribute #18823)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-44dc-476e-999f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-44dc-476e-999f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-44dc-476e-999f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-44dc-476e-999f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainlocalhostinguk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5011,14 +5011,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-8008-4c91-a16b-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-8008-4c91-a16b-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: localhostinguk.com (MISP Attribute #18824)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: localhostinguk.com (MISP Attribute #18824)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-8008-4c91-a16b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-8008-4c91-a16b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-8008-4c91-a16b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-8008-4c91-a16b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">localhostinguk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5032,14 +5032,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-f528-4693-9214-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-f528-4693-9214-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shorturlservice.com (MISP Attribute #18825)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shorturlservice.com (MISP Attribute #18825)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-f528-4693-9214-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-f528-4693-9214-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-f528-4693-9214-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-f528-4693-9214-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shorturlservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5053,14 +5053,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-646c-46fa-b45a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-646c-46fa-b45a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: onlineloginserviceeu.com (MISP Attribute #18826)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: onlineloginserviceeu.com (MISP Attribute #18826)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-646c-46fa-b45a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-646c-46fa-b45a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-646c-46fa-b45a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-646c-46fa-b45a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">onlineloginserviceeu.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5074,14 +5074,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-6ee8-4b70-acdc-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-6ee8-4b70-acdc-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: onlineloginserviceuk.com (MISP Attribute #18827)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: onlineloginserviceuk.com (MISP Attribute #18827)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-6ee8-4b70-acdc-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-6ee8-4b70-acdc-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-6ee8-4b70-acdc-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-6ee8-4b70-acdc-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">onlineloginserviceuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5095,14 +5095,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-c338-4d27-8906-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-c338-4d27-8906-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: onlineloginserviceusa.com (MISP Attribute #18828)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: onlineloginserviceusa.com (MISP Attribute #18828)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-c338-4d27-8906-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-c338-4d27-8906-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-c338-4d27-8906-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-c338-4d27-8906-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">onlineloginserviceusa.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5116,14 +5116,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4178-428d-9a89-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4178-428d-9a89-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basichostnetservice.com (MISP Attribute #18829)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basichostnetservice.com (MISP Attribute #18829)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4178-428d-9a89-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4178-428d-9a89-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4178-428d-9a89-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4178-428d-9a89-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basichostnetservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5137,14 +5137,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3bf0-48e4-b015-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3bf0-48e4-b015-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: loginservicebasic.com (MISP Attribute #18830)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: loginservicebasic.com (MISP Attribute #18830)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3bf0-48e4-b015-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3bf0-48e4-b015-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3bf0-48e4-b015-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3bf0-48e4-b015-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">loginservicebasic.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5158,14 +5158,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-26c8-401d-afe0-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-26c8-401d-afe0-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basichostingrussia.com (MISP Attribute #18831)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basichostingrussia.com (MISP Attribute #18831)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-26c8-401d-afe0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-26c8-401d-afe0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-26c8-401d-afe0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-26c8-401d-afe0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basichostingrussia.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5179,14 +5179,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7348-4b92-8293-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7348-4b92-8293-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: bitserverhk.com (MISP Attribute #18832)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: bitserverhk.com (MISP Attribute #18832)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7348-4b92-8293-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7348-4b92-8293-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7348-4b92-8293-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7348-4b92-8293-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bitserverhk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5200,14 +5200,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-f0c4-4628-a01d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-f0c4-4628-a01d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: openserverholland.com (MISP Attribute #18577)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: openserverholland.com (MISP Attribute #18577)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-f0c4-4628-a01d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-f0c4-4628-a01d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-f0c4-4628-a01d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-f0c4-4628-a01d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">openserverholland.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5221,14 +5221,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-b028-4cd7-b4c3-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-b028-4cd7-b4c3-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: bitserverlux.com (MISP Attribute #18833)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: bitserverlux.com (MISP Attribute #18833)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-b028-4cd7-b4c3-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-b028-4cd7-b4c3-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-b028-4cd7-b4c3-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-b028-4cd7-b4c3-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">bitserverlux.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5242,14 +5242,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0d88-4041-bb35-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0d88-4041-bb35-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailseverrus23.com (MISP Attribute #18578)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailseverrus23.com (MISP Attribute #18578)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0d88-4041-bb35-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0d88-4041-bb35-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0d88-4041-bb35-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0d88-4041-bb35-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailseverrus23.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5263,14 +5263,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-8ccc-4d1c-96fd-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-8ccc-4d1c-96fd-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: selectedservicemy.com (MISP Attribute #18834)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: selectedservicemy.com (MISP Attribute #18834)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-8ccc-4d1c-96fd-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-8ccc-4d1c-96fd-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-8ccc-4d1c-96fd-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-8ccc-4d1c-96fd-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">selectedservicemy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5284,14 +5284,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-8b1c-4ee5-94be-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-8b1c-4ee5-94be-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: smtpserver389.com (MISP Attribute #18579)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: smtpserver389.com (MISP Attribute #18579)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-8b1c-4ee5-94be-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-8b1c-4ee5-94be-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-8b1c-4ee5-94be-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-8b1c-4ee5-94be-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">smtpserver389.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5305,14 +5305,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-f24c-4033-934a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-f24c-4033-934a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: selectedserviceru.com (MISP Attribute #18835)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: selectedserviceru.com (MISP Attribute #18835)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-f24c-4033-934a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-f24c-4033-934a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-f24c-4033-934a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-f24c-4033-934a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">selectedserviceru.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5326,14 +5326,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-8c14-48ff-aa3c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-8c14-48ff-aa3c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: pageserver77.com (MISP Attribute #18580)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: pageserver77.com (MISP Attribute #18580)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-8c14-48ff-aa3c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-8c14-48ff-aa3c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-8c14-48ff-aa3c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-8c14-48ff-aa3c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">pageserver77.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5347,14 +5347,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1050-4a49-a531-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1050-4a49-a531-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: selectedservicesg.com (MISP Attribute #18836)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: selectedservicesg.com (MISP Attribute #18836)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1050-4a49-a531-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1050-4a49-a531-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1050-4a49-a531-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1050-4a49-a531-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">selectedservicesg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5368,14 +5368,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-5594-49f9-9ea6-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-5594-49f9-9ea6-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: euanticorruption.com (MISP Attribute #18581)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: euanticorruption.com (MISP Attribute #18581)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-5594-49f9-9ea6-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-5594-49f9-9ea6-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-5594-49f9-9ea6-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-5594-49f9-9ea6-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">euanticorruption.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5389,14 +5389,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-dd14-499c-a5c8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-dd14-499c-a5c8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basicmyoffshore.com (MISP Attribute #18837)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basicmyoffshore.com (MISP Attribute #18837)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-dd14-499c-a5c8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-dd14-499c-a5c8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-dd14-499c-a5c8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-dd14-499c-a5c8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basicmyoffshore.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5410,14 +5410,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-4134-4408-bffb-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-4134-4408-bffb-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ablyazovcog.com (MISP Attribute #18582)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ablyazovcog.com (MISP Attribute #18582)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-4134-4408-bffb-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-4134-4408-bffb-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-4134-4408-bffb-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-4134-4408-bffb-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ablyazovcog.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5431,14 +5431,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-a7e4-469f-a011-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-a7e4-469f-a011-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basicruoffshore.com (MISP Attribute #18838)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basicruoffshore.com (MISP Attribute #18838)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-a7e4-469f-a011-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-a7e4-469f-a011-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-a7e4-469f-a011-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-a7e4-469f-a011-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basicruoffshore.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5452,14 +5452,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-ed04-4563-b839-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-ed04-4563-b839-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ablyazovcriminalgang.com (MISP Attribute #18583)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ablyazovcriminalgang.com (MISP Attribute #18583)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-ed04-4563-b839-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-ed04-4563-b839-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-ed04-4563-b839-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-ed04-4563-b839-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ablyazovcriminalgang.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5473,14 +5473,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-fff8-4ae5-946a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-fff8-4ae5-946a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basicsgoffshore.com (MISP Attribute #18839)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basicsgoffshore.com (MISP Attribute #18839)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-fff8-4ae5-946a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-fff8-4ae5-946a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-fff8-4ae5-946a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-fff8-4ae5-946a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basicsgoffshore.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5494,14 +5494,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-81ec-4128-9036-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-81ec-4128-9036-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ablyazovgang.com (MISP Attribute #18584)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ablyazovgang.com (MISP Attribute #18584)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-81ec-4128-9036-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-81ec-4128-9036-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-81ec-4128-9036-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-81ec-4128-9036-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ablyazovgang.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5515,14 +5515,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d554-4f2f-a399-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d554-4f2f-a399-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: onlineloginportal.com (MISP Attribute #18840)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: onlineloginportal.com (MISP Attribute #18840)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d554-4f2f-a399-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d554-4f2f-a399-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d554-4f2f-a399-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d554-4f2f-a399-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">onlineloginportal.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5536,14 +5536,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-b634-4bd2-964f-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-b634-4bd2-964f-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ablyazovcriminals.com (MISP Attribute #18585)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ablyazovcriminals.com (MISP Attribute #18585)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-b634-4bd2-964f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-b634-4bd2-964f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-b634-4bd2-964f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-b634-4bd2-964f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ablyazovcriminals.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5557,14 +5557,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-2e14-46ca-84d1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-2e14-46ca-84d1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: onlineloginportalhk.com (MISP Attribute #18841)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: onlineloginportalhk.com (MISP Attribute #18841)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-2e14-46ca-84d1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-2e14-46ca-84d1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-2e14-46ca-84d1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-2e14-46ca-84d1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">onlineloginportalhk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5578,14 +5578,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-969c-4f41-9b29-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-969c-4f41-9b29-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ablyazovcrimestory.com (MISP Attribute #18586)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ablyazovcrimestory.com (MISP Attribute #18586)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-969c-4f41-9b29-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-969c-4f41-9b29-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-969c-4f41-9b29-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-969c-4f41-9b29-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ablyazovcrimestory.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5599,14 +5599,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ab8c-41d3-86e4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ab8c-41d3-86e4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: onlineloginportalmy.com (MISP Attribute #18842)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: onlineloginportalmy.com (MISP Attribute #18842)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ab8c-41d3-86e4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ab8c-41d3-86e4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ab8c-41d3-86e4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ab8c-41d3-86e4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">onlineloginportalmy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5620,14 +5620,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-6360-4a3a-ada0-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-6360-4a3a-ada0-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ablyazovmafia.com (MISP Attribute #18587)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ablyazovmafia.com (MISP Attribute #18587)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-6360-4a3a-ada0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-6360-4a3a-ada0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-6360-4a3a-ada0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-6360-4a3a-ada0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ablyazovmafia.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5641,14 +5641,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-25e4-459a-9744-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-25e4-459a-9744-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: onlineloginportalsg.com (MISP Attribute #18843)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: onlineloginportalsg.com (MISP Attribute #18843)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-25e4-459a-9744-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-25e4-459a-9744-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-25e4-459a-9744-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-25e4-459a-9744-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">onlineloginportalsg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5662,14 +5662,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-fb04-40f9-aeff-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-fb04-40f9-aeff-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ablyazovcrimesyndicate.com (MISP Attribute #18588)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ablyazovcrimesyndicate.com (MISP Attribute #18588)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-fb04-40f9-aeff-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-fb04-40f9-aeff-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-fb04-40f9-aeff-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-fb04-40f9-aeff-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ablyazovcrimesyndicate.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5683,14 +5683,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5af4-43e2-afa4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5af4-43e2-afa4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: personaldoaminru.com (MISP Attribute #18844)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: personaldoaminru.com (MISP Attribute #18844)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5af4-43e2-afa4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5af4-43e2-afa4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5af4-43e2-afa4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5af4-43e2-afa4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">personaldoaminru.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5704,14 +5704,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-930c-472e-a915-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-930c-472e-a915-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ablyazovorganisedcrime.com (MISP Attribute #18589)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ablyazovorganisedcrime.com (MISP Attribute #18589)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-930c-472e-a915-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-930c-472e-a915-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-930c-472e-a915-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-930c-472e-a915-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ablyazovorganisedcrime.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5725,14 +5725,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-bfac-49c8-9853-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-bfac-49c8-9853-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: personaldoaminsg.com (MISP Attribute #18845)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: personaldoaminsg.com (MISP Attribute #18845)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-bfac-49c8-9853-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-bfac-49c8-9853-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-bfac-49c8-9853-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-bfac-49c8-9853-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">personaldoaminsg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5746,14 +5746,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-c7dc-42df-859a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-c7dc-42df-859a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linkshrtnr22.com (MISP Attribute #18590)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linkshrtnr22.com (MISP Attribute #18590)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-c7dc-42df-859a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-c7dc-42df-859a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-c7dc-42df-859a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-c7dc-42df-859a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linkshrtnr22.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5767,14 +5767,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-49a4-4739-aceb-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-49a4-4739-aceb-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainexpertswebuk.com (MISP Attribute #18846)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainexpertswebuk.com (MISP Attribute #18846)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-49a4-4739-aceb-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-49a4-4739-aceb-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-49a4-4739-aceb-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-49a4-4739-aceb-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainexpertswebuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5788,14 +5788,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-1394-4cd7-b32d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-1394-4cd7-b32d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ablyazovangels.com (MISP Attribute #18591)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ablyazovangels.com (MISP Attribute #18591)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-1394-4cd7-b32d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-1394-4cd7-b32d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-1394-4cd7-b32d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-1394-4cd7-b32d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ablyazovangels.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5809,14 +5809,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7680-4679-b122-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7680-4679-b122-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serviceasneed.com (MISP Attribute #18847)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serviceasneed.com (MISP Attribute #18847)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7680-4679-b122-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7680-4679-b122-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7680-4679-b122-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7680-4679-b122-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serviceasneed.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5830,14 +5830,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-e8f0-4210-a5a8-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-e8f0-4210-a5a8-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: sapserver39j.com (MISP Attribute #18592)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: sapserver39j.com (MISP Attribute #18592)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-e8f0-4210-a5a8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-e8f0-4210-a5a8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-e8f0-4210-a5a8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-e8f0-4210-a5a8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">sapserver39j.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5851,14 +5851,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-92f4-4263-aba5-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-92f4-4263-aba5-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webdomainexperts.com (MISP Attribute #18848)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webdomainexperts.com (MISP Attribute #18848)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-92f4-4263-aba5-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-92f4-4263-aba5-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-92f4-4263-aba5-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-92f4-4263-aba5-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webdomainexperts.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5872,14 +5872,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-e538-4957-a77a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-e538-4957-a77a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: pageserver299.com (MISP Attribute #18593)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: pageserver299.com (MISP Attribute #18593)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-e538-4957-a77a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-e538-4957-a77a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-e538-4957-a77a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-e538-4957-a77a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">pageserver299.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5893,14 +5893,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-9d70-42e3-99df-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-9d70-42e3-99df-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: buzzoffbul.com (MISP Attribute #18849)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: buzzoffbul.com (MISP Attribute #18849)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-9d70-42e3-99df-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-9d70-42e3-99df-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-9d70-42e3-99df-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-9d70-42e3-99df-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">buzzoffbul.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5914,14 +5914,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-624c-4728-b4e2-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-624c-4728-b4e2-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shadymario.com (MISP Attribute #18594)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shadymario.com (MISP Attribute #18594)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-624c-4728-b4e2-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-624c-4728-b4e2-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-624c-4728-b4e2-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-624c-4728-b4e2-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shadymario.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5935,14 +5935,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7e20-49ed-aa14-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7e20-49ed-aa14-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: buzzoffhk.com (MISP Attribute #18850)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: buzzoffhk.com (MISP Attribute #18850)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7e20-49ed-aa14-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7e20-49ed-aa14-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7e20-49ed-aa14-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7e20-49ed-aa14-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">buzzoffhk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5956,14 +5956,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-fdd8-48f5-aede-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-fdd8-48f5-aede-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailserver399.com (MISP Attribute #18595)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailserver399.com (MISP Attribute #18595)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-fdd8-48f5-aede-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-fdd8-48f5-aede-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-fdd8-48f5-aede-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-fdd8-48f5-aede-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailserver399.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5977,14 +5977,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4868-4ba6-9d46-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4868-4ba6-9d46-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: buzzoffmy.com (MISP Attribute #18851)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: buzzoffmy.com (MISP Attribute #18851)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4868-4ba6-9d46-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4868-4ba6-9d46-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4868-4ba6-9d46-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4868-4ba6-9d46-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">buzzoffmy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -5998,14 +5998,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-4a18-483e-889b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-4a18-483e-889b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: newserver39.com (MISP Attribute #18596)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: newserver39.com (MISP Attribute #18596)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-4a18-483e-889b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-4a18-483e-889b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-4a18-483e-889b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-4a18-483e-889b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">newserver39.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6019,14 +6019,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3340-45f1-915d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3340-45f1-915d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: buzzoffru.com (MISP Attribute #18852)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: buzzoffru.com (MISP Attribute #18852)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3340-45f1-915d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3340-45f1-915d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3340-45f1-915d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3340-45f1-915d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">buzzoffru.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6040,14 +6040,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-63d0-44ec-8fa7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-63d0-44ec-8fa7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: maildeliveryagent.com (MISP Attribute #18597)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: maildeliveryagent.com (MISP Attribute #18597)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-63d0-44ec-8fa7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-63d0-44ec-8fa7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-63d0-44ec-8fa7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-63d0-44ec-8fa7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">maildeliveryagent.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6061,14 +6061,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-34c0-47a6-9887-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-34c0-47a6-9887-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: buzzoffsg.com (MISP Attribute #18853)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: buzzoffsg.com (MISP Attribute #18853)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-34c0-47a6-9887-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-34c0-47a6-9887-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-34c0-47a6-9887-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-34c0-47a6-9887-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">buzzoffsg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6082,14 +6082,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-9798-4cb1-ade2-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-9798-4cb1-ade2-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hbh-europe-ripoff-report.com (MISP Attribute #18598)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hbh-europe-ripoff-report.com (MISP Attribute #18598)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-9798-4cb1-ade2-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-9798-4cb1-ade2-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-9798-4cb1-ade2-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-9798-4cb1-ade2-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hbh-europe-ripoff-report.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6103,14 +6103,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5454-4b4d-aa33-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5454-4b4d-aa33-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostbasichk.com (MISP Attribute #18854)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostbasichk.com (MISP Attribute #18854)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5454-4b4d-aa33-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5454-4b4d-aa33-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5454-4b4d-aa33-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5454-4b4d-aa33-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostbasichk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6124,14 +6124,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-8fb8-4691-9e50-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-8fb8-4691-9e50-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shortformurl.com (MISP Attribute #18599)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shortformurl.com (MISP Attribute #18599)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-8fb8-4691-9e50-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-8fb8-4691-9e50-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-8fb8-4691-9e50-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-8fb8-4691-9e50-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shortformurl.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6145,14 +6145,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3fd0-4d16-94f7-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3fd0-4d16-94f7-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostbasicholl.com (MISP Attribute #18855)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostbasicholl.com (MISP Attribute #18855)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3fd0-4d16-94f7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3fd0-4d16-94f7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3fd0-4d16-94f7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3fd0-4d16-94f7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostbasicholl.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6166,14 +6166,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-b100-401e-bc99-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-b100-401e-bc99-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shortformurl.xyz (MISP Attribute #18600)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shortformurl.xyz (MISP Attribute #18600)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-b100-401e-bc99-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-b100-401e-bc99-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-b100-401e-bc99-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-b100-401e-bc99-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shortformurl.xyz</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6187,14 +6187,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-aeb0-4b09-9650-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-aeb0-4b09-9650-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostbasicmy.com (MISP Attribute #18856)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostbasicmy.com (MISP Attribute #18856)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-aeb0-4b09-9650-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-aeb0-4b09-9650-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-aeb0-4b09-9650-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-aeb0-4b09-9650-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostbasicmy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6208,14 +6208,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-a4f8-4564-83d2-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-a4f8-4564-83d2-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webredirect39.com (MISP Attribute #18601)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webredirect39.com (MISP Attribute #18601)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-a4f8-4564-83d2-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-a4f8-4564-83d2-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-a4f8-4564-83d2-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-a4f8-4564-83d2-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webredirect39.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6229,14 +6229,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-2a10-40d2-ad2d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-2a10-40d2-ad2d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostbasicru.com (MISP Attribute #18857)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostbasicru.com (MISP Attribute #18857)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-2a10-40d2-ad2d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-2a10-40d2-ad2d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-2a10-40d2-ad2d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-2a10-40d2-ad2d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostbasicru.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6250,14 +6250,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-ba64-44ff-aa99-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-ba64-44ff-aa99-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: logserver39.com (MISP Attribute #18602)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: logserver39.com (MISP Attribute #18602)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-ba64-44ff-aa99-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-ba64-44ff-aa99-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-ba64-44ff-aa99-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-ba64-44ff-aa99-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">logserver39.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6271,14 +6271,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-0394-493e-92cc-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-0394-493e-92cc-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostbasicsg.com (MISP Attribute #18858)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostbasicsg.com (MISP Attribute #18858)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-0394-493e-92cc-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-0394-493e-92cc-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-0394-493e-92cc-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-0394-493e-92cc-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostbasicsg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6292,14 +6292,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-1770-4e23-b405-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-1770-4e23-b405-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webmasterserver39.com (MISP Attribute #18603)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webmasterserver39.com (MISP Attribute #18603)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-1770-4e23-b405-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-1770-4e23-b405-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-1770-4e23-b405-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-1770-4e23-b405-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webmasterserver39.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6313,14 +6313,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-076c-40b4-acd9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-076c-40b4-acd9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: demoprojectsuk.com (MISP Attribute #18859)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: demoprojectsuk.com (MISP Attribute #18859)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-076c-40b4-acd9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-076c-40b4-acd9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-076c-40b4-acd9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-076c-40b4-acd9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">demoprojectsuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6334,14 +6334,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-124c-417d-a74e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-124c-417d-a74e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webnetonlineservice.com (MISP Attribute #18604)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webnetonlineservice.com (MISP Attribute #18604)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-124c-417d-a74e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-124c-417d-a74e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-124c-417d-a74e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-124c-417d-a74e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webnetonlineservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6355,14 +6355,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-0180-4724-9fc2-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-0180-4724-9fc2-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shortnerserviceonline.com (MISP Attribute #18860)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shortnerserviceonline.com (MISP Attribute #18860)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-0180-4724-9fc2-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-0180-4724-9fc2-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-0180-4724-9fc2-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-0180-4724-9fc2-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shortnerserviceonline.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6376,14 +6376,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-155c-49d2-b611-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-155c-49d2-b611-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: redirectonline.xyz (MISP Attribute #18605)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: redirectonline.xyz (MISP Attribute #18605)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-155c-49d2-b611-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-155c-49d2-b611-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-155c-49d2-b611-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-155c-49d2-b611-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">redirectonline.xyz</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6397,14 +6397,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ae7c-4519-9607-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ae7c-4519-9607-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hklinbas.com (MISP Attribute #18861)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hklinbas.com (MISP Attribute #18861)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ae7c-4519-9607-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ae7c-4519-9607-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ae7c-4519-9607-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ae7c-4519-9607-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hklinbas.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6418,14 +6418,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-c3e8-4f50-863c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-c3e8-4f50-863c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: homeserver87.com (MISP Attribute #18606)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: homeserver87.com (MISP Attribute #18606)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-c3e8-4f50-863c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-c3e8-4f50-863c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-c3e8-4f50-863c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-c3e8-4f50-863c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">homeserver87.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6439,14 +6439,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4aac-4dc1-874c-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4aac-4dc1-874c-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: luxlinbas.com (MISP Attribute #18862)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: luxlinbas.com (MISP Attribute #18862)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4aac-4dc1-874c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4aac-4dc1-874c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4aac-4dc1-874c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4aac-4dc1-874c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">luxlinbas.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6460,14 +6460,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-2198-4e07-b618-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-2198-4e07-b618-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: netcomserviceonline.com (MISP Attribute #18607)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: netcomserviceonline.com (MISP Attribute #18607)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-2198-4e07-b618-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-2198-4e07-b618-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-2198-4e07-b618-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-2198-4e07-b618-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">netcomserviceonline.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6481,14 +6481,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1518-4800-9a25-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1518-4800-9a25-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mylinbas.com (MISP Attribute #18863)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mylinbas.com (MISP Attribute #18863)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1518-4800-9a25-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1518-4800-9a25-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1518-4800-9a25-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1518-4800-9a25-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mylinbas.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6502,14 +6502,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-525c-4396-ba4d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-525c-4396-ba4d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: servermappingserviceonline.com (MISP Attribute #18608)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: servermappingserviceonline.com (MISP Attribute #18608)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-525c-4396-ba4d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-525c-4396-ba4d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-525c-4396-ba4d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-525c-4396-ba4d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">servermappingserviceonline.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6523,14 +6523,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4578-4f21-b8e0-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4578-4f21-b8e0-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ruslinbas.com (MISP Attribute #18864)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ruslinbas.com (MISP Attribute #18864)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4578-4f21-b8e0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4578-4f21-b8e0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4578-4f21-b8e0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4578-4f21-b8e0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ruslinbas.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6544,14 +6544,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-9900-4bde-bd24-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-9900-4bde-bd24-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: onlinenetworkinghelp.com (MISP Attribute #18609)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: onlinenetworkinghelp.com (MISP Attribute #18609)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-9900-4bde-bd24-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-9900-4bde-bd24-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-9900-4bde-bd24-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-9900-4bde-bd24-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">onlinenetworkinghelp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6565,14 +6565,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-90cc-4198-b987-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-90cc-4198-b987-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: sglinbas.com (MISP Attribute #18865)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: sglinbas.com (MISP Attribute #18865)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-90cc-4198-b987-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-90cc-4198-b987-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-90cc-4198-b987-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-90cc-4198-b987-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">sglinbas.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6586,14 +6586,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-b18c-4072-87f0-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-b18c-4072-87f0-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: loginauths-service.com (MISP Attribute #18610)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: loginauths-service.com (MISP Attribute #18610)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-b18c-4072-87f0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-b18c-4072-87f0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-b18c-4072-87f0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-b18c-4072-87f0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">loginauths-service.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6607,14 +6607,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5ebc-4cef-b91d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5ebc-4cef-b91d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverfortechies.com (MISP Attribute #18866)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverfortechies.com (MISP Attribute #18866)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5ebc-4cef-b91d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5ebc-4cef-b91d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5ebc-4cef-b91d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5ebc-4cef-b91d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverfortechies.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6628,14 +6628,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-7680-41d3-bc19-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-7680-41d3-bc19-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: softnetworksolutions.com (MISP Attribute #18611)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: softnetworksolutions.com (MISP Attribute #18611)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-7680-41d3-bc19-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-7680-41d3-bc19-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-7680-41d3-bc19-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-7680-41d3-bc19-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">softnetworksolutions.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6649,14 +6649,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-748c-44c9-aef9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-748c-44c9-aef9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basicservicehk.com (MISP Attribute #18867)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basicservicehk.com (MISP Attribute #18867)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-748c-44c9-aef9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-748c-44c9-aef9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-748c-44c9-aef9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-748c-44c9-aef9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basicservicehk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6670,14 +6670,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-c1d4-4fb9-9ac9-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-c1d4-4fb9-9ac9-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ultronnetworksolution.com (MISP Attribute #18612)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ultronnetworksolution.com (MISP Attribute #18612)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-c1d4-4fb9-9ac9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-c1d4-4fb9-9ac9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-c1d4-4fb9-9ac9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-c1d4-4fb9-9ac9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ultronnetworksolution.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6691,14 +6691,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-82f0-4cf1-aa52-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-82f0-4cf1-aa52-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basicservicelux.com (MISP Attribute #18868)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basicservicelux.com (MISP Attribute #18868)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-82f0-4cf1-aa52-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-82f0-4cf1-aa52-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-82f0-4cf1-aa52-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-82f0-4cf1-aa52-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basicservicelux.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6712,14 +6712,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-b778-4722-af3a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-b778-4722-af3a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: softredirect.info (MISP Attribute #18613)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: softredirect.info (MISP Attribute #18613)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-b778-4722-af3a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-b778-4722-af3a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-b778-4722-af3a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-b778-4722-af3a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">softredirect.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6733,14 +6733,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-61ac-49a6-8ce9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-61ac-49a6-8ce9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basicservicemy.com (MISP Attribute #18869)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basicservicemy.com (MISP Attribute #18869)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-61ac-49a6-8ce9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-61ac-49a6-8ce9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-61ac-49a6-8ce9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-61ac-49a6-8ce9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basicservicemy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6754,14 +6754,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-28b0-4f26-b8ed-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-28b0-4f26-b8ed-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: extranetserviceonline.com (MISP Attribute #18614)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: extranetserviceonline.com (MISP Attribute #18614)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-28b0-4f26-b8ed-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-28b0-4f26-b8ed-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-28b0-4f26-b8ed-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-28b0-4f26-b8ed-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">extranetserviceonline.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6775,14 +6775,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-87e4-4558-a61a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-87e4-4558-a61a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basicservicerus.com (MISP Attribute #18870)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basicservicerus.com (MISP Attribute #18870)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-87e4-4558-a61a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-87e4-4558-a61a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-87e4-4558-a61a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-87e4-4558-a61a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basicservicerus.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6796,14 +6796,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-1eb8-428d-b36b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-1eb8-428d-b36b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: short-ner.com (MISP Attribute #18615)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: short-ner.com (MISP Attribute #18615)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-1eb8-428d-b36b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-1eb8-428d-b36b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-1eb8-428d-b36b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-1eb8-428d-b36b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">short-ner.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6817,14 +6817,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ffc0-44b9-8d8e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ffc0-44b9-8d8e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: basicservicesg.com (MISP Attribute #18871)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: basicservicesg.com (MISP Attribute #18871)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ffc0-44b9-8d8e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ffc0-44b9-8d8e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ffc0-44b9-8d8e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ffc0-44b9-8d8e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">basicservicesg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6838,14 +6838,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-2038-46e4-9331-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-2038-46e4-9331-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserveruk.com (MISP Attribute #18616)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserveruk.com (MISP Attribute #18616)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-2038-46e4-9331-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-2038-46e4-9331-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-2038-46e4-9331-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-2038-46e4-9331-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserveruk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6859,14 +6859,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-cf40-41d9-90fb-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-cf40-41d9-90fb-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverforhelphk.com (MISP Attribute #18872)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverforhelphk.com (MISP Attribute #18872)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-cf40-41d9-90fb-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-cf40-41d9-90fb-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-cf40-41d9-90fb-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-cf40-41d9-90fb-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverforhelphk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6880,14 +6880,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-e8f0-402b-8d49-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-e8f0-402b-8d49-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mywebredirect.info (MISP Attribute #18617)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mywebredirect.info (MISP Attribute #18617)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-e8f0-402b-8d49-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-e8f0-402b-8d49-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-e8f0-402b-8d49-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-e8f0-402b-8d49-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mywebredirect.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6901,14 +6901,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-85c0-4aa0-9d28-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-85c0-4aa0-9d28-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverforhelpru.com (MISP Attribute #18873)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverforhelpru.com (MISP Attribute #18873)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-85c0-4aa0-9d28-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-85c0-4aa0-9d28-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-85c0-4aa0-9d28-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-85c0-4aa0-9d28-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverforhelpru.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6922,14 +6922,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0118-48e1-8d89-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0118-48e1-8d89-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: srtnr.co (MISP Attribute #18618)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: srtnr.co (MISP Attribute #18618)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0118-48e1-8d89-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0118-48e1-8d89-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0118-48e1-8d89-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0118-48e1-8d89-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">srtnr.co</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6943,14 +6943,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-f8ac-4b06-b3e2-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-f8ac-4b06-b3e2-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverforhelpsg.com (MISP Attribute #18874)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverforhelpsg.com (MISP Attribute #18874)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-f8ac-4b06-b3e2-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-f8ac-4b06-b3e2-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-f8ac-4b06-b3e2-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-f8ac-4b06-b3e2-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverforhelpsg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6964,14 +6964,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-74cc-423f-a7af-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-74cc-423f-a7af-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: cyberanalyticals.com (MISP Attribute #18619)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: cyberanalyticals.com (MISP Attribute #18619)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-74cc-423f-a7af-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-74cc-423f-a7af-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-74cc-423f-a7af-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-74cc-423f-a7af-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">cyberanalyticals.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -6985,14 +6985,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-af2c-4075-b385-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-af2c-4075-b385-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainforhostuk.com (MISP Attribute #18875)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainforhostuk.com (MISP Attribute #18875)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-af2c-4075-b385-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-af2c-4075-b385-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-af2c-4075-b385-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-af2c-4075-b385-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainforhostuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7006,14 +7006,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-c230-41f6-9a49-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-c230-41f6-9a49-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mail-logger.com (MISP Attribute #18620)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mail-logger.com (MISP Attribute #18620)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-c230-41f6-9a49-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-c230-41f6-9a49-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-c230-41f6-9a49-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-c230-41f6-9a49-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mail-logger.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7027,14 +7027,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-6098-4415-bf1e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-6098-4415-bf1e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: transferdomainhk.com (MISP Attribute #18876)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: transferdomainhk.com (MISP Attribute #18876)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-6098-4415-bf1e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-6098-4415-bf1e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-6098-4415-bf1e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-6098-4415-bf1e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">transferdomainhk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7048,14 +7048,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-dabc-4879-9bd0-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-dabc-4879-9bd0-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailer-domain.com (MISP Attribute #18621)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailer-domain.com (MISP Attribute #18621)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-dabc-4879-9bd0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-dabc-4879-9bd0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-dabc-4879-9bd0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-dabc-4879-9bd0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailer-domain.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7069,14 +7069,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7154-4e65-8649-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7154-4e65-8649-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: transferdomainlu.com (MISP Attribute #18877)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: transferdomainlu.com (MISP Attribute #18877)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7154-4e65-8649-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7154-4e65-8649-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7154-4e65-8649-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7154-4e65-8649-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">transferdomainlu.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7090,14 +7090,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-4744-4707-8722-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-4744-4707-8722-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: servermailing34.com (MISP Attribute #18622)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: servermailing34.com (MISP Attribute #18622)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-4744-4707-8722-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-4744-4707-8722-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-4744-4707-8722-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-4744-4707-8722-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">servermailing34.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7111,14 +7111,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-fc78-4632-bc67-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-fc78-4632-bc67-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: transferdomainmy.com (MISP Attribute #18878)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: transferdomainmy.com (MISP Attribute #18878)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-fc78-4632-bc67-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-fc78-4632-bc67-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-fc78-4632-bc67-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-fc78-4632-bc67-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">transferdomainmy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7132,14 +7132,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-3f64-4f6e-849d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-3f64-4f6e-849d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: nodeserver50.com (MISP Attribute #18623)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: nodeserver50.com (MISP Attribute #18623)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-3f64-4f6e-849d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-3f64-4f6e-849d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-3f64-4f6e-849d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-3f64-4f6e-849d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">nodeserver50.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7153,14 +7153,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-abfc-4f30-a75e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-abfc-4f30-a75e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shoponlinefreesg.com (MISP Attribute #18879)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shoponlinefreesg.com (MISP Attribute #18879)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-abfc-4f30-a75e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-abfc-4f30-a75e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-abfc-4f30-a75e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-abfc-4f30-a75e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shoponlinefreesg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7174,14 +7174,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-f87c-402a-9b1a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-f87c-402a-9b1a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: rackserver39.com (MISP Attribute #18624)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: rackserver39.com (MISP Attribute #18624)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-f87c-402a-9b1a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-f87c-402a-9b1a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-f87c-402a-9b1a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-f87c-402a-9b1a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">rackserver39.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7195,14 +7195,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-56c4-4a2a-8774-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-56c4-4a2a-8774-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shoponlinefreeuk.com (MISP Attribute #18880)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shoponlinefreeuk.com (MISP Attribute #18880)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-56c4-4a2a-8774-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-56c4-4a2a-8774-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-56c4-4a2a-8774-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-56c4-4a2a-8774-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shoponlinefreeuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7216,14 +7216,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-6b68-4e98-ac7d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-6b68-4e98-ac7d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailerdomain56.com (MISP Attribute #18625)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailerdomain56.com (MISP Attribute #18625)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-6b68-4e98-ac7d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-6b68-4e98-ac7d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-6b68-4e98-ac7d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-6b68-4e98-ac7d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailerdomain56.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7237,14 +7237,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5cf4-43bc-9d02-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5cf4-43bc-9d02-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shrinkandshareurl.com (MISP Attribute #18881)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shrinkandshareurl.com (MISP Attribute #18881)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5cf4-43bc-9d02-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5cf4-43bc-9d02-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5cf4-43bc-9d02-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5cf4-43bc-9d02-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shrinkandshareurl.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7258,14 +7258,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-c258-4537-9381-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-c258-4537-9381-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: loginserviceunified.com (MISP Attribute #18626)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: loginserviceunified.com (MISP Attribute #18626)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-c258-4537-9381-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-c258-4537-9381-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-c258-4537-9381-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-c258-4537-9381-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">loginserviceunified.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7279,14 +7279,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4c7c-4ff7-84df-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4c7c-4ff7-84df-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: strngbltru.com (MISP Attribute #18882)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: strngbltru.com (MISP Attribute #18882)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4c7c-4ff7-84df-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4c7c-4ff7-84df-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4c7c-4ff7-84df-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4c7c-4ff7-84df-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">strngbltru.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7300,14 +7300,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-1f64-4635-a8e9-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-1f64-4635-a8e9-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: comservicelogin.com (MISP Attribute #18627)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: comservicelogin.com (MISP Attribute #18627)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-1f64-4635-a8e9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-1f64-4635-a8e9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-1f64-4635-a8e9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-1f64-4635-a8e9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">comservicelogin.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7321,14 +7321,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-863c-4ea3-bc83-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-863c-4ea3-bc83-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: optionalblogginges.com (MISP Attribute #18883)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: optionalblogginges.com (MISP Attribute #18883)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-863c-4ea3-bc83-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-863c-4ea3-bc83-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-863c-4ea3-bc83-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-863c-4ea3-bc83-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">optionalblogginges.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7342,14 +7342,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-ec28-413e-ac2c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-ec28-413e-ac2c-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 4mblk.com (MISP Attribute #18628)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 4mblk.com (MISP Attribute #18628)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-ec28-413e-ac2c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-ec28-413e-ac2c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-ec28-413e-ac2c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-ec28-413e-ac2c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">4mblk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7363,14 +7363,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-dc1c-4a27-9d22-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-dc1c-4a27-9d22-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: optionalbloggingeu.com (MISP Attribute #18884)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: optionalbloggingeu.com (MISP Attribute #18884)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-dc1c-4a27-9d22-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-dc1c-4a27-9d22-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-dc1c-4a27-9d22-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-dc1c-4a27-9d22-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">optionalbloggingeu.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7384,14 +7384,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0644-4281-87ba-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0644-4281-87ba-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: corn-en-us.com (MISP Attribute #18629)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: corn-en-us.com (MISP Attribute #18629)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0644-4281-87ba-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0644-4281-87ba-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0644-4281-87ba-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0644-4281-87ba-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">corn-en-us.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7405,14 +7405,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5f4c-49d8-b403-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5f4c-49d8-b403-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: optionalblogginguk.com (MISP Attribute #18885)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: optionalblogginguk.com (MISP Attribute #18885)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5f4c-49d8-b403-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5f4c-49d8-b403-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5f4c-49d8-b403-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5f4c-49d8-b403-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">optionalblogginguk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7426,14 +7426,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-5f68-40d7-83ee-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-5f68-40d7-83ee-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: corn-en-gb.com (MISP Attribute #18630)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: corn-en-gb.com (MISP Attribute #18630)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-5f68-40d7-83ee-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-5f68-40d7-83ee-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-5f68-40d7-83ee-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-5f68-40d7-83ee-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">corn-en-gb.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7447,14 +7447,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-40c4-4a93-96e4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-40c4-4a93-96e4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shrinkthisurl.com (MISP Attribute #18886)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shrinkthisurl.com (MISP Attribute #18886)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-40c4-4a93-96e4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-40c4-4a93-96e4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-40c4-4a93-96e4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-40c4-4a93-96e4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shrinkthisurl.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7468,14 +7468,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-1fac-46a2-9be7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-1fac-46a2-9be7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: corn-lang-eng.com (MISP Attribute #18631)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: corn-lang-eng.com (MISP Attribute #18631)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-1fac-46a2-9be7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-1fac-46a2-9be7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-1fac-46a2-9be7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-1fac-46a2-9be7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">corn-lang-eng.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7489,14 +7489,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4690-4211-b94f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4690-4211-b94f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: updatenameserver45.com (MISP Attribute #18887)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: updatenameserver45.com (MISP Attribute #18887)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4690-4211-b94f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4690-4211-b94f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4690-4211-b94f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4690-4211-b94f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">updatenameserver45.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7510,14 +7510,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0ac4-408b-b5e4-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0ac4-408b-b5e4-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: corn-loginservicesverified.com (MISP Attribute #18632)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: corn-loginservicesverified.com (MISP Attribute #18632)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0ac4-408b-b5e4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0ac4-408b-b5e4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0ac4-408b-b5e4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0ac4-408b-b5e4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">corn-loginservicesverified.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7531,14 +7531,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-b444-4749-83d7-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-b444-4749-83d7-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: rulinuxbasic.com (MISP Attribute #18888)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: rulinuxbasic.com (MISP Attribute #18888)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-b444-4749-83d7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-b444-4749-83d7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-b444-4749-83d7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-b444-4749-83d7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">rulinuxbasic.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7552,14 +7552,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-563c-4c15-ba60-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-563c-4c15-ba60-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: corn-msrvrgr.com (MISP Attribute #18633)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: corn-msrvrgr.com (MISP Attribute #18633)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-563c-4c15-ba60-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-563c-4c15-ba60-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-563c-4c15-ba60-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-563c-4c15-ba60-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">corn-msrvrgr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7573,14 +7573,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-8810-46a1-b086-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-8810-46a1-b086-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: russialinuxbasic.com (MISP Attribute #18889)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: russialinuxbasic.com (MISP Attribute #18889)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-8810-46a1-b086-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-8810-46a1-b086-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-8810-46a1-b086-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-8810-46a1-b086-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">russialinuxbasic.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7594,14 +7594,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-4eb0-4f7b-acd7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-4eb0-4f7b-acd7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: corn-servicelogin.com (MISP Attribute #18634)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: corn-servicelogin.com (MISP Attribute #18634)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-4eb0-4f7b-acd7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-4eb0-4f7b-acd7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-4eb0-4f7b-acd7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-4eb0-4f7b-acd7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">corn-servicelogin.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7615,14 +7615,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5fa0-4bc1-82c4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5fa0-4bc1-82c4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainsforfreehosting.com (MISP Attribute #18890)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainsforfreehosting.com (MISP Attribute #18890)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5fa0-4bc1-82c4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5fa0-4bc1-82c4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5fa0-4bc1-82c4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5fa0-4bc1-82c4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainsforfreehosting.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7636,14 +7636,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-8ed4-4367-9b88-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-8ed4-4367-9b88-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: corn-ukr.com (MISP Attribute #18635)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: corn-ukr.com (MISP Attribute #18635)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-8ed4-4367-9b88-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-8ed4-4367-9b88-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-8ed4-4367-9b88-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-8ed4-4367-9b88-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">corn-ukr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7657,14 +7657,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3794-4593-8994-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3794-4593-8994-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainsforsupport.com (MISP Attribute #18891)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainsforsupport.com (MISP Attribute #18891)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3794-4593-8994-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3794-4593-8994-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3794-4593-8994-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3794-4593-8994-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainsforsupport.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7678,14 +7678,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-8ec4-4b0a-9792-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-8ec4-4b0a-9792-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: corn-fr-fr.com (MISP Attribute #18636)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: corn-fr-fr.com (MISP Attribute #18636)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-8ec4-4b0a-9792-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-8ec4-4b0a-9792-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-8ec4-4b0a-9792-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-8ec4-4b0a-9792-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">corn-fr-fr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7699,14 +7699,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ddec-496d-90fa-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ddec-496d-90fa-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainsfortechhelp.com (MISP Attribute #18892)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainsfortechhelp.com (MISP Attribute #18892)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ddec-496d-90fa-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ddec-496d-90fa-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ddec-496d-90fa-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ddec-496d-90fa-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainsfortechhelp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7720,14 +7720,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0e30-4512-be41-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0e30-4512-be41-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserver89.org (MISP Attribute #18637)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserver89.org (MISP Attribute #18637)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0e30-4512-be41-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0e30-4512-be41-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0e30-4512-be41-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0e30-4512-be41-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserver89.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7741,14 +7741,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-e2cc-4736-9799-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-e2cc-4736-9799-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linuxbasichk.com (MISP Attribute #18893)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linuxbasichk.com (MISP Attribute #18893)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-e2cc-4736-9799-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-e2cc-4736-9799-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-e2cc-4736-9799-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-e2cc-4736-9799-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linuxbasichk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7762,14 +7762,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-b704-4f9a-bac6-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-b704-4f9a-bac6-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserver89.net (MISP Attribute #18638)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserver89.net (MISP Attribute #18638)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-b704-4f9a-bac6-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-b704-4f9a-bac6-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-b704-4f9a-bac6-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-b704-4f9a-bac6-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserver89.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7783,14 +7783,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d5b4-4852-907d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d5b4-4852-907d-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linuxbasichk1.com (MISP Attribute #18894)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linuxbasichk1.com (MISP Attribute #18894)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d5b4-4852-907d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d5b4-4852-907d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d5b4-4852-907d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d5b4-4852-907d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linuxbasichk1.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7804,14 +7804,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-15c4-4f56-9c76-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-15c4-4f56-9c76-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: srtnr.com (MISP Attribute #18639)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: srtnr.com (MISP Attribute #18639)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-15c4-4f56-9c76-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-15c4-4f56-9c76-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-15c4-4f56-9c76-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-15c4-4f56-9c76-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">srtnr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7825,14 +7825,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-e070-47f5-9941-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-e070-47f5-9941-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linuxbasicmy.com (MISP Attribute #18895)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linuxbasicmy.com (MISP Attribute #18895)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-e070-47f5-9941-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-e070-47f5-9941-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-e070-47f5-9941-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-e070-47f5-9941-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linuxbasicmy.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7846,14 +7846,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-40d0-4407-8e21-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-40d0-4407-8e21-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserver89.com (MISP Attribute #18640)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserver89.com (MISP Attribute #18640)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-40d0-4407-8e21-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-40d0-4407-8e21-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-40d0-4407-8e21-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-40d0-4407-8e21-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserver89.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7867,14 +7867,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3690-4c15-99b4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3690-4c15-99b4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linuxbasicru.com (MISP Attribute #18896)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linuxbasicru.com (MISP Attribute #18896)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3690-4c15-99b4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3690-4c15-99b4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3690-4c15-99b4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3690-4c15-99b4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linuxbasicru.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7888,14 +7888,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-50e0-4cc7-8527-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-50e0-4cc7-8527-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserveruk89.org (MISP Attribute #18641)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserveruk89.org (MISP Attribute #18641)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-50e0-4cc7-8527-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-50e0-4cc7-8527-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-50e0-4cc7-8527-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-50e0-4cc7-8527-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserveruk89.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7909,14 +7909,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-fe1c-4b88-a1f1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-fe1c-4b88-a1f1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linuxbasicru1.com (MISP Attribute #18897)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linuxbasicru1.com (MISP Attribute #18897)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-fe1c-4b88-a1f1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-fe1c-4b88-a1f1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-fe1c-4b88-a1f1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-fe1c-4b88-a1f1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linuxbasicru1.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7930,14 +7930,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-d2a4-4362-80d4-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-d2a4-4362-80d4-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserveruk89.net (MISP Attribute #18642)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserveruk89.net (MISP Attribute #18642)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-d2a4-4362-80d4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-d2a4-4362-80d4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-d2a4-4362-80d4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-d2a4-4362-80d4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserveruk89.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7951,14 +7951,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-efd8-4e35-b441-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-efd8-4e35-b441-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linuxbasicsg.com (MISP Attribute #18898)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linuxbasicsg.com (MISP Attribute #18898)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-efd8-4e35-b441-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-efd8-4e35-b441-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-efd8-4e35-b441-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-efd8-4e35-b441-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linuxbasicsg.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7972,14 +7972,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0968-4995-8b4b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0968-4995-8b4b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: 2mblk.com (MISP Attribute #18643)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: 2mblk.com (MISP Attribute #18643)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0968-4995-8b4b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0968-4995-8b4b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0968-4995-8b4b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0968-4995-8b4b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">2mblk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -7993,14 +7993,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-226c-4b68-9093-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-226c-4b68-9093-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linuxbasicsg1.com (MISP Attribute #18899)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linuxbasicsg1.com (MISP Attribute #18899)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-226c-4b68-9093-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-226c-4b68-9093-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-226c-4b68-9093-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-226c-4b68-9093-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linuxbasicsg1.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8014,14 +8014,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-ddd8-474a-bf5e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-ddd8-474a-bf5e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailserveruk89.com (MISP Attribute #18644)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailserveruk89.com (MISP Attribute #18644)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-ddd8-474a-bf5e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-ddd8-474a-bf5e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-ddd8-474a-bf5e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-ddd8-474a-bf5e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailserveruk89.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8035,14 +8035,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ce3c-4b3d-a1cf-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ce3c-4b3d-a1cf-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostingserviceclean.com (MISP Attribute #18900)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostingserviceclean.com (MISP Attribute #18900)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ce3c-4b3d-a1cf-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ce3c-4b3d-a1cf-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ce3c-4b3d-a1cf-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ce3c-4b3d-a1cf-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostingserviceclean.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8056,14 +8056,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-7b58-47aa-9a92-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-7b58-47aa-9a92-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mblk1.com (MISP Attribute #18645)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mblk1.com (MISP Attribute #18645)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-7b58-47aa-9a92-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-7b58-47aa-9a92-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-7b58-47aa-9a92-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-7b58-47aa-9a92-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mblk1.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8077,14 +8077,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d230-4215-839c-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d230-4215-839c-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostingserviceforall.com (MISP Attribute #18901)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostingserviceforall.com (MISP Attribute #18901)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d230-4215-839c-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d230-4215-839c-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d230-4215-839c-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d230-4215-839c-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostingserviceforall.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8098,14 +8098,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-f934-4a99-9c8f-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-f934-4a99-9c8f-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: un-told.net (MISP Attribute #18646)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: un-told.net (MISP Attribute #18646)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-f934-4a99-9c8f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-f934-4a99-9c8f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-f934-4a99-9c8f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-f934-4a99-9c8f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">un-told.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8119,14 +8119,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-bd48-4ac8-8a01-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-bd48-4ac8-8a01-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostingservicesloyal.com (MISP Attribute #18902)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostingservicesloyal.com (MISP Attribute #18902)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-bd48-4ac8-8a01-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-bd48-4ac8-8a01-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-bd48-4ac8-8a01-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-bd48-4ac8-8a01-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostingservicesloyal.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8140,14 +8140,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-d980-4714-a8f9-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-d980-4714-a8f9-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-website33.net (MISP Attribute #18647)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-website33.net (MISP Attribute #18647)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-d980-4714-a8f9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-d980-4714-a8f9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-d980-4714-a8f9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-d980-4714-a8f9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-website33.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8161,14 +8161,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-b0f8-471a-a175-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-b0f8-471a-a175-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostingservicesukit.com (MISP Attribute #18903)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostingservicesukit.com (MISP Attribute #18903)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-b0f8-471a-a175-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-b0f8-471a-a175-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-b0f8-471a-a175-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-b0f8-471a-a175-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostingservicesukit.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8182,14 +8182,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-8e70-479d-9aab-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-8e70-479d-9aab-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-website33.biz (MISP Attribute #18648)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-website33.biz (MISP Attribute #18648)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-8e70-479d-9aab-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-8e70-479d-9aab-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-8e70-479d-9aab-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-8e70-479d-9aab-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-website33.biz</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8203,14 +8203,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-a7c8-492e-b0cc-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-a7c8-492e-b0cc-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: xpertmaildomain.com (MISP Attribute #18904)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: xpertmaildomain.com (MISP Attribute #18904)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-a7c8-492e-b0cc-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-a7c8-492e-b0cc-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-a7c8-492e-b0cc-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-a7c8-492e-b0cc-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">xpertmaildomain.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8224,14 +8224,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-3bf4-44f6-b012-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-3bf4-44f6-b012-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-website33.com (MISP Attribute #18649)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-website33.com (MISP Attribute #18649)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-3bf4-44f6-b012-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-3bf4-44f6-b012-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-3bf4-44f6-b012-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-3bf4-44f6-b012-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-website33.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8245,14 +8245,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3584-4b12-925f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3584-4b12-925f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: standardofficeholland.com (MISP Attribute #18905)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: standardofficeholland.com (MISP Attribute #18905)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3584-4b12-925f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3584-4b12-925f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3584-4b12-925f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3584-4b12-925f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">standardofficeholland.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8266,14 +8266,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-b64c-41fd-8fed-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-b64c-41fd-8fed-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-website33.info (MISP Attribute #18650)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-website33.info (MISP Attribute #18650)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-b64c-41fd-8fed-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-b64c-41fd-8fed-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-b64c-41fd-8fed-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-b64c-41fd-8fed-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-website33.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8287,14 +8287,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-91e4-441f-8e18-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-91e4-441f-8e18-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: standardofficeil.com (MISP Attribute #18906)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: standardofficeil.com (MISP Attribute #18906)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-91e4-441f-8e18-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-91e4-441f-8e18-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-91e4-441f-8e18-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-91e4-441f-8e18-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">standardofficeil.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8308,14 +8308,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-00d8-4bb1-a02e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-00d8-4bb1-a02e-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: com-website33.org (MISP Attribute #18651)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: com-website33.org (MISP Attribute #18651)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-00d8-4bb1-a02e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-00d8-4bb1-a02e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-00d8-4bb1-a02e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-00d8-4bb1-a02e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">com-website33.org</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8329,14 +8329,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-56b4-4798-85da-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-56b4-4798-85da-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: standardofficeuk.com (MISP Attribute #18907)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: standardofficeuk.com (MISP Attribute #18907)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-56b4-4798-85da-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-56b4-4798-85da-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-56b4-4798-85da-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-56b4-4798-85da-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">standardofficeuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8350,14 +8350,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-dae4-45a9-9694-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-dae4-45a9-9694-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: browserextensions.info (MISP Attribute #18652)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: browserextensions.info (MISP Attribute #18652)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-dae4-45a9-9694-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-dae4-45a9-9694-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-dae4-45a9-9694-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-dae4-45a9-9694-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">browserextensions.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8371,14 +8371,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1fd0-4c51-aaa5-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1fd0-4c51-aaa5-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: postserverem.com (MISP Attribute #18908)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: postserverem.com (MISP Attribute #18908)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1fd0-4c51-aaa5-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1fd0-4c51-aaa5-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1fd0-4c51-aaa5-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1fd0-4c51-aaa5-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">postserverem.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8392,14 +8392,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-31a0-49cb-b011-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-31a0-49cb-b011-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: allaboutiot.website (MISP Attribute #18653)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: allaboutiot.website (MISP Attribute #18653)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-31a0-49cb-b011-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-31a0-49cb-b011-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-31a0-49cb-b011-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-31a0-49cb-b011-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">allaboutiot.website</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8413,14 +8413,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-c498-4a47-ac99-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-c498-4a47-ac99-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverformailings.com (MISP Attribute #18909)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverformailings.com (MISP Attribute #18909)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-c498-4a47-ac99-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-c498-4a47-ac99-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-c498-4a47-ac99-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-c498-4a47-ac99-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverformailings.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8434,14 +8434,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-2b90-4d94-aa1a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-2b90-4d94-aa1a-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainserver322.com (MISP Attribute #18654)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainserver322.com (MISP Attribute #18654)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-2b90-4d94-aa1a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-2b90-4d94-aa1a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-2b90-4d94-aa1a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-2b90-4d94-aa1a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainserver322.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8455,14 +8455,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-acf4-4960-87bf-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-acf4-4960-87bf-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverfornetworks.com (MISP Attribute #18910)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverfornetworks.com (MISP Attribute #18910)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-acf4-4960-87bf-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-acf4-4960-87bf-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-acf4-4960-87bf-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-acf4-4960-87bf-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverfornetworks.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8476,14 +8476,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-fb80-49d4-912d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-fb80-49d4-912d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: searchsimple.info (MISP Attribute #18655)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: searchsimple.info (MISP Attribute #18655)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-fb80-49d4-912d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-fb80-49d4-912d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-fb80-49d4-912d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-fb80-49d4-912d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">searchsimple.info</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8497,14 +8497,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-c358-49be-aa68-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-c358-49be-aa68-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverforzapper.com (MISP Attribute #18911)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverforzapper.com (MISP Attribute #18911)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-c358-49be-aa68-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-c358-49be-aa68-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-c358-49be-aa68-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-c358-49be-aa68-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverforzapper.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8518,14 +8518,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-014c-453e-b000-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-014c-453e-b000-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: ecom-servicelogin.com (MISP Attribute #18656)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: ecom-servicelogin.com (MISP Attribute #18656)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-014c-453e-b000-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-014c-453e-b000-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-014c-453e-b000-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-014c-453e-b000-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">ecom-servicelogin.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8539,14 +8539,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d710-4c41-89a9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d710-4c41-89a9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serviceforneworder.com (MISP Attribute #18912)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serviceforneworder.com (MISP Attribute #18912)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d710-4c41-89a9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d710-4c41-89a9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d710-4c41-89a9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d710-4c41-89a9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serviceforneworder.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8560,14 +8560,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-affc-4a69-ba79-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-affc-4a69-ba79-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: searchsimple.net (MISP Attribute #18657)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: searchsimple.net (MISP Attribute #18657)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-affc-4a69-ba79-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-affc-4a69-ba79-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-affc-4a69-ba79-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-affc-4a69-ba79-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">searchsimple.net</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8581,14 +8581,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5cec-4d36-9d48-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5cec-4d36-9d48-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: loginservicehelp.com (MISP Attribute #18913)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: loginservicehelp.com (MISP Attribute #18913)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5cec-4d36-9d48-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5cec-4d36-9d48-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5cec-4d36-9d48-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5cec-4d36-9d48-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">loginservicehelp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8602,14 +8602,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-72fc-4068-b954-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-72fc-4068-b954-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: sapserverhipe.com (MISP Attribute #18658)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: sapserverhipe.com (MISP Attribute #18658)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-72fc-4068-b954-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-72fc-4068-b954-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-72fc-4068-b954-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-72fc-4068-b954-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">sapserverhipe.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8623,14 +8623,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-829c-454d-bd75-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-829c-454d-bd75-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: shortenurlservices.com (MISP Attribute #18914)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: shortenurlservices.com (MISP Attribute #18914)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-829c-454d-bd75-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-829c-454d-bd75-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-829c-454d-bd75-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-829c-454d-bd75-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">shortenurlservices.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8644,14 +8644,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-1bd0-42d0-bdd1-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-1bd0-42d0-bdd1-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserver91.website (MISP Attribute #18659)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserver91.website (MISP Attribute #18659)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-1bd0-42d0-bdd1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-1bd0-42d0-bdd1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-1bd0-42d0-bdd1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-1bd0-42d0-bdd1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserver91.website</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8665,14 +8665,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5f40-4848-a111-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5f40-4848-a111-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostusewithtech.com (MISP Attribute #18915)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostusewithtech.com (MISP Attribute #18915)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5f40-4848-a111-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5f40-4848-a111-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5f40-4848-a111-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5f40-4848-a111-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostusewithtech.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8686,14 +8686,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-e18c-467e-a40b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-e18c-467e-a40b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: phpwebserver34.site (MISP Attribute #18660)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: phpwebserver34.site (MISP Attribute #18660)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-e18c-467e-a40b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-e18c-467e-a40b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-e18c-467e-a40b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-e18c-467e-a40b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">phpwebserver34.site</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8707,14 +8707,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-fdb8-4975-9ea4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-fdb8-4975-9ea4-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linuxhostingplatformuk.com (MISP Attribute #18916)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linuxhostingplatformuk.com (MISP Attribute #18916)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-fdb8-4975-9ea4-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-fdb8-4975-9ea4-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-fdb8-4975-9ea4-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-fdb8-4975-9ea4-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linuxhostingplatformuk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8728,14 +8728,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-1e90-4e26-9a90-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-1e90-4e26-9a90-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: phpwebserver34.tech (MISP Attribute #18661)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: phpwebserver34.tech (MISP Attribute #18661)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-1e90-4e26-9a90-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-1e90-4e26-9a90-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-1e90-4e26-9a90-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-1e90-4e26-9a90-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">phpwebserver34.tech</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8749,14 +8749,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-5cf0-4e14-9200-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-5cf0-4e14-9200-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: youranotherserver.com (MISP Attribute #18917)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: youranotherserver.com (MISP Attribute #18917)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-5cf0-4e14-9200-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-5cf0-4e14-9200-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-5cf0-4e14-9200-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-5cf0-4e14-9200-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">youranotherserver.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8770,14 +8770,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-7cc8-4a6d-ac95-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-7cc8-4a6d-ac95-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: phpwebserver34.xyz (MISP Attribute #18662)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: phpwebserver34.xyz (MISP Attribute #18662)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-7cc8-4a6d-ac95-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-7cc8-4a6d-ac95-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-7cc8-4a6d-ac95-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-7cc8-4a6d-ac95-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">phpwebserver34.xyz</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8791,14 +8791,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-b544-44bd-a17a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-b544-44bd-a17a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverforhiretech.com (MISP Attribute #18918)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverforhiretech.com (MISP Attribute #18918)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-b544-44bd-a17a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-b544-44bd-a17a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-b544-44bd-a17a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-b544-44bd-a17a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverforhiretech.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8812,14 +8812,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-d034-4204-95bd-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-d034-4204-95bd-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: phpwebserver34.best (MISP Attribute #18663)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: phpwebserver34.best (MISP Attribute #18663)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-d034-4204-95bd-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-d034-4204-95bd-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-d034-4204-95bd-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-d034-4204-95bd-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">phpwebserver34.best</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8833,14 +8833,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-b574-4200-beaa-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-b574-4200-beaa-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverfortechhelp.com (MISP Attribute #18919)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverfortechhelp.com (MISP Attribute #18919)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-b574-4200-beaa-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-b574-4200-beaa-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-b574-4200-beaa-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-b574-4200-beaa-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverfortechhelp.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8854,14 +8854,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-eccc-432c-9ad7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-eccc-432c-9ad7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: myfacetik.cf (MISP Attribute #18664)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: myfacetik.cf (MISP Attribute #18664)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-eccc-432c-9ad7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-eccc-432c-9ad7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-eccc-432c-9ad7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-eccc-432c-9ad7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">myfacetik.cf</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8875,14 +8875,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-90ec-4a51-9cb1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-90ec-4a51-9cb1-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: blogforpranks.com (MISP Attribute #18920)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: blogforpranks.com (MISP Attribute #18920)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-90ec-4a51-9cb1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-90ec-4a51-9cb1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-90ec-4a51-9cb1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-90ec-4a51-9cb1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">blogforpranks.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8896,14 +8896,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-dcdc-4da8-a2f7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-dcdc-4da8-a2f7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: goomail.ml (MISP Attribute #18665)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: goomail.ml (MISP Attribute #18665)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-dcdc-4da8-a2f7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-dcdc-4da8-a2f7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-dcdc-4da8-a2f7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-dcdc-4da8-a2f7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">goomail.ml</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8917,14 +8917,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-4078-4c94-97f9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-4078-4c94-97f9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: planyourexoticvacation.com (MISP Attribute #18921)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: planyourexoticvacation.com (MISP Attribute #18921)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-4078-4c94-97f9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-4078-4c94-97f9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-4078-4c94-97f9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-4078-4c94-97f9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">planyourexoticvacation.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8938,14 +8938,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-af7c-4f6b-9404-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-af7c-4f6b-9404-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: websociofiles.com (MISP Attribute #18666)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: websociofiles.com (MISP Attribute #18666)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-af7c-4f6b-9404-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-af7c-4f6b-9404-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-af7c-4f6b-9404-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-af7c-4f6b-9404-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">websociofiles.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8959,14 +8959,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3108-4ce1-b76a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3108-4ce1-b76a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: usewithcareathome.com (MISP Attribute #18922)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: usewithcareathome.com (MISP Attribute #18922)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3108-4ce1-b76a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3108-4ce1-b76a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3108-4ce1-b76a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3108-4ce1-b76a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">usewithcareathome.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -8980,14 +8980,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0c88-45e2-8ab3-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0c88-45e2-8ab3-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainmanager33.website (MISP Attribute #18667)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainmanager33.website (MISP Attribute #18667)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0c88-45e2-8ab3-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0c88-45e2-8ab3-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0c88-45e2-8ab3-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0c88-45e2-8ab3-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainmanager33.website</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9001,14 +9001,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-51d4-4035-8752-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-51d4-4035-8752-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverforhome.com (MISP Attribute #18923)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverforhome.com (MISP Attribute #18923)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-51d4-4035-8752-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-51d4-4035-8752-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-51d4-4035-8752-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-51d4-4035-8752-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverforhome.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9022,14 +9022,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-515c-4ed2-b281-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-515c-4ed2-b281-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainmanager33.com (MISP Attribute #18668)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainmanager33.com (MISP Attribute #18668)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-515c-4ed2-b281-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-515c-4ed2-b281-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-515c-4ed2-b281-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-515c-4ed2-b281-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainmanager33.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9043,14 +9043,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-f100-4344-9990-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-f100-4344-9990-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: optionsothego.com (MISP Attribute #18924)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: optionsothego.com (MISP Attribute #18924)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-f100-4344-9990-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-f100-4344-9990-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-f100-4344-9990-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-f100-4344-9990-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">optionsothego.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9064,14 +9064,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-6b38-4858-9427-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-6b38-4858-9427-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: domainmanager33.site (MISP Attribute #18669)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: domainmanager33.site (MISP Attribute #18669)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-6b38-4858-9427-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-6b38-4858-9427-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-6b38-4858-9427-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-6b38-4858-9427-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">domainmanager33.site</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9085,14 +9085,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1584-4172-9242-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1584-4172-9242-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: anitmationworldnews.com (MISP Attribute #18925)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: anitmationworldnews.com (MISP Attribute #18925)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1584-4172-9242-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1584-4172-9242-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1584-4172-9242-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1584-4172-9242-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">anitmationworldnews.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9106,14 +9106,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0a08-4a29-a4a3-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0a08-4a29-a4a3-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailtickr.com (MISP Attribute #18670)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailtickr.com (MISP Attribute #18670)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0a08-4a29-a4a3-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0a08-4a29-a4a3-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0a08-4a29-a4a3-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0a08-4a29-a4a3-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailtickr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9127,14 +9127,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-8c64-4036-b55a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-8c64-4036-b55a-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: servicegoingfar.com (MISP Attribute #18926)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: servicegoingfar.com (MISP Attribute #18926)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-8c64-4036-b55a-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-8c64-4036-b55a-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-8c64-4036-b55a-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-8c64-4036-b55a-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">servicegoingfar.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9148,14 +9148,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-376c-4b9f-92c5-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-376c-4b9f-92c5-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: servergateway56.com (MISP Attribute #18671)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: servergateway56.com (MISP Attribute #18671)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-376c-4b9f-92c5-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-376c-4b9f-92c5-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-376c-4b9f-92c5-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-376c-4b9f-92c5-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">servergateway56.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9169,14 +9169,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-8b3c-4a51-bc70-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-8b3c-4a51-bc70-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: trusteventservices.com (MISP Attribute #18927)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: trusteventservices.com (MISP Attribute #18927)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-8b3c-4a51-bc70-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-8b3c-4a51-bc70-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-8b3c-4a51-bc70-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-8b3c-4a51-bc70-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">trusteventservices.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9190,14 +9190,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-dac8-48f3-b108-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-dac8-48f3-b108-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: servergateway33.com (MISP Attribute #18672)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: servergateway33.com (MISP Attribute #18672)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-dac8-48f3-b108-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-dac8-48f3-b108-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-dac8-48f3-b108-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-dac8-48f3-b108-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">servergateway33.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9211,14 +9211,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ac3c-4cd0-852e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ac3c-4cd0-852e-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: belowmargins.com (MISP Attribute #18928)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: belowmargins.com (MISP Attribute #18928)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ac3c-4cd0-852e-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ac3c-4cd0-852e-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ac3c-4cd0-852e-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ac3c-4cd0-852e-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">belowmargins.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9232,14 +9232,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-d2e0-4497-ba46-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-d2e0-4497-ba46-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: msrfrgr.com (MISP Attribute #18673)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: msrfrgr.com (MISP Attribute #18673)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-d2e0-4497-ba46-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-d2e0-4497-ba46-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-d2e0-4497-ba46-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-d2e0-4497-ba46-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">msrfrgr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9253,14 +9253,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3b88-4b23-9f2f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3b88-4b23-9f2f-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: hostserverrus.com (MISP Attribute #18929)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: hostserverrus.com (MISP Attribute #18929)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3b88-4b23-9f2f-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3b88-4b23-9f2f-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3b88-4b23-9f2f-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3b88-4b23-9f2f-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">hostserverrus.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9274,14 +9274,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-6918-4c89-bc38-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-6918-4c89-bc38-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: pageserverru.com (MISP Attribute #18674)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: pageserverru.com (MISP Attribute #18674)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-6918-4c89-bc38-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-6918-4c89-bc38-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-6918-4c89-bc38-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-6918-4c89-bc38-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">pageserverru.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9295,14 +9295,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1390-41f2-9eef-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1390-41f2-9eef-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: registrationonlineeurope.com (MISP Attribute #18930)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: registrationonlineeurope.com (MISP Attribute #18930)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1390-41f2-9eef-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1390-41f2-9eef-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1390-41f2-9eef-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1390-41f2-9eef-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">registrationonlineeurope.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9316,14 +9316,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-a360-40c5-bf27-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-a360-40c5-bf27-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverhello54.com (MISP Attribute #18675)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverhello54.com (MISP Attribute #18675)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-a360-40c5-bf27-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-a360-40c5-bf27-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-a360-40c5-bf27-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-a360-40c5-bf27-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverhello54.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9337,14 +9337,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-7d38-4846-9698-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-7d38-4846-9698-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: tineeurl.com (MISP Attribute #18931)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: tineeurl.com (MISP Attribute #18931)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-7d38-4846-9698-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-7d38-4846-9698-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-7d38-4846-9698-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-7d38-4846-9698-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">tineeurl.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9358,14 +9358,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-a4a0-4395-876d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-a4a0-4395-876d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: smtpserver466.com (MISP Attribute #18676)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: smtpserver466.com (MISP Attribute #18676)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-a4a0-4395-876d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-a4a0-4395-876d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-a4a0-4395-876d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-a4a0-4395-876d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">smtpserver466.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9379,14 +9379,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3010-4cee-95ae-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3010-4cee-95ae-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: secureserverasia.com (MISP Attribute #18932)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: secureserverasia.com (MISP Attribute #18932)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3010-4cee-95ae-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3010-4cee-95ae-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3010-4cee-95ae-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3010-4cee-95ae-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">secureserverasia.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9400,14 +9400,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-d330-4e5c-a1e1-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-d330-4e5c-a1e1-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserver39.com (MISP Attribute #18677)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserver39.com (MISP Attribute #18677)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-d330-4e5c-a1e1-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-d330-4e5c-a1e1-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-d330-4e5c-a1e1-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-d330-4e5c-a1e1-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserver39.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9421,14 +9421,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-eaf8-406b-ac11-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-eaf8-406b-ac11-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: secureservereurope.com (MISP Attribute #18933)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: secureservereurope.com (MISP Attribute #18933)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-eaf8-406b-ac11-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-eaf8-406b-ac11-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-eaf8-406b-ac11-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-eaf8-406b-ac11-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">secureservereurope.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9442,14 +9442,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-91e4-4488-bb36-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-91e4-4488-bb36-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: linksrtnr.com (MISP Attribute #18678)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: linksrtnr.com (MISP Attribute #18678)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-91e4-4488-bb36-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-91e4-4488-bb36-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-91e4-4488-bb36-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-91e4-4488-bb36-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">linksrtnr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9463,14 +9463,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-806c-42c6-b2f9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-806c-42c6-b2f9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverasiasap.com (MISP Attribute #18934)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverasiasap.com (MISP Attribute #18934)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-806c-42c6-b2f9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-806c-42c6-b2f9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-806c-42c6-b2f9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-806c-42c6-b2f9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverasiasap.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9484,14 +9484,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-e7e8-4cc0-ba44-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-e7e8-4cc0-ba44-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: netmapservice.com (MISP Attribute #18679)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: netmapservice.com (MISP Attribute #18679)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-e7e8-4cc0-ba44-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-e7e8-4cc0-ba44-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-e7e8-4cc0-ba44-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-e7e8-4cc0-ba44-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">netmapservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9505,14 +9505,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-ae2c-4309-a967-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-ae2c-4309-a967-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: mailservereurope.com (MISP Attribute #18935)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: mailservereurope.com (MISP Attribute #18935)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-ae2c-4309-a967-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-ae2c-4309-a967-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-ae2c-4309-a967-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-ae2c-4309-a967-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">mailservereurope.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9526,14 +9526,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-7358-473b-9cfd-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-7358-473b-9cfd-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: imapserverholland.com (MISP Attribute #18680)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: imapserverholland.com (MISP Attribute #18680)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-7358-473b-9cfd-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-7358-473b-9cfd-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-7358-473b-9cfd-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-7358-473b-9cfd-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">imapserverholland.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9547,14 +9547,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-1900-4c7a-9a95-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-1900-4c7a-9a95-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverloadbalance.com (MISP Attribute #18936)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverloadbalance.com (MISP Attribute #18936)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-1900-4c7a-9a95-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-1900-4c7a-9a95-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-1900-4c7a-9a95-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-1900-4c7a-9a95-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverloadbalance.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9568,14 +9568,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-b358-4799-b811-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-b358-4799-b811-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserveronline9.com (MISP Attribute #18681)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserveronline9.com (MISP Attribute #18681)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-b358-4799-b811-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-b358-4799-b811-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-b358-4799-b811-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-b358-4799-b811-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserveronline9.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9589,14 +9589,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3c58-49a5-91d9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3c58-49a5-91d9-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: frwrdrwr.com (MISP Attribute #18937)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: frwrdrwr.com (MISP Attribute #18937)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3c58-49a5-91d9-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3c58-49a5-91d9-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3c58-49a5-91d9-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3c58-49a5-91d9-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">frwrdrwr.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9610,14 +9610,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-63fc-491f-b39b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-63fc-491f-b39b-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: getemailopens.com (MISP Attribute #18682)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: getemailopens.com (MISP Attribute #18682)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-63fc-491f-b39b-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-63fc-491f-b39b-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-63fc-491f-b39b-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-63fc-491f-b39b-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">getemailopens.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9631,14 +9631,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-6b04-446d-83a0-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-6b04-446d-83a0-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: localserversa.com (MISP Attribute #18938)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: localserversa.com (MISP Attribute #18938)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-6b04-446d-83a0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-6b04-446d-83a0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-6b04-446d-83a0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-6b04-446d-83a0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">localserversa.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9652,14 +9652,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-3a84-4dc8-9919-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-3a84-4dc8-9919-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: msrvrgeh.com (MISP Attribute #18683)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: msrvrgeh.com (MISP Attribute #18683)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-3a84-4dc8-9919-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-3a84-4dc8-9919-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-3a84-4dc8-9919-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-3a84-4dc8-9919-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">msrvrgeh.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9673,14 +9673,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d060-40eb-9e73-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d060-40eb-9e73-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: serverdemoservice.com (MISP Attribute #18939)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: serverdemoservice.com (MISP Attribute #18939)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d060-40eb-9e73-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d060-40eb-9e73-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d060-40eb-9e73-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d060-40eb-9e73-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">serverdemoservice.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9694,14 +9694,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-0d88-4db6-8d5d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-0d88-4db6-8d5d-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: msrvrgh.com (MISP Attribute #18684)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: msrvrgh.com (MISP Attribute #18684)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-0d88-4db6-8d5d-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-0d88-4db6-8d5d-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-0d88-4db6-8d5d-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-0d88-4db6-8d5d-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">msrvrgh.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9715,14 +9715,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-dab8-4408-8afd-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-dab8-4408-8afd-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fastserverasia.com (MISP Attribute #18940)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fastserverasia.com (MISP Attribute #18940)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-dab8-4408-8afd-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-dab8-4408-8afd-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-dab8-4408-8afd-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-dab8-4408-8afd-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fastserverasia.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9736,14 +9736,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-caac-4790-9459-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-caac-4790-9459-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailserverholland.com (MISP Attribute #18685)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailserverholland.com (MISP Attribute #18685)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-caac-4790-9459-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-caac-4790-9459-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-caac-4790-9459-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-caac-4790-9459-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailserverholland.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9757,14 +9757,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-844c-45a5-8ab8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-844c-45a5-8ab8-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fastservereurope.com (MISP Attribute #18941)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fastservereurope.com (MISP Attribute #18941)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-844c-45a5-8ab8-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-844c-45a5-8ab8-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-844c-45a5-8ab8-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-844c-45a5-8ab8-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fastservereurope.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9778,14 +9778,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-f210-4037-8741-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-f210-4037-8741-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: emailserverhk48.com (MISP Attribute #18686)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: emailserverhk48.com (MISP Attribute #18686)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-f210-4037-8741-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-f210-4037-8741-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-f210-4037-8741-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-f210-4037-8741-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">emailserverhk48.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9799,14 +9799,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-d620-4c77-b6c0-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-d620-4c77-b6c0-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fastserveruk.com (MISP Attribute #18942)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fastserveruk.com (MISP Attribute #18942)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-d620-4c77-b6c0-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-d620-4c77-b6c0-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-d620-4c77-b6c0-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-d620-4c77-b6c0-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fastserveruk.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9820,14 +9820,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974a-8504-4659-bfd7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974a-8504-4659-bfd7-7a498064ab0b" timestamp="2020-06-08T15:53:46+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: webserverredirect99.com (MISP Attribute #18687)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: webserverredirect99.com (MISP Attribute #18687)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974a-8504-4659-bfd7-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974a-8504-4659-bfd7-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974a-8504-4659-bfd7-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974a-8504-4659-bfd7-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">webserverredirect99.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9841,14 +9841,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Network activity</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede974b-3028-4600-82af-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede974b-3028-4600-82af-7a498064ab0b" timestamp="2020-06-08T15:53:47+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Network activity: fastserverusa.com (MISP Attribute #18943)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Domain Watchlist</indicator:Type>
                                     <indicator:Description>Network activity: fastserverusa.com (MISP Attribute #18943)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede974b-3028-4600-82af-7a498064ab0b">
-                                        <cybox:Object id=":DomainName-5ede974b-3028-4600-82af-7a498064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede974b-3028-4600-82af-7a498064ab0b">
+                                        <cybox:Object id="citizenlab:DomainName-5ede974b-3028-4600-82af-7a498064ab0b">
                                             <cybox:Properties xsi:type="DomainNameObj:DomainNameObjectType">
                                                 <DomainNameObj:Value condition="Equals">fastserverusa.com</DomainNameObj:Value>
                                             </cybox:Properties>
@@ -9862,14 +9862,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-4efc-4e42-afa5-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-4efc-4e42-afa5-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: n0replyupdatesnotificationskj9@gmail.com (MISP Attribute #19039)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: n0replyupdatesnotificationskj9@gmail.com (MISP Attribute #19039)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-4efc-4e42-afa5-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-4efc-4e42-afa5-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-4efc-4e42-afa5-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-4efc-4e42-afa5-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -9887,14 +9887,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-6950-4509-9af0-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-6950-4509-9af0-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: n0replyn0tificati0nupdatemail@gmail.com (MISP Attribute #19040)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: n0replyn0tificati0nupdatemail@gmail.com (MISP Attribute #19040)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-6950-4509-9af0-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-6950-4509-9af0-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-6950-4509-9af0-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-6950-4509-9af0-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -9912,14 +9912,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-89ec-4587-a2d4-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-89ec-4587-a2d4-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: n0reply.notificationexsasuve@gmail.com (MISP Attribute #19041)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: n0reply.notificationexsasuve@gmail.com (MISP Attribute #19041)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-89ec-4587-a2d4-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-89ec-4587-a2d4-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-89ec-4587-a2d4-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-89ec-4587-a2d4-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -9937,14 +9937,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-e864-4084-a3bb-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-e864-4084-a3bb-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: noreply.535466586you6585tubadh@gmail.com (MISP Attribute #19042)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: noreply.535466586you6585tubadh@gmail.com (MISP Attribute #19042)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-e864-4084-a3bb-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-e864-4084-a3bb-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-e864-4084-a3bb-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-e864-4084-a3bb-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -9962,14 +9962,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-409c-44b3-8207-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-409c-44b3-8207-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: no.reply.n0tification.alsdkch@gmail.com (MISP Attribute #19043)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: no.reply.n0tification.alsdkch@gmail.com (MISP Attribute #19043)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-409c-44b3-8207-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-409c-44b3-8207-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-409c-44b3-8207-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-409c-44b3-8207-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -9987,14 +9987,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-2e0c-42e1-9cdb-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-2e0c-42e1-9cdb-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: noreply.notifications.gkejkdgj@gmail.com (MISP Attribute #19044)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: noreply.notifications.gkejkdgj@gmail.com (MISP Attribute #19044)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-2e0c-42e1-9cdb-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-2e0c-42e1-9cdb-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-2e0c-42e1-9cdb-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-2e0c-42e1-9cdb-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -10012,14 +10012,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-81f8-4221-8637-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-81f8-4221-8637-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: noreplynotification.updates@gmail.com (MISP Attribute #19045)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: noreplynotification.updates@gmail.com (MISP Attribute #19045)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-81f8-4221-8637-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-81f8-4221-8637-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-81f8-4221-8637-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-81f8-4221-8637-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -10037,14 +10037,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-9808-43ba-8d46-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-9808-43ba-8d46-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: no.reply.updates.asdfaffgh78jg@gmail.com (MISP Attribute #19046)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: no.reply.updates.asdfaffgh78jg@gmail.com (MISP Attribute #19046)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-9808-43ba-8d46-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-9808-43ba-8d46-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-9808-43ba-8d46-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-9808-43ba-8d46-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -10062,14 +10062,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-3820-4868-ad30-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-3820-4868-ad30-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: scorpiobond4@gmail.com (MISP Attribute #19047)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: scorpiobond4@gmail.com (MISP Attribute #19047)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-3820-4868-ad30-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-3820-4868-ad30-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-3820-4868-ad30-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-3820-4868-ad30-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -10087,14 +10087,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-681c-4f01-9706-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-681c-4f01-9706-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: sophia.1johnson@mail.com (MISP Attribute #19048)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: sophia.1johnson@mail.com (MISP Attribute #19048)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-681c-4f01-9706-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-681c-4f01-9706-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-681c-4f01-9706-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-681c-4f01-9706-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
@@ -10112,14 +10112,14 @@
                             </incident:Related_Indicator>
                             <incident:Related_Indicator>
                                 <stixCommon:Relationship>Payload delivery</stixCommon:Relationship>
-                                <stixCommon:Indicator id=":indicator-5ede97f5-1448-4d36-a35e-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
+                                <stixCommon:Indicator id="citizenlab:indicator-5ede97f5-1448-4d36-a35e-7e298064ab0b" timestamp="2020-06-08T15:56:37+00:00" xsi:type='indicator:IndicatorType'>
                                     <indicator:Title>Payload delivery: noreply.mailingservice.3kdj9e9@gmail.com (MISP Attribute #19049)</indicator:Title>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malware Artifacts</indicator:Type>
                                     <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">Malicious E-mail</indicator:Type>
                                     <indicator:Description>Payload delivery: noreply.mailingservice.3kdj9e9@gmail.com (MISP Attribute #19049)</indicator:Description>
                                     <indicator:Valid_Time_Position/>
-                                    <indicator:Observable id=":observable-5ede97f5-1448-4d36-a35e-7e298064ab0b">
-                                        <cybox:Object id=":EmailMessage-5ede97f5-1448-4d36-a35e-7e298064ab0b">
+                                    <indicator:Observable id="citizenlab:observable-5ede97f5-1448-4d36-a35e-7e298064ab0b">
+                                        <cybox:Object id="citizenlab:EmailMessage-5ede97f5-1448-4d36-a35e-7e298064ab0b">
                                             <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                                                 <EmailMessageObj:Header>
                                                     <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">


### PR DESCRIPTION
The stix files fail stix validation[[1]](https://github.com/STIXProject/stix-validator) because they are missing an alias for the namespace.  This PR adds that missing namespace alias.

Each file was modified with:
```
sed -i.bak 's/=":/="citizenlab:/g'  ./201712_Cyberbit/stix.xml
sed -i.bak 's|xmlns:="https|xmlns:citizenlab="https|' ./201712_Cyberbit/stix.xml
```

# Before
```
 stix-validator.py ./201712_Cyberbit/stix.xml
[-] Performing xml schema validation on ./201712_Cyberbit/stix.xml
[-] Unexpected error occurred with file './201712_Cyberbit/stix.xml'. No further validation will be performed: Failed to parse QName 'xmlns:', line 29, column 8 (stix.xml, line 29)
================================================================================
[-] Results: ./201712_Cyberbit/stix.xml
[!] Fatal Error: Failed to parse QName 'xmlns:', line 29, column 8 (stix.xml, line 29)
```

# After
```
stix-validator.py ./201712_Cyberbit/stix.xml
[-] Performing xml schema validation on ./201712_Cyberbit/stix.xml
================================================================================
[-] Results: ./201712_Cyberbit/stix.xml
[+] XML Schema: True
```

[1] https://github.com/STIXProject/stix-validator